### PR TITLE
feat(datasources): add csv output format for query results

### DIFF
--- a/claude-plugin/skills/debug-with-grafana/SKILL.md
+++ b/claude-plugin/skills/debug-with-grafana/SKILL.md
@@ -428,8 +428,14 @@ Recommended next actions:
   2. <Additional action>
 ```
 
-Use `-o graph` for any visualizations shared with the user. Use `-o json` for
-data retrieved for your own analysis.
+Use `-o graph` for any visualizations shared with the user. When you need to
+filter, aggregate, or otherwise manipulate query results for your own
+analysis, pipe `-o csv` into DuckDB (see
+[`references/query-patterns.md`](references/query-patterns.md#csv-format-for-sql-based-analysis))
+rather than writing a python or jq script — it's SQL against real columns
+instead of ad hoc parsing. Fall back to `-o json` only when you need structure
+CSV's flat columns don't carry (e.g. trace bodies, log `structuredMetadata`/
+`parsed` fields).
 
 ---
 

--- a/claude-plugin/skills/debug-with-grafana/references/query-patterns.md
+++ b/claude-plugin/skills/debug-with-grafana/references/query-patterns.md
@@ -9,7 +9,7 @@ Advanced patterns for querying Prometheus and Loki datasources with gcx.
 - [Loki Query Patterns](#loki-query-patterns) - stream selectors, log metric queries
 - [Prometheus Datasource Operations](#prometheus-datasource-operations) - label/metadata discovery workflow
 - [Loki Datasource Operations](#loki-datasource-operations) - label/series discovery workflow
-- [Output Formats](#output-formats) - table, wide, JSON shapes, `--json` field selection
+- [Output Formats](#output-formats) - table, wide, JSON shapes, CSV for DuckDB analysis, `--json` field selection
 - [Performance Tips](#performance-tips) - Loki series limits, distributed-request counting, indexed vs structured-metadata vs parsed labels
 - [Comparison Queries](#comparison-queries) - comparing now vs a past instant
 
@@ -348,6 +348,37 @@ JSON structure:
 }
 ```
 
+### CSV Format (for SQL-based analysis)
+
+`-o csv` gives one row per series/label-combination, same columns as `-o wide`
+(one column per label, plus TIMESTAMP/VALUE). Available for Prometheus, Loki
+log queries, Tempo search, Infinity, SQL, Athena discovery, and CloudWatch —
+not for hierarchical shapes like `traces get`, which stays JSON/table-only.
+
+Pipe it straight into DuckDB — this is the preferred way to filter, aggregate,
+join, or otherwise manipulate query results, not a python or jq script:
+
+```bash
+# Filter to series still down, via stdin
+gcx metrics query -d <uid> 'up' -o csv 2>/dev/null | \
+  duckdb -c "SELECT * FROM read_csv('/dev/stdin') WHERE VALUE = 0"
+
+# Aggregate a range query by label — top offenders by mean value
+gcx metrics query -d <uid> \
+  'rate(http_requests_total{status=~"5.."}[5m])' \
+  --from now-1h --to now --step 1m -o csv 2>/dev/null | \
+  duckdb -c "SELECT job, avg(VALUE) AS avg_rate FROM read_csv('/dev/stdin') GROUP BY job ORDER BY avg_rate DESC"
+
+# Or persist to a file first, then query it (and re-query without re-running gcx)
+gcx metrics query -d <uid> 'up' -o csv 2>/dev/null > /tmp/up.csv
+duckdb -c "SELECT count(*) FROM read_csv('/tmp/up.csv') WHERE VALUE = 0"
+```
+
+DuckDB infers real column types (timestamps, numbers) from the CSV, so
+comparisons, `GROUP BY`, and joins across two query results (e.g. errors vs.
+latency in the same window) work directly in SQL instead of hand-rolled
+parsing.
+
 ### Field Selection
 
 Use `--json` to select fields without external tools:
@@ -358,14 +389,15 @@ gcx metrics query -d <uid> 'up' --json list
 
 # Select specific fields
 gcx metrics query -d <uid> 'up' --json metric,value
-
-# For complex filtering, pipe to python3 (jq may not be installed)
-gcx metrics query -d <uid> 'up' -o json 2>/dev/null | \
-  python3 -c "import json,sys; data=json.load(sys.stdin); print(len(data['data']['result']))"
 ```
 
-> **Piping caution**: Never use `2>&1` when piping gcx JSON output — gcx writes
-> hints to stderr that break JSON parsers. Use `2>/dev/null` instead.
+`--json` is for trimming a JSON payload down to a couple of fields. For
+anything beyond that — filtering, aggregation, grouping, joining multiple
+queries — reach for `-o csv | duckdb` above instead of a python or jq script.
+
+> **Piping caution**: Never use `2>&1` when piping gcx output through an
+> external tool (duckdb, jq, python) — gcx writes hints to stderr that break
+> JSON/CSV parsers. Use `2>/dev/null` instead.
 
 ## Performance Tips
 

--- a/claude-plugin/skills/debug-with-grafana/references/query-patterns.md
+++ b/claude-plugin/skills/debug-with-grafana/references/query-patterns.md
@@ -350,10 +350,16 @@ JSON structure:
 
 ### CSV Format (for SQL-based analysis)
 
-`-o csv` gives one row per series/label-combination, same columns as `-o wide`
-(one column per label, plus TIMESTAMP/VALUE). Available for Prometheus, Loki
-log queries, Tempo search, Infinity, SQL, Athena discovery, and CloudWatch —
-not for hierarchical shapes like `traces get`, which stays JSON/table-only.
+`-o csv` gives one row per series/label-combination or table row, with the
+same columns as that datasource's `-o table` output — not a single fixed
+schema. Prometheus, Loki metric queries, and Tempo metrics emit one column
+per label plus TIMESTAMP/VALUE; Loki log queries emit TIME, stream labels,
+and MESSAGE; Tempo search emits TRACE_ID/SERVICE/NAME/DURATION/START; SQL,
+Infinity, and InfluxDB emit the query's own columns. Available for
+Prometheus, Loki (log and metric queries), Tempo search and metrics,
+Pyroscope, Infinity, InfluxDB, SQL, Athena discovery, ClickHouse
+table/column info, and CloudWatch — not for hierarchical shapes like
+`traces get`, which stays JSON/table-only.
 
 Pipe it straight into DuckDB — this is the preferred way to filter, aggregate,
 join, or otherwise manipulate query results, not a python or jq script:

--- a/docs/reference/cli/gcx_datasources_athena_describe-table.md
+++ b/docs/reference/cli/gcx_datasources_athena_describe-table.md
@@ -33,7 +33,7 @@ gcx datasources athena describe-table TABLE [flags]
   -h, --help                help for describe-table
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, csv, json, table, wide, yaml (default "table")
       --region string       AWS region override
 ```
 

--- a/docs/reference/cli/gcx_datasources_athena_list-catalogs.md
+++ b/docs/reference/cli/gcx_datasources_athena_list-catalogs.md
@@ -24,7 +24,7 @@ gcx datasources athena list-catalogs [flags]
   -h, --help                help for list-catalogs
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, csv, json, table, wide, yaml (default "table")
       --region string       AWS region override
 ```
 

--- a/docs/reference/cli/gcx_datasources_athena_list-databases.md
+++ b/docs/reference/cli/gcx_datasources_athena_list-databases.md
@@ -25,7 +25,7 @@ gcx datasources athena list-databases [flags]
   -h, --help                help for list-databases
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, csv, json, table, wide, yaml (default "table")
       --region string       AWS region override
 ```
 

--- a/docs/reference/cli/gcx_datasources_athena_list-tables.md
+++ b/docs/reference/cli/gcx_datasources_athena_list-tables.md
@@ -29,7 +29,7 @@ gcx datasources athena list-tables [flags]
   -h, --help                help for list-tables
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, csv, json, table, wide, yaml (default "table")
       --region string       AWS region override
 ```
 

--- a/docs/reference/cli/gcx_datasources_athena_query.md
+++ b/docs/reference/cli/gcx_datasources_athena_query.md
@@ -49,7 +49,7 @@ gcx datasources athena query [EXPR] [flags]
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int           Max rows to return (0 disables enforcement) (default 100)
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, csv, json, table, wide, yaml (default "table")
       --region string       AWS region override
       --result-reuse        Enable Athena query result reuse (engine v3)
       --share-link          Print the Grafana Explore URL for the executed query to stderr

--- a/docs/reference/cli/gcx_datasources_azuremonitor_logs_query.md
+++ b/docs/reference/cli/gcx_datasources_azuremonitor_logs_query.md
@@ -54,7 +54,7 @@ gcx datasources azuremonitor logs query KQL [flags]
       --jq string               jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string             Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --open                    Open the executed query in Grafana Explore
-  -o, --output string           Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string           Output format. One of: agents, csv, json, table, wide, yaml (default "table")
       --resource-group string   Azure resource group of the workspace (required)
       --share-link              Print the Grafana Explore URL for the executed query to stderr
       --since string            Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from

--- a/docs/reference/cli/gcx_datasources_azuremonitor_query.md
+++ b/docs/reference/cli/gcx_datasources_azuremonitor_query.md
@@ -69,7 +69,7 @@ gcx datasources azuremonitor query [flags]
       --metric string               Metric name, e.g. Transactions (required)
       --namespace string            Metric namespace, e.g. Microsoft.Storage/storageAccounts (required)
       --open                        Open the executed query in Grafana Explore
-  -o, --output string               Output format. One of: agents, graph, json, table, wide, yaml (default "table")
+  -o, --output string               Output format. One of: agents, csv, graph, json, table, wide, yaml (default "table")
       --region string               Azure region, e.g. uksouth (optional; used for multi-resource queries)
       --resource string             Azure resource name; use the slash form for sub-resources, e.g. mystorage/blobServices/default (required)
       --resource-group string       Azure resource group name (required)

--- a/docs/reference/cli/gcx_datasources_azuremonitor_resource-graph_query.md
+++ b/docs/reference/cli/gcx_datasources_azuremonitor_resource-graph_query.md
@@ -49,7 +49,7 @@ gcx datasources azuremonitor resource-graph query KQL [flags]
       --jq string                  jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string                Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --open                       Open the executed query in Grafana Explore
-  -o, --output string              Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string              Output format. One of: agents, csv, json, table, wide, yaml (default "table")
       --share-link                 Print the Grafana Explore URL for the executed query to stderr
       --subscription stringArray   Azure subscription ID to query (repeatable; at least one required)
 ```

--- a/docs/reference/cli/gcx_datasources_bigquery_describe-table.md
+++ b/docs/reference/cli/gcx_datasources_bigquery_describe-table.md
@@ -42,7 +42,7 @@ gcx datasources bigquery describe-table TABLE [flags]
   -h, --help                help for describe-table
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, csv, json, table, wide, yaml (default "table")
       --project string      GCP project ID (default: the datasource's default project)
 ```
 

--- a/docs/reference/cli/gcx_datasources_bigquery_list-datasets.md
+++ b/docs/reference/cli/gcx_datasources_bigquery_list-datasets.md
@@ -36,7 +36,7 @@ gcx datasources bigquery list-datasets [flags]
   -h, --help                help for list-datasets
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, csv, json, table, wide, yaml (default "table")
       --project string      GCP project ID (default: the datasource's default project)
 ```
 

--- a/docs/reference/cli/gcx_datasources_bigquery_list-tables.md
+++ b/docs/reference/cli/gcx_datasources_bigquery_list-tables.md
@@ -38,7 +38,7 @@ gcx datasources bigquery list-tables [flags]
   -h, --help                help for list-tables
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, csv, json, table, wide, yaml (default "table")
       --project string      GCP project ID (default: the datasource's default project)
 ```
 

--- a/docs/reference/cli/gcx_datasources_bigquery_query.md
+++ b/docs/reference/cli/gcx_datasources_bigquery_query.md
@@ -55,7 +55,7 @@ gcx datasources bigquery query [EXPR] [flags]
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int           Max rows to return; requests above 1000 are capped, with a warning (0 disables enforcement) (default 100)
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, csv, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_datasources_clickhouse_describe-table.md
+++ b/docs/reference/cli/gcx_datasources_clickhouse_describe-table.md
@@ -32,7 +32,7 @@ gcx datasources clickhouse describe-table TABLE [flags]
   -h, --help                help for describe-table
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, csv, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_datasources_clickhouse_list-tables.md
+++ b/docs/reference/cli/gcx_datasources_clickhouse_list-tables.md
@@ -34,7 +34,7 @@ gcx datasources clickhouse list-tables [flags]
   -h, --help                help for list-tables
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, csv, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_datasources_clickhouse_query.md
+++ b/docs/reference/cli/gcx_datasources_clickhouse_query.md
@@ -47,7 +47,7 @@ gcx datasources clickhouse query [EXPR] [flags]
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int           Max rows to return (0 disables enforcement) (default 100)
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, csv, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_datasources_cloudmonitoring_query.md
+++ b/docs/reference/cli/gcx_datasources_cloudmonitoring_query.md
@@ -72,7 +72,7 @@ gcx datasources cloudmonitoring query [flags]
       --json string               Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --metric string             Metric type, e.g. compute.googleapis.com/instance/cpu/utilization (required)
       --open                      Open the executed query in Grafana Explore
-  -o, --output string             Output format. One of: agents, graph, json, table, wide, yaml (default "table")
+  -o, --output string             Output format. One of: agents, csv, graph, json, table, wide, yaml (default "table")
       --project string            GCP project ID (required)
       --reducer string            Cross-series reducer: REDUCE_NONE, REDUCE_MEAN, REDUCE_SUM, REDUCE_MIN, REDUCE_MAX, REDUCE_COUNT, ... (default "REDUCE_NONE")
       --share-link                Print the Grafana Explore URL for the executed query to stderr

--- a/docs/reference/cli/gcx_datasources_cloudwatch_query.md
+++ b/docs/reference/cli/gcx_datasources_cloudwatch_query.md
@@ -55,7 +55,7 @@ gcx datasources cloudwatch query [flags]
       --metric string               CloudWatch metric name, e.g. CPUUtilization (required)
       --namespace string            CloudWatch namespace, e.g. AWS/EC2 (required)
       --open                        Open the executed query in Grafana Explore
-  -o, --output string               Output format. One of: agents, graph, json, table, wide, yaml (default "table")
+  -o, --output string               Output format. One of: agents, csv, graph, json, table, wide, yaml (default "table")
       --period string               Period in seconds (e.g. 60, 300) or "auto" to let CloudWatch pick a period that fits the time range (default "auto")
       --region string               AWS region, e.g. us-east-1 (required)
       --share-link                  Print the Grafana Explore URL for the executed query to stderr

--- a/docs/reference/cli/gcx_datasources_elasticsearch_metrics.md
+++ b/docs/reference/cli/gcx_datasources_elasticsearch_metrics.md
@@ -51,7 +51,7 @@ gcx datasources elasticsearch metrics [EXPR] [flags]
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: agents, graph, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, csv, graph, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_datasources_elasticsearch_query.md
+++ b/docs/reference/cli/gcx_datasources_elasticsearch_query.md
@@ -57,7 +57,7 @@ gcx datasources elasticsearch query [EXPR] [flags]
       --limit int           Max documents to return (1-1000) (default 100)
       --mode string         Search mode: "documents" (raw documents) or "logs" (newest-first, plugin-internal fields omitted) (default "documents")
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, csv, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_datasources_infinity_query.md
+++ b/docs/reference/cli/gcx_datasources_infinity_query.md
@@ -41,7 +41,7 @@ gcx datasources infinity query [EXPR] [flags]
   -h, --help                help for query
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, csv, json, table, wide, yaml (default "table")
       --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')
 ```

--- a/docs/reference/cli/gcx_datasources_influxdb_query.md
+++ b/docs/reference/cli/gcx_datasources_influxdb_query.md
@@ -38,7 +38,7 @@ gcx datasources influxdb query [EXPR] [flags]
   -h, --help                help for query
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, csv, json, table, wide, yaml (default "table")
       --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')
 ```

--- a/docs/reference/cli/gcx_datasources_loki_metrics.md
+++ b/docs/reference/cli/gcx_datasources_loki_metrics.md
@@ -51,7 +51,7 @@ gcx datasources loki metrics [EXPR] [flags]
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: agents, graph, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, csv, graph, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_datasources_loki_query.md
+++ b/docs/reference/cli/gcx_datasources_loki_query.md
@@ -51,7 +51,7 @@ gcx datasources loki query [EXPR] [flags]
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int           Maximum number of log lines to return (0 means no limit) (default 50)
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: agents, json, raw, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, csv, json, raw, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_datasources_mysql_describe-table.md
+++ b/docs/reference/cli/gcx_datasources_mysql_describe-table.md
@@ -39,7 +39,7 @@ gcx datasources mysql describe-table TABLE [flags]
   -h, --help                help for describe-table
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, csv, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_datasources_mysql_list-tables.md
+++ b/docs/reference/cli/gcx_datasources_mysql_list-tables.md
@@ -35,7 +35,7 @@ gcx datasources mysql list-tables [flags]
   -h, --help                help for list-tables
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, csv, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_datasources_mysql_query.md
+++ b/docs/reference/cli/gcx_datasources_mysql_query.md
@@ -41,7 +41,7 @@ gcx datasources mysql query [EXPR] [flags]
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int           Max rows to return; requests above 1000 are capped, with a warning (0 disables enforcement) (default 100)
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, csv, json, table, wide, yaml (default "table")
       --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_datasources_postgres_describe-table.md
+++ b/docs/reference/cli/gcx_datasources_postgres_describe-table.md
@@ -35,7 +35,7 @@ gcx datasources postgres describe-table TABLE [flags]
   -h, --help                help for describe-table
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, csv, json, table, wide, yaml (default "table")
       --schema string       Schema of the table (exact match, case-sensitive; defaults to all schemas)
 ```
 

--- a/docs/reference/cli/gcx_datasources_postgres_list-tables.md
+++ b/docs/reference/cli/gcx_datasources_postgres_list-tables.md
@@ -34,7 +34,7 @@ gcx datasources postgres list-tables [flags]
   -h, --help                help for list-tables
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, csv, json, table, wide, yaml (default "table")
       --schema string       Filter tables to this schema (exact match, case-sensitive)
 ```
 

--- a/docs/reference/cli/gcx_datasources_postgres_query.md
+++ b/docs/reference/cli/gcx_datasources_postgres_query.md
@@ -41,7 +41,7 @@ gcx datasources postgres query [EXPR] [flags]
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int           Max rows to return; requests above 1000 are capped, with a warning (0 disables enforcement) (default 100)
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, csv, json, table, wide, yaml (default "table")
       --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_datasources_prometheus_query.md
+++ b/docs/reference/cli/gcx_datasources_prometheus_query.md
@@ -49,7 +49,7 @@ gcx datasources prometheus query [EXPR] [flags]
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: agents, graph, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, csv, graph, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_datasources_pyroscope_query.md
+++ b/docs/reference/cli/gcx_datasources_pyroscope_query.md
@@ -71,7 +71,7 @@ gcx datasources pyroscope query [EXPR] [flags]
       --jq string                     jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string                   Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --max-nodes int                 Maximum nodes in flame graph (default 0/unlimited for pprof output, 50000 for all other formats)
-  -o, --output string                 Output format. One of: agents, graph, json, pprof, table, wide, yaml (default "table")
+  -o, --output string                 Output format. One of: agents, csv, graph, json, pprof, table, wide, yaml (default "table")
       --pprof-overwrite               Overwrite the output file if it already exists (only with -o pprof)
       --pprof-path string             Destination path for pprof binary output (only with -o pprof; default: profile-YYYY-MM-DD-HHMMSS.pb.gz)
       --profile-id strings            Drill down to specific profile UUIDs from exemplar queries (repeatable)

--- a/docs/reference/cli/gcx_datasources_query.md
+++ b/docs/reference/cli/gcx_datasources_query.md
@@ -44,7 +44,7 @@ gcx datasources query DATASOURCE_UID [EXPR] [flags]
       --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int             Maximum number of log lines to return for loki queries (0 means no limit) (default 50)
       --max-nodes int         Maximum nodes in flame graph (pyroscope only) (default 1024)
-  -o, --output string         Output format. One of: agents, graph, json, table, wide, yaml (default "table")
+  -o, --output string         Output format. One of: agents, csv, graph, json, table, wide, yaml (default "table")
       --profile-type string   Profile type ID for pyroscope queries (e.g., 'process_cpu:cpu:nanoseconds:cpu:nanoseconds')
       --since string          Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --step string           Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_datasources_tempo_baseline.md
+++ b/docs/reference/cli/gcx_datasources_tempo_baseline.md
@@ -60,7 +60,7 @@ gcx datasources tempo baseline TRACE_ID [flags]
       --jq string            jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int            Maximum number of candidates to return; must be at least 1 (default 20)
-  -o, --output string        Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string        Output format. One of: agents, csv, json, table, wide, yaml (default "table")
       --to string            Absolute end time override (RFC3339, Unix timestamp, or relative like 'now'); requires --from
       --window string        Search window padding applied before and after the seed trace's time range, so candidates from before or after the seed are eligible (e.g., 30m, 6h, 7d). Ignored when --from/--to are set (default "30m")
 ```

--- a/docs/reference/cli/gcx_datasources_tempo_get.md
+++ b/docs/reference/cli/gcx_datasources_tempo_get.md
@@ -50,7 +50,7 @@ gcx datasources tempo get TRACE_ID [flags]
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --llm                 [experimental] Request LLM-friendly trace format by sending the 'Accept: application/vnd.grafana.llm' header. Falls back to default JSON
       --open                Open the retrieved trace in Grafana Explore
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, csv, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the retrieved trace to stderr
       --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_datasources_tempo_get.md
+++ b/docs/reference/cli/gcx_datasources_tempo_get.md
@@ -50,7 +50,7 @@ gcx datasources tempo get TRACE_ID [flags]
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --llm                 [experimental] Request LLM-friendly trace format by sending the 'Accept: application/vnd.grafana.llm' header. Falls back to default JSON
       --open                Open the retrieved trace in Grafana Explore
-  -o, --output string       Output format. One of: agents, csv, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the retrieved trace to stderr
       --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_datasources_tempo_metrics.md
+++ b/docs/reference/cli/gcx_datasources_tempo_metrics.md
@@ -54,7 +54,7 @@ gcx datasources tempo metrics [TRACEQL] [flags]
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: agents, graph, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, csv, graph, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_datasources_tempo_query.md
+++ b/docs/reference/cli/gcx_datasources_tempo_query.md
@@ -47,7 +47,7 @@ gcx datasources tempo query [TRACEQL] [flags]
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int           Maximum number of traces to return (0 means no limit) (default 20)
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, csv, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_logs_metrics.md
+++ b/docs/reference/cli/gcx_logs_metrics.md
@@ -45,7 +45,7 @@ gcx logs metrics [EXPR] [flags]
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: agents, graph, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, csv, graph, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_logs_query.md
+++ b/docs/reference/cli/gcx_logs_query.md
@@ -51,7 +51,7 @@ gcx logs query [EXPR] [flags]
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int           Maximum number of log lines to return (0 means no limit) (default 50)
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: agents, json, raw, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, csv, json, raw, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_metrics_billing_query.md
+++ b/docs/reference/cli/gcx_metrics_billing_query.md
@@ -43,7 +43,7 @@ gcx metrics billing query [EXPR] [flags]
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: agents, graph, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, csv, graph, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_metrics_query.md
+++ b/docs/reference/cli/gcx_metrics_query.md
@@ -49,7 +49,7 @@ gcx metrics query [EXPR] [flags]
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: agents, graph, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, csv, graph, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_profiles_query.md
+++ b/docs/reference/cli/gcx_profiles_query.md
@@ -63,7 +63,7 @@ gcx profiles query [EXPR] [flags]
       --jq string                     jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string                   Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --max-nodes int                 Maximum nodes in flame graph (default 0/unlimited for pprof output, 50000 for all other formats)
-  -o, --output string                 Output format. One of: agents, graph, json, pprof, table, wide, yaml (default "table")
+  -o, --output string                 Output format. One of: agents, csv, graph, json, pprof, table, wide, yaml (default "table")
       --pprof-overwrite               Overwrite the output file if it already exists (only with -o pprof)
       --pprof-path string             Destination path for pprof binary output (only with -o pprof; default: profile-YYYY-MM-DD-HHMMSS.pb.gz)
       --profile-id strings            Drill down to specific profile UUIDs from exemplar queries (repeatable)

--- a/docs/reference/cli/gcx_traces_baseline.md
+++ b/docs/reference/cli/gcx_traces_baseline.md
@@ -60,7 +60,7 @@ gcx traces baseline TRACE_ID [flags]
       --jq string            jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int            Maximum number of candidates to return; must be at least 1 (default 20)
-  -o, --output string        Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string        Output format. One of: agents, csv, json, table, wide, yaml (default "table")
       --to string            Absolute end time override (RFC3339, Unix timestamp, or relative like 'now'); requires --from
       --window string        Search window padding applied before and after the seed trace's time range, so candidates from before or after the seed are eligible (e.g., 30m, 6h, 7d). Ignored when --from/--to are set (default "30m")
 ```

--- a/docs/reference/cli/gcx_traces_get.md
+++ b/docs/reference/cli/gcx_traces_get.md
@@ -44,7 +44,7 @@ gcx traces get TRACE_ID [flags]
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --llm                 [experimental] Request LLM-friendly trace format by sending the 'Accept: application/vnd.grafana.llm' header. Falls back to default JSON
       --open                Open the retrieved trace in Grafana Explore
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, csv, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the retrieved trace to stderr
       --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_traces_get.md
+++ b/docs/reference/cli/gcx_traces_get.md
@@ -44,7 +44,7 @@ gcx traces get TRACE_ID [flags]
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --llm                 [experimental] Request LLM-friendly trace format by sending the 'Accept: application/vnd.grafana.llm' header. Falls back to default JSON
       --open                Open the retrieved trace in Grafana Explore
-  -o, --output string       Output format. One of: agents, csv, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the retrieved trace to stderr
       --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_traces_metrics.md
+++ b/docs/reference/cli/gcx_traces_metrics.md
@@ -45,7 +45,7 @@ gcx traces metrics [TRACEQL] [flags]
       --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: agents, graph, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, csv, graph, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_traces_query.md
+++ b/docs/reference/cli/gcx_traces_query.md
@@ -41,7 +41,7 @@ gcx traces query [TRACEQL] [flags]
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int           Maximum number of traces to return (0 means no limit) (default 20)
       --open                Open the executed query in Grafana Explore
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+  -o, --output string       Output format. One of: agents, csv, json, table, wide, yaml (default "table")
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/internal/datasources/query/codecs.go
+++ b/internal/datasources/query/codecs.go
@@ -109,14 +109,26 @@ func (c *queryCSVCodec) Encode(w io.Writer, data any) error {
 		return prometheus.FormatCSV(w, resp)
 	case *loki.QueryResponse:
 		return loki.FormatQueryCSV(w, resp)
+	case *loki.MetricQueryResponse:
+		return loki.FormatMetricQueryCSV(w, resp)
+	case *pyroscope.QueryResponse:
+		return pyroscope.FormatCSV(w, resp)
 	case *tempo.SearchResponse:
 		return tempo.FormatSearchCSV(w, resp)
+	case *tempo.MetricsResponse:
+		return tempo.FormatMetricsCSV(w, resp)
 	case *infinity.QueryResponse:
 		return infinity.FormatCSV(w, resp)
+	case *influxdb.QueryResponse:
+		return influxdb.FormatCSV(w, resp)
 	case *tempo.GetTraceResponse:
 		return errors.New("csv output is not supported for trace get; use -o table/wide/json/yaml")
 	case *querysql.QueryResponse:
 		return querysql.FormatCSV(w, resp)
+	case []clickhouse.TableInfo:
+		return clickhouse.FormatListTablesCSV(w, resp)
+	case []clickhouse.ColumnInfo:
+		return clickhouse.FormatDescribeTableCSV(w, resp)
 	case athena.StringList:
 		return athena.FormatStringListCSV(w, resp.Items, resp.Header)
 	case *cloudwatch.QueryResponse:

--- a/internal/datasources/query/codecs.go
+++ b/internal/datasources/query/codecs.go
@@ -97,6 +97,39 @@ func (c *queryWideCodec) Decode(io.Reader, any) error {
 	return errors.New("query wide codec does not support decoding")
 }
 
+type queryCSVCodec struct{}
+
+func (c *queryCSVCodec) Format() format.Format {
+	return "csv"
+}
+
+func (c *queryCSVCodec) Encode(w io.Writer, data any) error {
+	switch resp := data.(type) {
+	case *prometheus.QueryResponse:
+		return prometheus.FormatCSV(w, resp)
+	case *loki.QueryResponse:
+		return loki.FormatQueryCSV(w, resp)
+	case *tempo.SearchResponse:
+		return tempo.FormatSearchCSV(w, resp)
+	case *infinity.QueryResponse:
+		return infinity.FormatCSV(w, resp)
+	case *tempo.GetTraceResponse:
+		return errors.New("csv output is not supported for trace get; use -o table/wide/json/yaml")
+	case *querysql.QueryResponse:
+		return querysql.FormatCSV(w, resp)
+	case athena.StringList:
+		return athena.FormatStringListCSV(w, resp.Items, resp.Header)
+	case *cloudwatch.QueryResponse:
+		return cloudwatch.FormatCSV(w, resp)
+	default:
+		return errors.New("invalid data type for query csv codec")
+	}
+}
+
+func (c *queryCSVCodec) Decode(io.Reader, any) error {
+	return errors.New("query csv codec does not support decoding")
+}
+
 type queryGraphCodec struct{}
 
 func (c *queryGraphCodec) Format() format.Format {
@@ -212,6 +245,7 @@ func (c *queryYAMLCodec) Decode(r io.Reader, v any) error {
 func RegisterCodecs(ioOpts *cmdio.Options, enableGraph bool) {
 	ioOpts.RegisterCustomCodec("table", &queryTableCodec{})
 	ioOpts.RegisterCustomCodec("wide", &queryWideCodec{})
+	ioOpts.RegisterCustomCodec("csv", &queryCSVCodec{})
 	ioOpts.RegisterCustomCodec("json", &queryJSONCodec{inner: format.NewJSONCodec()})
 	ioOpts.RegisterCustomCodec("yaml", &queryYAMLCodec{inner: format.NewYAMLCodec()})
 	if enableGraph {

--- a/internal/datasources/query/codecs.go
+++ b/internal/datasources/query/codecs.go
@@ -145,14 +145,26 @@ func (c *queryCSVCodec) Encode(w io.Writer, data any) error {
 		return prometheus.FormatCSV(w, resp)
 	case *loki.QueryResponse:
 		return loki.FormatQueryCSV(w, resp)
+	case *loki.MetricQueryResponse:
+		return loki.FormatMetricQueryCSV(w, resp)
+	case *pyroscope.QueryResponse:
+		return pyroscope.FormatCSV(w, resp)
 	case *tempo.SearchResponse:
 		return tempo.FormatSearchCSV(w, resp)
+	case *tempo.MetricsResponse:
+		return tempo.FormatMetricsCSV(w, resp)
 	case *infinity.QueryResponse:
 		return infinity.FormatCSV(w, resp)
+	case *influxdb.QueryResponse:
+		return influxdb.FormatCSV(w, resp)
 	case *tempo.GetTraceResponse:
 		return errors.New("csv output is not supported for trace get; use -o table/wide/json/yaml")
 	case *querysql.QueryResponse:
 		return querysql.FormatCSV(w, resp)
+	case []clickhouse.TableInfo:
+		return clickhouse.FormatListTablesCSV(w, resp)
+	case []clickhouse.ColumnInfo:
+		return clickhouse.FormatDescribeTableCSV(w, resp)
 	case athena.StringList:
 		return athena.FormatStringListCSV(w, resp.Items, resp.Header)
 	case *cloudwatch.QueryResponse:

--- a/internal/datasources/query/codecs.go
+++ b/internal/datasources/query/codecs.go
@@ -133,6 +133,39 @@ func (c *queryWideCodec) Decode(io.Reader, any) error {
 	return errors.New("query wide codec does not support decoding")
 }
 
+type queryCSVCodec struct{}
+
+func (c *queryCSVCodec) Format() format.Format {
+	return "csv"
+}
+
+func (c *queryCSVCodec) Encode(w io.Writer, data any) error {
+	switch resp := data.(type) {
+	case *prometheus.QueryResponse:
+		return prometheus.FormatCSV(w, resp)
+	case *loki.QueryResponse:
+		return loki.FormatQueryCSV(w, resp)
+	case *tempo.SearchResponse:
+		return tempo.FormatSearchCSV(w, resp)
+	case *infinity.QueryResponse:
+		return infinity.FormatCSV(w, resp)
+	case *tempo.GetTraceResponse:
+		return errors.New("csv output is not supported for trace get; use -o table/wide/json/yaml")
+	case *querysql.QueryResponse:
+		return querysql.FormatCSV(w, resp)
+	case athena.StringList:
+		return athena.FormatStringListCSV(w, resp.Items, resp.Header)
+	case *cloudwatch.QueryResponse:
+		return cloudwatch.FormatCSV(w, resp)
+	default:
+		return errors.New("invalid data type for query csv codec")
+	}
+}
+
+func (c *queryCSVCodec) Decode(io.Reader, any) error {
+	return errors.New("query csv codec does not support decoding")
+}
+
 type queryGraphCodec struct{}
 
 func (c *queryGraphCodec) Format() format.Format {
@@ -271,6 +304,7 @@ func (c *queryYAMLCodec) Decode(r io.Reader, v any) error {
 func RegisterCodecs(ioOpts *cmdio.Options, enableGraph bool) {
 	ioOpts.RegisterCustomCodec("table", &queryTableCodec{})
 	ioOpts.RegisterCustomCodec("wide", &queryWideCodec{})
+	ioOpts.RegisterCustomCodec("csv", &queryCSVCodec{})
 	ioOpts.RegisterCustomCodec("json", &queryJSONCodec{inner: format.NewJSONCodec()})
 	ioOpts.RegisterCustomCodec("yaml", &queryYAMLCodec{inner: format.NewYAMLCodec()})
 	if enableGraph {

--- a/internal/datasources/query/codecs_test.go
+++ b/internal/datasources/query/codecs_test.go
@@ -8,10 +8,12 @@ import (
 
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/query/clickhouse"
 	"github.com/grafana/gcx/internal/query/infinity"
 	"github.com/grafana/gcx/internal/query/influxdb"
 	"github.com/grafana/gcx/internal/query/loki"
 	"github.com/grafana/gcx/internal/query/prometheus"
+	"github.com/grafana/gcx/internal/query/pyroscope"
 	"github.com/grafana/gcx/internal/query/tempo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -205,5 +207,93 @@ func TestTraceGetCodecDispatch(t *testing.T) {
 		require.NoError(t, err)
 		assert.Contains(t, out.String(), "spans: 0")
 		assert.Contains(t, out.String(), "services: 0")
+	})
+}
+
+// TestCSVCodecDispatch verifies the csv codec routes the six types that
+// table supports but wide doesn't (loki metric query, pyroscope, tempo
+// metrics, influxdb, clickhouse table/column info) to the matching
+// FormatCSV function, still rejects trace-get, and rejects an unsupported
+// type.
+func TestCSVCodecDispatch(t *testing.T) {
+	newCSVIO := func() *cmdio.Options {
+		t.Helper()
+		ioOpts := &cmdio.Options{OutputFormat: "csv"}
+		dsquery.RegisterCodecs(ioOpts, false)
+		return ioOpts
+	}
+
+	t.Run("loki metric query", func(t *testing.T) {
+		resp := &loki.MetricQueryResponse{
+			Data: loki.MetricQueryData{
+				Result: []loki.MetricQuerySample{
+					{Metric: map[string]string{"level": "error"}, Values: [][]any{{float64(1700000000), "3.5"}}},
+				},
+			},
+		}
+		var out bytes.Buffer
+		require.NoError(t, newCSVIO().Encode(&out, resp))
+		assert.Contains(t, out.String(), "TIMESTAMP,VALUE,LEVEL")
+	})
+
+	t.Run("pyroscope", func(t *testing.T) {
+		resp := &pyroscope.QueryResponse{
+			Flamegraph: &pyroscope.Flamegraph{
+				Names:  []string{"total", "main"},
+				Levels: []pyroscope.Level{{Values: []string{"0", "10", "10", "1"}}},
+			},
+		}
+		var out bytes.Buffer
+		require.NoError(t, newCSVIO().Encode(&out, resp))
+		assert.Contains(t, out.String(), "FUNCTION,SELF,TOTAL,PERCENTAGE")
+	})
+
+	t.Run("tempo metrics", func(t *testing.T) {
+		val := float64(1)
+		resp := &tempo.MetricsResponse{
+			Instant: true,
+			Series:  []tempo.MetricsSeries{{Value: &val}},
+		}
+		var out bytes.Buffer
+		require.NoError(t, newCSVIO().Encode(&out, resp))
+		assert.Contains(t, out.String(), "VALUE")
+	})
+
+	t.Run("influxdb", func(t *testing.T) {
+		resp := &influxdb.QueryResponse{
+			Columns: []string{"host"},
+			Rows:    [][]any{{"server-a"}},
+		}
+		var out bytes.Buffer
+		require.NoError(t, newCSVIO().Encode(&out, resp))
+		assert.Equal(t, "host\nserver-a\n", out.String())
+	})
+
+	t.Run("clickhouse table info", func(t *testing.T) {
+		resp := []clickhouse.TableInfo{{Database: "default", Name: "events", Engine: "MergeTree"}}
+		var out bytes.Buffer
+		require.NoError(t, newCSVIO().Encode(&out, resp))
+		assert.Contains(t, out.String(), "DATABASE,NAME,ENGINE")
+	})
+
+	t.Run("clickhouse column info", func(t *testing.T) {
+		resp := []clickhouse.ColumnInfo{{Name: "id", Type: "UInt64"}}
+		var out bytes.Buffer
+		require.NoError(t, newCSVIO().Encode(&out, resp))
+		assert.Contains(t, out.String(), "NAME,TYPE")
+	})
+
+	t.Run("trace get still rejected", func(t *testing.T) {
+		var out bytes.Buffer
+		err := newCSVIO().Encode(&out, &tempo.GetTraceResponse{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "csv output is not supported for trace get")
+	})
+
+	t.Run("unsupported type rejected", func(t *testing.T) {
+		var out bytes.Buffer
+		err := newCSVIO().Encode(&out, "not a query response")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid data type for query csv codec")
 	})
 }

--- a/internal/datasources/query/codecs_test.go
+++ b/internal/datasources/query/codecs_test.go
@@ -10,12 +10,14 @@ import (
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/query/azuremonitor"
+	"github.com/grafana/gcx/internal/query/clickhouse"
 	"github.com/grafana/gcx/internal/query/cloudmonitoring"
 	"github.com/grafana/gcx/internal/query/elasticsearch"
 	"github.com/grafana/gcx/internal/query/infinity"
 	"github.com/grafana/gcx/internal/query/influxdb"
 	"github.com/grafana/gcx/internal/query/loki"
 	"github.com/grafana/gcx/internal/query/prometheus"
+	"github.com/grafana/gcx/internal/query/pyroscope"
 	"github.com/grafana/gcx/internal/query/tempo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -360,5 +362,93 @@ func TestQueryCodecsCloudMonitoring(t *testing.T) {
 		var out bytes.Buffer
 		require.NoError(t, newIO("graph").Encode(&out, resp))
 		assert.Contains(t, out.String(), "cpu/utilization")
+	})
+}
+
+// TestCSVCodecDispatch verifies the csv codec routes the six types that
+// table supports but wide doesn't (loki metric query, pyroscope, tempo
+// metrics, influxdb, clickhouse table/column info) to the matching
+// FormatCSV function, still rejects trace-get, and rejects an unsupported
+// type.
+func TestCSVCodecDispatch(t *testing.T) {
+	newCSVIO := func() *cmdio.Options {
+		t.Helper()
+		ioOpts := &cmdio.Options{OutputFormat: "csv"}
+		dsquery.RegisterCodecs(ioOpts, false)
+		return ioOpts
+	}
+
+	t.Run("loki metric query", func(t *testing.T) {
+		resp := &loki.MetricQueryResponse{
+			Data: loki.MetricQueryData{
+				Result: []loki.MetricQuerySample{
+					{Metric: map[string]string{"level": "error"}, Values: [][]any{{float64(1700000000), "3.5"}}},
+				},
+			},
+		}
+		var out bytes.Buffer
+		require.NoError(t, newCSVIO().Encode(&out, resp))
+		assert.Contains(t, out.String(), "TIMESTAMP,VALUE,LEVEL")
+	})
+
+	t.Run("pyroscope", func(t *testing.T) {
+		resp := &pyroscope.QueryResponse{
+			Flamegraph: &pyroscope.Flamegraph{
+				Names:  []string{"total", "main"},
+				Levels: []pyroscope.Level{{Values: []string{"0", "10", "10", "1"}}},
+			},
+		}
+		var out bytes.Buffer
+		require.NoError(t, newCSVIO().Encode(&out, resp))
+		assert.Contains(t, out.String(), "FUNCTION,SELF,TOTAL,PERCENTAGE")
+	})
+
+	t.Run("tempo metrics", func(t *testing.T) {
+		val := float64(1)
+		resp := &tempo.MetricsResponse{
+			Instant: true,
+			Series:  []tempo.MetricsSeries{{Value: &val}},
+		}
+		var out bytes.Buffer
+		require.NoError(t, newCSVIO().Encode(&out, resp))
+		assert.Contains(t, out.String(), "VALUE")
+	})
+
+	t.Run("influxdb", func(t *testing.T) {
+		resp := &influxdb.QueryResponse{
+			Columns: []string{"host"},
+			Rows:    [][]any{{"server-a"}},
+		}
+		var out bytes.Buffer
+		require.NoError(t, newCSVIO().Encode(&out, resp))
+		assert.Equal(t, "host\nserver-a\n", out.String())
+	})
+
+	t.Run("clickhouse table info", func(t *testing.T) {
+		resp := []clickhouse.TableInfo{{Database: "default", Name: "events", Engine: "MergeTree"}}
+		var out bytes.Buffer
+		require.NoError(t, newCSVIO().Encode(&out, resp))
+		assert.Contains(t, out.String(), "DATABASE,NAME,ENGINE")
+	})
+
+	t.Run("clickhouse column info", func(t *testing.T) {
+		resp := []clickhouse.ColumnInfo{{Name: "id", Type: "UInt64"}}
+		var out bytes.Buffer
+		require.NoError(t, newCSVIO().Encode(&out, resp))
+		assert.Contains(t, out.String(), "NAME,TYPE")
+	})
+
+	t.Run("trace get still rejected", func(t *testing.T) {
+		var out bytes.Buffer
+		err := newCSVIO().Encode(&out, &tempo.GetTraceResponse{})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "csv output is not supported for trace get")
+	})
+
+	t.Run("unsupported type rejected", func(t *testing.T) {
+		var out bytes.Buffer
+		err := newCSVIO().Encode(&out, "not a query response")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid data type for query csv codec")
 	})
 }

--- a/internal/datasources/tempo/get.go
+++ b/internal/datasources/tempo/get.go
@@ -24,6 +24,9 @@ type getOpts struct {
 
 func (opts *getOpts) setup(flags *pflag.FlagSet) {
 	dsquery.RegisterCodecs(&opts.IO, false)
+	// csv is not supported for trace get (queryCSVCodec rejects
+	// *tempo.GetTraceResponse), so hide it from the advertised menu.
+	opts.IO.HideFormat("csv")
 	// Default is the human-readable tree table for all non-agent sessions.
 	// Piped output renders the same table without ANSI styling (via IsStylingEnabled).
 	// Agent mode is the only path that overrides the default to JSON.

--- a/internal/datasources/tempo/get_test.go
+++ b/internal/datasources/tempo/get_test.go
@@ -75,6 +75,19 @@ current-context: default
 	assert.Empty(t, stderr.String())
 }
 
+// TestGetCmd_CSVHiddenFromOutputMenu verifies csv is not advertised in the
+// -o flag's usage string, since queryCSVCodec rejects *tempo.GetTraceResponse.
+// An explicit -o csv still resolves to the codec and fails with the
+// command's own rejection message rather than "unknown output format".
+func TestGetCmd_CSVHiddenFromOutputMenu(t *testing.T) {
+	loader := &providers.ConfigLoader{}
+	cmd := tempo.GetCmd(loader)
+
+	outputFlag := cmd.Flags().Lookup("output")
+	require.NotNil(t, outputFlag)
+	assert.NotContains(t, outputFlag.Usage, "csv")
+}
+
 func writeTempoTestConfig(t *testing.T, content string) string {
 	t.Helper()
 	f, err := os.CreateTemp(t.TempDir(), "gcx-tempo-config-*.yaml")

--- a/internal/query/athena/formatter.go
+++ b/internal/query/athena/formatter.go
@@ -13,9 +13,21 @@ func FormatStringList(w io.Writer, items []string, header string) error {
 		fmt.Fprintln(w, "No data")
 		return nil
 	}
+	return buildStringListTable(items, header).Render(w)
+}
+
+// FormatStringListCSV formats a []string as single-column CSV with the given header.
+func FormatStringListCSV(w io.Writer, items []string, header string) error {
+	if len(items) == 0 {
+		return nil
+	}
+	return buildStringListTable(items, header).RenderCSV(w)
+}
+
+func buildStringListTable(items []string, header string) *style.TableBuilder {
 	t := style.NewTable(header)
 	for _, item := range items {
 		t.Row(item)
 	}
-	return t.Render(w)
+	return t
 }

--- a/internal/query/athena/formatter.go
+++ b/internal/query/athena/formatter.go
@@ -16,11 +16,9 @@ func FormatStringList(w io.Writer, items []string, header string) error {
 	return buildStringListTable(items, header).Render(w)
 }
 
-// FormatStringListCSV formats a []string as single-column CSV with the given header.
+// FormatStringListCSV formats a []string as single-column CSV with the given
+// header. An empty list still emits the header row rather than zero bytes.
 func FormatStringListCSV(w io.Writer, items []string, header string) error {
-	if len(items) == 0 {
-		return nil
-	}
 	return buildStringListTable(items, header).RenderCSV(w)
 }
 

--- a/internal/query/athena/formatter_test.go
+++ b/internal/query/athena/formatter_test.go
@@ -27,3 +27,19 @@ func TestFormatStringList(t *testing.T) {
 		assert.Contains(t, buf.String(), "No data")
 	})
 }
+
+func TestFormatStringListCSV(t *testing.T) {
+	t.Run("renders items", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := athena.FormatStringListCSV(&buf, []string{"alpha", "beta"}, "CATALOG")
+		require.NoError(t, err)
+		assert.Equal(t, "CATALOG\nalpha\nbeta\n", buf.String())
+	})
+
+	t.Run("empty result", func(t *testing.T) {
+		var buf bytes.Buffer
+		err := athena.FormatStringListCSV(&buf, []string{}, "EMPTY")
+		require.NoError(t, err)
+		assert.Empty(t, buf.String())
+	})
+}

--- a/internal/query/athena/formatter_test.go
+++ b/internal/query/athena/formatter_test.go
@@ -36,10 +36,10 @@ func TestFormatStringListCSV(t *testing.T) {
 		assert.Equal(t, "CATALOG\nalpha\nbeta\n", buf.String())
 	})
 
-	t.Run("empty result", func(t *testing.T) {
+	t.Run("empty result still emits header", func(t *testing.T) {
 		var buf bytes.Buffer
 		err := athena.FormatStringListCSV(&buf, []string{}, "EMPTY")
 		require.NoError(t, err)
-		assert.Empty(t, buf.String())
+		assert.Equal(t, "EMPTY\n", buf.String())
 	})
 }

--- a/internal/query/clickhouse/formatter.go
+++ b/internal/query/clickhouse/formatter.go
@@ -40,3 +40,36 @@ func formatNullableUint64(v *uint64) string {
 	}
 	return strconv.FormatUint(*v, 10)
 }
+
+// FormatListTablesCSV formats a slice of TableInfo as CSV. TOTAL_ROWS/
+// TOTAL_BYTES are empty (not "-") for an absent value, so DuckDB infers a
+// numeric column instead of falling back to VARCHAR.
+func FormatListTablesCSV(w io.Writer, tables []TableInfo) error {
+	if len(tables) == 0 {
+		return nil
+	}
+	t := style.NewTable("DATABASE", "NAME", "ENGINE", "TOTAL_ROWS", "TOTAL_BYTES")
+	for _, tbl := range tables {
+		t.Row(tbl.Database, tbl.Name, tbl.Engine, formatNullableUint64CSV(tbl.TotalRows), formatNullableUint64CSV(tbl.TotalBytes))
+	}
+	return t.RenderCSV(w)
+}
+
+// FormatDescribeTableCSV formats a slice of ColumnInfo as CSV.
+func FormatDescribeTableCSV(w io.Writer, cols []ColumnInfo) error {
+	if len(cols) == 0 {
+		return nil
+	}
+	t := style.NewTable("NAME", "TYPE", "DEFAULT_TYPE", "DEFAULT_EXPRESSION", "COMMENT")
+	for _, c := range cols {
+		t.Row(c.Name, c.Type, c.DefaultType, c.DefaultExpression, c.Comment)
+	}
+	return t.RenderCSV(w)
+}
+
+func formatNullableUint64CSV(v *uint64) string {
+	if v == nil {
+		return ""
+	}
+	return strconv.FormatUint(*v, 10)
+}

--- a/internal/query/clickhouse/formatter.go
+++ b/internal/query/clickhouse/formatter.go
@@ -45,9 +45,6 @@ func formatNullableUint64(v *uint64) string {
 // TOTAL_BYTES are empty (not "-") for an absent value, so DuckDB infers a
 // numeric column instead of falling back to VARCHAR.
 func FormatListTablesCSV(w io.Writer, tables []TableInfo) error {
-	if len(tables) == 0 {
-		return nil
-	}
 	t := style.NewTable("DATABASE", "NAME", "ENGINE", "TOTAL_ROWS", "TOTAL_BYTES")
 	for _, tbl := range tables {
 		t.Row(tbl.Database, tbl.Name, tbl.Engine, formatNullableUint64CSV(tbl.TotalRows), formatNullableUint64CSV(tbl.TotalBytes))
@@ -57,9 +54,6 @@ func FormatListTablesCSV(w io.Writer, tables []TableInfo) error {
 
 // FormatDescribeTableCSV formats a slice of ColumnInfo as CSV.
 func FormatDescribeTableCSV(w io.Writer, cols []ColumnInfo) error {
-	if len(cols) == 0 {
-		return nil
-	}
 	t := style.NewTable("NAME", "TYPE", "DEFAULT_TYPE", "DEFAULT_EXPRESSION", "COMMENT")
 	for _, c := range cols {
 		t.Row(c.Name, c.Type, c.DefaultType, c.DefaultExpression, c.Comment)

--- a/internal/query/clickhouse/formatter_test.go
+++ b/internal/query/clickhouse/formatter_test.go
@@ -40,3 +40,34 @@ func TestFormatDescribeTableTable(t *testing.T) {
 	assert.Contains(t, out, "primary key")
 	assert.Contains(t, out, "DEFAULT")
 }
+
+func TestFormatListTablesCSV(t *testing.T) {
+	totalRows := uint64(1000)
+	tables := []clickhouse.TableInfo{
+		{Database: "default", Name: "events", Engine: "MergeTree", TotalRows: &totalRows, TotalBytes: nil},
+	}
+	var buf bytes.Buffer
+	require.NoError(t, clickhouse.FormatListTablesCSV(&buf, tables))
+	assert.Equal(t, "DATABASE,NAME,ENGINE,TOTAL_ROWS,TOTAL_BYTES\ndefault,events,MergeTree,1000,\n", buf.String())
+}
+
+func TestFormatListTablesCSV_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, clickhouse.FormatListTablesCSV(&buf, nil))
+	assert.Empty(t, buf.String())
+}
+
+func TestFormatDescribeTableCSV(t *testing.T) {
+	cols := []clickhouse.ColumnInfo{
+		{Name: "id", Type: "UInt64", Comment: "primary key"},
+	}
+	var buf bytes.Buffer
+	require.NoError(t, clickhouse.FormatDescribeTableCSV(&buf, cols))
+	assert.Equal(t, "NAME,TYPE,DEFAULT_TYPE,DEFAULT_EXPRESSION,COMMENT\nid,UInt64,,,primary key\n", buf.String())
+}
+
+func TestFormatDescribeTableCSV_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, clickhouse.FormatDescribeTableCSV(&buf, nil))
+	assert.Empty(t, buf.String())
+}

--- a/internal/query/clickhouse/formatter_test.go
+++ b/internal/query/clickhouse/formatter_test.go
@@ -54,7 +54,7 @@ func TestFormatListTablesCSV(t *testing.T) {
 func TestFormatListTablesCSV_Empty(t *testing.T) {
 	var buf bytes.Buffer
 	require.NoError(t, clickhouse.FormatListTablesCSV(&buf, nil))
-	assert.Empty(t, buf.String())
+	assert.Equal(t, "DATABASE,NAME,ENGINE,TOTAL_ROWS,TOTAL_BYTES\n", buf.String())
 }
 
 func TestFormatDescribeTableCSV(t *testing.T) {
@@ -69,5 +69,5 @@ func TestFormatDescribeTableCSV(t *testing.T) {
 func TestFormatDescribeTableCSV_Empty(t *testing.T) {
 	var buf bytes.Buffer
 	require.NoError(t, clickhouse.FormatDescribeTableCSV(&buf, nil))
-	assert.Empty(t, buf.String())
+	assert.Equal(t, "NAME,TYPE,DEFAULT_TYPE,DEFAULT_EXPRESSION,COMMENT\n", buf.String())
 }

--- a/internal/query/cloudwatch/formatter.go
+++ b/internal/query/cloudwatch/formatter.go
@@ -38,6 +38,19 @@ func FormatWide(w io.Writer, resp *QueryResponse) error {
 		return nil
 	}
 
+	return buildWideTable(resp).Render(w)
+}
+
+// FormatCSV renders query results as CSV, same columns as FormatWide.
+func FormatCSV(w io.Writer, resp *QueryResponse) error {
+	if len(resp.Frames) == 0 {
+		return nil
+	}
+
+	return buildWideTable(resp).RenderCSV(w)
+}
+
+func buildWideTable(resp *QueryResponse) *style.TableBuilder {
 	t := style.NewTable("TIMESTAMP", "VALUE", "SERIES", "LABEL")
 	for _, frame := range resp.Frames {
 		label := frameLabel(frame)
@@ -50,7 +63,7 @@ func FormatWide(w io.Writer, resp *QueryResponse) error {
 			t.Row(ts.Format("2006-01-02T15:04:05Z07:00"), val, label, labelStr)
 		}
 	}
-	return t.Render(w)
+	return t
 }
 
 // FormatNamespaces renders a list of CloudWatch namespaces.

--- a/internal/query/cloudwatch/formatter.go
+++ b/internal/query/cloudwatch/formatter.go
@@ -41,12 +41,9 @@ func FormatWide(w io.Writer, resp *QueryResponse) error {
 	return buildWideTable(resp).Render(w)
 }
 
-// FormatCSV renders query results as CSV, same columns as FormatWide.
+// FormatCSV renders query results as CSV, same columns as FormatWide. An
+// empty result still emits the header row rather than zero bytes.
 func FormatCSV(w io.Writer, resp *QueryResponse) error {
-	if len(resp.Frames) == 0 {
-		return nil
-	}
-
 	return buildWideTable(resp).RenderCSV(w)
 }
 

--- a/internal/query/cloudwatch/formatter_test.go
+++ b/internal/query/cloudwatch/formatter_test.go
@@ -97,6 +97,31 @@ func TestFormatWide_Empty(t *testing.T) {
 	assert.Contains(t, buf.String(), "No data")
 }
 
+func TestFormatCSV_HasLabelColumn(t *testing.T) {
+	resp := &cloudwatch.QueryResponse{
+		Frames: []cloudwatch.Frame{
+			{
+				Name:       "CPUUtilization",
+				Labels:     map[string]string{"InstanceId": "i-abc"},
+				Timestamps: []time.Time{ts("2026-05-17T00:00:00Z")},
+				Values:     []*float64{pf(10.0)},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, cloudwatch.FormatCSV(&buf, resp))
+	out := buf.String()
+	assert.Contains(t, out, "TIMESTAMP,VALUE,SERIES,LABEL")
+	assert.Contains(t, out, "InstanceId")
+}
+
+func TestFormatCSV_Empty(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, cloudwatch.FormatCSV(&buf, &cloudwatch.QueryResponse{}))
+	assert.Empty(t, buf.String())
+}
+
 func TestFormatNamespaces_Populated(t *testing.T) {
 	var buf bytes.Buffer
 	require.NoError(t, cloudwatch.FormatNamespaces(&buf, []string{"AWS/EC2", "AWS/Lambda"}))

--- a/internal/query/cloudwatch/formatter_test.go
+++ b/internal/query/cloudwatch/formatter_test.go
@@ -119,7 +119,7 @@ func TestFormatCSV_HasLabelColumn(t *testing.T) {
 func TestFormatCSV_Empty(t *testing.T) {
 	var buf bytes.Buffer
 	require.NoError(t, cloudwatch.FormatCSV(&buf, &cloudwatch.QueryResponse{}))
-	assert.Empty(t, buf.String())
+	assert.Equal(t, "TIMESTAMP,VALUE,SERIES,LABEL\n", buf.String())
 }
 
 func TestFormatNamespaces_Populated(t *testing.T) {

--- a/internal/query/infinity/formatter.go
+++ b/internal/query/infinity/formatter.go
@@ -15,6 +15,19 @@ func FormatTable(w io.Writer, resp *QueryResponse) error {
 		return nil
 	}
 
+	return buildTable(resp).Render(w)
+}
+
+// FormatCSV renders a QueryResponse as CSV, same columns as FormatTable.
+func FormatCSV(w io.Writer, resp *QueryResponse) error {
+	if len(resp.Rows) == 0 {
+		return nil
+	}
+
+	return buildTable(resp).RenderCSV(w)
+}
+
+func buildTable(resp *QueryResponse) *style.TableBuilder {
 	headers := make([]string, len(resp.Columns))
 	for i, col := range resp.Columns {
 		headers[i] = strings.ToUpper(col.Name)
@@ -29,5 +42,5 @@ func FormatTable(w io.Writer, resp *QueryResponse) error {
 		t.Row(cells...)
 	}
 
-	return t.Render(w)
+	return t
 }

--- a/internal/query/infinity/formatter.go
+++ b/internal/query/infinity/formatter.go
@@ -18,12 +18,9 @@ func FormatTable(w io.Writer, resp *QueryResponse) error {
 	return buildTable(resp).Render(w)
 }
 
-// FormatCSV renders a QueryResponse as CSV, same columns as FormatTable.
+// FormatCSV renders a QueryResponse as CSV, same columns as FormatTable. An
+// empty result still emits the header row rather than zero bytes.
 func FormatCSV(w io.Writer, resp *QueryResponse) error {
-	if len(resp.Rows) == 0 {
-		return nil
-	}
-
 	return buildTable(resp).RenderCSV(w)
 }
 

--- a/internal/query/infinity/formatter_test.go
+++ b/internal/query/infinity/formatter_test.go
@@ -97,3 +97,28 @@ func TestFormatTable(t *testing.T) {
 		})
 	}
 }
+
+func TestFormatCSV(t *testing.T) {
+	resp := &infinity.QueryResponse{
+		Columns: []infinity.Column{
+			{Name: "host", Type: "string"},
+			{Name: "status", Type: "number"},
+		},
+		Rows: [][]any{
+			{"server-1", float64(200)},
+			{"server-2", float64(500)},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, infinity.FormatCSV(&buf, resp))
+
+	want := "HOST,STATUS\nserver-1,200\nserver-2,500\n"
+	assert.Equal(t, want, buf.String())
+}
+
+func TestFormatCSV_NoData(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, infinity.FormatCSV(&buf, &infinity.QueryResponse{}))
+	assert.Empty(t, buf.String())
+}

--- a/internal/query/influxdb/formatter.go
+++ b/internal/query/influxdb/formatter.go
@@ -32,6 +32,29 @@ func FormatQueryTable(w io.Writer, resp *QueryResponse) error {
 	return t.Render(w)
 }
 
+// FormatCSV formats a QueryResponse as CSV — same column layout and cell
+// formatting as FormatQueryTable (RFC3339 timestamps, decimal floats).
+func FormatCSV(w io.Writer, resp *QueryResponse) error {
+	if len(resp.Rows) == 0 {
+		return nil
+	}
+
+	t := style.NewTable(resp.Columns...)
+	for _, row := range resp.Rows {
+		vals := make([]string, len(row))
+		for i, v := range row {
+			if resp.TimeColumns[i] {
+				vals[i] = formatTimestampMs(v)
+			} else {
+				vals[i] = formatValue(v)
+			}
+		}
+		t.Row(vals...)
+	}
+
+	return t.RenderCSV(w)
+}
+
 // formatTimestampMs converts a millisecond-epoch value to RFC3339.
 func formatTimestampMs(v any) string {
 	var ms int64

--- a/internal/query/influxdb/formatter.go
+++ b/internal/query/influxdb/formatter.go
@@ -33,12 +33,9 @@ func FormatQueryTable(w io.Writer, resp *QueryResponse) error {
 }
 
 // FormatCSV formats a QueryResponse as CSV — same column layout and cell
-// formatting as FormatQueryTable (RFC3339 timestamps, decimal floats).
+// formatting as FormatQueryTable (RFC3339 timestamps, decimal floats). An
+// empty result still emits the header row rather than zero bytes.
 func FormatCSV(w io.Writer, resp *QueryResponse) error {
-	if len(resp.Rows) == 0 {
-		return nil
-	}
-
 	t := style.NewTable(resp.Columns...)
 	for _, row := range resp.Rows {
 		vals := make([]string, len(row))

--- a/internal/query/influxdb/formatter_test.go
+++ b/internal/query/influxdb/formatter_test.go
@@ -65,6 +65,26 @@ func TestFormatQueryTable(t *testing.T) {
 	}
 }
 
+func TestFormatCSV(t *testing.T) {
+	resp := &influxdb.QueryResponse{
+		Columns:     []string{"time", "cpu", "host"},
+		TimeColumns: map[int]bool{0: true},
+		Rows: [][]any{
+			{float64(1700000000000), float64(55.2), "server-a"},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, influxdb.FormatCSV(&buf, resp))
+	assert.Equal(t, "time,cpu,host\n2023-11-14T22:13:20Z,55.2,server-a\n", buf.String())
+}
+
+func TestFormatCSV_NoData(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, influxdb.FormatCSV(&buf, &influxdb.QueryResponse{}))
+	assert.Empty(t, buf.String())
+}
+
 func TestFormatMeasurementsTable(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/query/loki/formatter.go
+++ b/internal/query/loki/formatter.go
@@ -258,6 +258,77 @@ func FormatMetricQueryTable(w io.Writer, resp *MetricQueryResponse) error {
 	return t.Render(w)
 }
 
+// FormatMetricQueryCSV formats a MetricQueryResponse as CSV: TIMESTAMP,
+// VALUE, and one column per metric label — same layout as
+// FormatMetricQueryTable, but TIMESTAMP is rendered as RFC3339 (rather than
+// a raw epoch-seconds number) so DuckDB infers a real timestamp column
+// instead of a double.
+func FormatMetricQueryCSV(w io.Writer, resp *MetricQueryResponse) error {
+	if len(resp.Data.Result) == 0 {
+		return nil
+	}
+
+	labelNames := collectMetricLabelNames(resp.Data.Result)
+	header := make([]string, 0, len(labelNames)+2)
+	header = append(header, "TIMESTAMP", "VALUE")
+	for _, name := range labelNames {
+		header = append(header, strings.ToUpper(name))
+	}
+	t := style.NewTable(header...)
+
+	appendRow := func(metric map[string]string, point []any) {
+		if len(point) < 2 {
+			return
+		}
+		row := make([]string, 0, len(labelNames)+2)
+		row = append(row, formatMetricTimestamp(point[0]), formatMetricValue(point[1]))
+		for _, name := range labelNames {
+			row = append(row, metric[name])
+		}
+		t.Row(row...)
+	}
+
+	for _, sample := range resp.Data.Result {
+		if len(sample.Values) > 0 {
+			for _, v := range sample.Values {
+				appendRow(sample.Metric, v)
+			}
+		} else if len(sample.Value) >= 2 {
+			appendRow(sample.Metric, sample.Value)
+		}
+	}
+
+	return t.RenderCSV(w)
+}
+
+// formatMetricTimestamp parses a Unix-epoch-seconds value (float or numeric
+// string, same wire shape Prometheus uses) into RFC3339.
+func formatMetricTimestamp(v any) string {
+	switch ts := v.(type) {
+	case float64:
+		return time.Unix(int64(ts), int64((ts-float64(int64(ts)))*1e9)).UTC().Format(time.RFC3339)
+	case string:
+		f, err := strconv.ParseFloat(ts, 64)
+		if err != nil {
+			return ts
+		}
+		return time.Unix(int64(f), int64((f-float64(int64(f)))*1e9)).UTC().Format(time.RFC3339)
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
+func formatMetricValue(v any) string {
+	switch val := v.(type) {
+	case string:
+		return val
+	case float64:
+		return strconv.FormatFloat(val, 'f', -1, 64)
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}
+
 func buildDisplayEntries(resp *QueryResponse) []displayLogEntry {
 	if resp == nil {
 		return nil

--- a/internal/query/loki/formatter.go
+++ b/internal/query/loki/formatter.go
@@ -107,6 +107,21 @@ func FormatQueryTableWide(w io.Writer, resp *QueryResponse) error {
 		return nil
 	}
 
+	return buildQueryWideTable(resp, entries).Render(w)
+}
+
+// FormatQueryCSV formats a QueryResponse as CSV, one column per stream label —
+// the same column layout as FormatQueryTableWide.
+func FormatQueryCSV(w io.Writer, resp *QueryResponse) error {
+	entries := buildDisplayEntries(resp)
+	if len(entries) == 0 {
+		return nil
+	}
+
+	return buildQueryWideTable(resp, entries).RenderCSV(w)
+}
+
+func buildQueryWideTable(resp *QueryResponse, entries []displayLogEntry) *style.TableBuilder {
 	labelNames := collectStreamLabelNames(resp.Data.Result)
 	hasLevel := anyEntry(entries, func(e displayLogEntry) string { return e.Level })
 	hasSource := anyEntry(entries, func(e displayLogEntry) string { return e.Source })
@@ -146,7 +161,7 @@ func FormatQueryTableWide(w io.Writer, resp *QueryResponse) error {
 		t.Row(row...)
 	}
 
-	return t.Render(w)
+	return t
 }
 
 // FormatQueryRaw prints only the original log line bodies.

--- a/internal/query/loki/formatter.go
+++ b/internal/query/loki/formatter.go
@@ -111,13 +111,11 @@ func FormatQueryTableWide(w io.Writer, resp *QueryResponse) error {
 }
 
 // FormatQueryCSV formats a QueryResponse as CSV, one column per stream label —
-// the same column layout as FormatQueryTableWide.
+// the same column layout as FormatQueryTableWide. An empty result still
+// emits the header row rather than zero bytes, so a CSV consumer can detect
+// the schema.
 func FormatQueryCSV(w io.Writer, resp *QueryResponse) error {
 	entries := buildDisplayEntries(resp)
-	if len(entries) == 0 {
-		return nil
-	}
-
 	return buildQueryWideTable(resp, entries).RenderCSV(w)
 }
 
@@ -264,10 +262,6 @@ func FormatMetricQueryTable(w io.Writer, resp *MetricQueryResponse) error {
 // a raw epoch-seconds number) so DuckDB infers a real timestamp column
 // instead of a double.
 func FormatMetricQueryCSV(w io.Writer, resp *MetricQueryResponse) error {
-	if len(resp.Data.Result) == 0 {
-		return nil
-	}
-
 	labelNames := collectMetricLabelNames(resp.Data.Result)
 	header := make([]string, 0, len(labelNames)+2)
 	header = append(header, "TIMESTAMP", "VALUE")

--- a/internal/query/loki/formatter_test.go
+++ b/internal/query/loki/formatter_test.go
@@ -98,6 +98,49 @@ func TestFormatQueryTableWide_IncludesTimestampAndLabels(t *testing.T) {
 	assert.Contains(t, out, "tenantID=120351")
 }
 
+func TestFormatQueryCSV_IncludesTimestampAndLabels(t *testing.T) {
+	resp := &loki.QueryResponse{
+		Data: loki.QueryResultData{
+			Result: []loki.StreamEntry{{
+				Stream: map[string]string{
+					"app":       "tempo",
+					"namespace": "prod",
+					"__meta":    "hidden",
+				},
+				Values: []loki.LogEntry{{
+					Timestamp: "1775637286777686890",
+					Line:      `level=warn caller=retention.go:113 msg="compaction delayed" tenantID=120351`,
+				}},
+			}},
+		},
+	}
+
+	var buf bytes.Buffer
+	err := loki.FormatQueryCSV(&buf, resp)
+	require.NoError(t, err)
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	require.Len(t, lines, 2)
+	assert.Equal(t, "TIME,LEVEL,SOURCE,APP,NAMESPACE,MESSAGE,DETAILS", lines[0])
+	assert.NotContains(t, lines[0], "__META")
+
+	assert.Contains(t, lines[1], "2026-04-08T08:34:46.77768689Z")
+	assert.Contains(t, lines[1], "warn")
+	assert.Contains(t, lines[1], "retention.go:113")
+	assert.Contains(t, lines[1], "tempo")
+	assert.Contains(t, lines[1], "prod")
+	assert.Contains(t, lines[1], "compaction delayed")
+	assert.Contains(t, lines[1], "tenantID=120351")
+}
+
+func TestFormatQueryCSV_NoData(t *testing.T) {
+	resp := &loki.QueryResponse{Data: loki.QueryResultData{Result: nil}}
+
+	var buf bytes.Buffer
+	require.NoError(t, loki.FormatQueryCSV(&buf, resp))
+	assert.Empty(t, buf.String())
+}
+
 func TestFormatQueryTable_FallsBackToPlainMessage(t *testing.T) {
 	resp := &loki.QueryResponse{
 		Data: loki.QueryResultData{

--- a/internal/query/loki/formatter_test.go
+++ b/internal/query/loki/formatter_test.go
@@ -141,6 +141,36 @@ func TestFormatQueryCSV_NoData(t *testing.T) {
 	assert.Empty(t, buf.String())
 }
 
+func TestFormatMetricQueryCSV(t *testing.T) {
+	resp := &loki.MetricQueryResponse{
+		Data: loki.MetricQueryData{
+			ResultType: "matrix",
+			Result: []loki.MetricQuerySample{
+				{
+					Metric: map[string]string{"level": "error"},
+					Values: [][]any{{float64(1700000000), "3.5"}},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, loki.FormatMetricQueryCSV(&buf, resp))
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	require.Len(t, lines, 2)
+	assert.Equal(t, "TIMESTAMP,VALUE,LEVEL", lines[0])
+	assert.Equal(t, "2023-11-14T22:13:20Z,3.5,error", lines[1])
+}
+
+func TestFormatMetricQueryCSV_NoData(t *testing.T) {
+	resp := &loki.MetricQueryResponse{Data: loki.MetricQueryData{Result: nil}}
+
+	var buf bytes.Buffer
+	require.NoError(t, loki.FormatMetricQueryCSV(&buf, resp))
+	assert.Empty(t, buf.String())
+}
+
 func TestFormatQueryTable_FallsBackToPlainMessage(t *testing.T) {
 	resp := &loki.QueryResponse{
 		Data: loki.QueryResultData{

--- a/internal/query/loki/formatter_test.go
+++ b/internal/query/loki/formatter_test.go
@@ -138,7 +138,7 @@ func TestFormatQueryCSV_NoData(t *testing.T) {
 
 	var buf bytes.Buffer
 	require.NoError(t, loki.FormatQueryCSV(&buf, resp))
-	assert.Empty(t, buf.String())
+	assert.Equal(t, "TIME,MESSAGE\n", buf.String())
 }
 
 func TestFormatMetricQueryCSV(t *testing.T) {
@@ -168,7 +168,7 @@ func TestFormatMetricQueryCSV_NoData(t *testing.T) {
 
 	var buf bytes.Buffer
 	require.NoError(t, loki.FormatMetricQueryCSV(&buf, resp))
-	assert.Empty(t, buf.String())
+	assert.Equal(t, "TIMESTAMP,VALUE\n", buf.String())
 }
 
 func TestFormatQueryTable_FallsBackToPlainMessage(t *testing.T) {

--- a/internal/query/prometheus/formatter.go
+++ b/internal/query/prometheus/formatter.go
@@ -42,15 +42,37 @@ func FormatWideTable(w io.Writer, resp *QueryResponse) error {
 		return nil
 	}
 
+	t, err := buildWideTable(resp)
+	if err != nil {
+		return err
+	}
+	return t.Render(w)
+}
+
+// FormatCSV formats a QueryResponse as CSV, one column per label plus
+// TIMESTAMP and VALUE — the same column layout as FormatWideTable.
+func FormatCSV(w io.Writer, resp *QueryResponse) error {
+	if len(resp.Data.Result) == 0 {
+		return nil
+	}
+
+	t, err := buildWideTable(resp)
+	if err != nil {
+		return err
+	}
+	return t.RenderCSV(w)
+}
+
+func buildWideTable(resp *QueryResponse) (*style.TableBuilder, error) {
 	switch resp.Data.ResultType {
 	case "vector":
-		return formatVectorWideTable(w, resp)
+		return buildVectorWideTable(resp), nil
 	case "matrix":
-		return formatMatrixWideTable(w, resp)
+		return buildMatrixWideTable(resp), nil
 	case "scalar":
-		return formatScalarTable(w, resp)
+		return buildScalarTable(resp), nil
 	default:
-		return fmt.Errorf("unsupported result type: %s", resp.Data.ResultType)
+		return nil, fmt.Errorf("unsupported result type: %s", resp.Data.ResultType)
 	}
 }
 
@@ -87,7 +109,7 @@ func formatMatrixTable(w io.Writer, resp *QueryResponse) error {
 	return t.Render(w)
 }
 
-func formatVectorWideTable(w io.Writer, resp *QueryResponse) error {
+func buildVectorWideTable(resp *QueryResponse) *style.TableBuilder {
 	labelNames := collectLabelNames(resp.Data.Result)
 
 	header := make([]string, 0, len(labelNames)+2)
@@ -111,10 +133,10 @@ func formatVectorWideTable(w io.Writer, resp *QueryResponse) error {
 		t.Row(row...)
 	}
 
-	return t.Render(w)
+	return t
 }
 
-func formatMatrixWideTable(w io.Writer, resp *QueryResponse) error {
+func buildMatrixWideTable(resp *QueryResponse) *style.TableBuilder {
 	labelNames := collectLabelNames(resp.Data.Result)
 
 	header := make([]string, 0, len(labelNames)+2)
@@ -140,10 +162,10 @@ func formatMatrixWideTable(w io.Writer, resp *QueryResponse) error {
 		}
 	}
 
-	return t.Render(w)
+	return t
 }
 
-func formatScalarTable(w io.Writer, resp *QueryResponse) error {
+func buildScalarTable(resp *QueryResponse) *style.TableBuilder {
 	t := style.NewTable("TIMESTAMP", "VALUE")
 
 	for _, sample := range resp.Data.Result {
@@ -154,7 +176,11 @@ func formatScalarTable(w io.Writer, resp *QueryResponse) error {
 		}
 	}
 
-	return t.Render(w)
+	return t
+}
+
+func formatScalarTable(w io.Writer, resp *QueryResponse) error {
+	return buildScalarTable(resp).Render(w)
 }
 
 func collectLabelNames(samples []Sample) []string {

--- a/internal/query/prometheus/formatter.go
+++ b/internal/query/prometheus/formatter.go
@@ -50,12 +50,11 @@ func FormatWideTable(w io.Writer, resp *QueryResponse) error {
 }
 
 // FormatCSV formats a QueryResponse as CSV, one column per label plus
-// TIMESTAMP and VALUE — the same column layout as FormatWideTable.
+// TIMESTAMP and VALUE — the same column layout as FormatWideTable. Unlike
+// FormatWideTable, an empty result still emits the header row: a CSV
+// consumer like DuckDB needs it to detect the schema, and zero bytes reads
+// as a query failure rather than an empty result set.
 func FormatCSV(w io.Writer, resp *QueryResponse) error {
-	if len(resp.Data.Result) == 0 {
-		return nil
-	}
-
 	t, err := buildWideTable(resp)
 	if err != nil {
 		return err

--- a/internal/query/prometheus/formatter_test.go
+++ b/internal/query/prometheus/formatter_test.go
@@ -81,3 +81,43 @@ func TestFormatVectorTableVariants(t *testing.T) {
 		})
 	}
 }
+
+func TestFormatCSV(t *testing.T) {
+	resp := &prometheus.QueryResponse{
+		Status: "success",
+		Data: prometheus.ResultData{
+			ResultType: "vector",
+			Result: []prometheus.Sample{
+				{
+					Metric: map[string]string{
+						"instance": "localhost:9090",
+						"job":      "prometheus",
+					},
+					Value: []any{float64(1700000000), "1"},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, prometheus.FormatCSV(&buf, resp))
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	require.Len(t, lines, 2)
+	assert.Equal(t, "INSTANCE,JOB,TIMESTAMP,VALUE", lines[0])
+	assert.Equal(t, "localhost:9090,prometheus,2023-11-14T22:13:20Z,1", lines[1])
+}
+
+func TestFormatCSV_NoData(t *testing.T) {
+	resp := &prometheus.QueryResponse{
+		Status: "success",
+		Data: prometheus.ResultData{
+			ResultType: "vector",
+			Result:     nil,
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, prometheus.FormatCSV(&buf, resp))
+	assert.Empty(t, buf.String())
+}

--- a/internal/query/prometheus/formatter_test.go
+++ b/internal/query/prometheus/formatter_test.go
@@ -119,5 +119,5 @@ func TestFormatCSV_NoData(t *testing.T) {
 
 	var buf bytes.Buffer
 	require.NoError(t, prometheus.FormatCSV(&buf, resp))
-	assert.Empty(t, buf.String())
+	assert.Equal(t, "TIMESTAMP,VALUE\n", buf.String())
 }

--- a/internal/query/pyroscope/formatter.go
+++ b/internal/query/pyroscope/formatter.go
@@ -34,6 +34,31 @@ func FormatQueryTable(w io.Writer, resp *QueryResponse) error {
 	return t.Render(w)
 }
 
+// FormatCSV formats a Pyroscope query response as CSV of its top functions —
+// same data as FormatQueryTable (via ExtractTopFunctions), but PERCENTAGE is
+// a plain number (no trailing "%") so DuckDB infers a numeric column, and
+// FUNCTION isn't truncated to 60 chars (that truncation exists only for
+// terminal width, not for analysis).
+func FormatCSV(w io.Writer, resp *QueryResponse) error {
+	if resp.Flamegraph == nil || len(resp.Flamegraph.Names) == 0 {
+		return nil
+	}
+
+	samples := ExtractTopFunctions(resp.Flamegraph, 20)
+
+	t := style.NewTable("FUNCTION", "SELF", "TOTAL", "PERCENTAGE")
+	for _, s := range samples {
+		t.Row(
+			s.Name,
+			strconv.FormatInt(s.Self, 10),
+			strconv.FormatInt(s.Total, 10),
+			strconv.FormatFloat(s.Percentage, 'f', -1, 64),
+		)
+	}
+
+	return t.RenderCSV(w)
+}
+
 // FormatPprofWriteTable formats the result of writing a pprof binary as a single-row table.
 func FormatPprofWriteTable(w io.Writer, result *PprofWriteResult) error {
 	t := style.NewTable("PATH")

--- a/internal/query/pyroscope/formatter.go
+++ b/internal/query/pyroscope/formatter.go
@@ -38,12 +38,9 @@ func FormatQueryTable(w io.Writer, resp *QueryResponse) error {
 // same data as FormatQueryTable (via ExtractTopFunctions), but PERCENTAGE is
 // a plain number (no trailing "%") so DuckDB infers a numeric column, and
 // FUNCTION isn't truncated to 60 chars (that truncation exists only for
-// terminal width, not for analysis).
+// terminal width, not for analysis). No profile data still emits the header
+// row rather than zero bytes.
 func FormatCSV(w io.Writer, resp *QueryResponse) error {
-	if resp.Flamegraph == nil || len(resp.Flamegraph.Names) == 0 {
-		return nil
-	}
-
 	samples := ExtractTopFunctions(resp.Flamegraph, 20)
 
 	t := style.NewTable("FUNCTION", "SELF", "TOTAL", "PERCENTAGE")

--- a/internal/query/pyroscope/formatter_test.go
+++ b/internal/query/pyroscope/formatter_test.go
@@ -4,12 +4,38 @@ import (
 	"bytes"
 	"encoding/json"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/grafana/gcx/internal/query/pyroscope"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestFormatCSV(t *testing.T) {
+	resp := &pyroscope.QueryResponse{
+		Flamegraph: &pyroscope.Flamegraph{
+			Names: []string{"total", "main", "doWork"},
+			// Each level's Values are groups of 4: [offset, total, self, nameIndex].
+			Levels:  []pyroscope.Level{{Values: []string{"0", "100", "10", "1"}}, {Values: []string{"0", "60", "60", "2"}}},
+			Total:   100,
+			MaxSelf: 60,
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, pyroscope.FormatCSV(&buf, resp))
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	assert.Equal(t, "FUNCTION,SELF,TOTAL,PERCENTAGE", lines[0])
+	assert.Contains(t, buf.String(), "doWork,60,60,60")
+}
+
+func TestFormatCSV_NoProfileData(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, pyroscope.FormatCSV(&buf, &pyroscope.QueryResponse{}))
+	assert.Empty(t, buf.String())
+}
 
 func tp(value float64, timestamp int64) pyroscope.TimePoint {
 	return pyroscope.TimePoint{

--- a/internal/query/pyroscope/formatter_test.go
+++ b/internal/query/pyroscope/formatter_test.go
@@ -34,7 +34,7 @@ func TestFormatCSV(t *testing.T) {
 func TestFormatCSV_NoProfileData(t *testing.T) {
 	var buf bytes.Buffer
 	require.NoError(t, pyroscope.FormatCSV(&buf, &pyroscope.QueryResponse{}))
-	assert.Empty(t, buf.String())
+	assert.Equal(t, "FUNCTION,SELF,TOTAL,PERCENTAGE\n", buf.String())
 }
 
 func tp(value float64, timestamp int64) pyroscope.TimePoint {

--- a/internal/query/sql/formatter.go
+++ b/internal/query/sql/formatter.go
@@ -17,6 +17,25 @@ func FormatTable(w io.Writer, resp *QueryResponse) error {
 		return nil
 	}
 
+	return buildTable(resp).Render(w)
+}
+
+// FormatWideTable formats a QueryResponse as a wide table. SQL datasource
+// results are inherently flat, so this delegates to FormatTable.
+func FormatWideTable(w io.Writer, resp *QueryResponse) error {
+	return FormatTable(w, resp)
+}
+
+// FormatCSV formats a QueryResponse as CSV, same columns as FormatTable.
+func FormatCSV(w io.Writer, resp *QueryResponse) error {
+	if len(resp.Rows) == 0 {
+		return nil
+	}
+
+	return buildTable(resp).RenderCSV(w)
+}
+
+func buildTable(resp *QueryResponse) *style.TableBuilder {
 	timeColumns := make(map[int]bool, len(resp.Columns))
 	headers := make([]string, len(resp.Columns))
 	for i, col := range resp.Columns {
@@ -38,13 +57,7 @@ func FormatTable(w io.Writer, resp *QueryResponse) error {
 		}
 		t.Row(vals...)
 	}
-	return t.Render(w)
-}
-
-// FormatWideTable formats a QueryResponse as a wide table. SQL datasource
-// results are inherently flat, so this delegates to FormatTable.
-func FormatWideTable(w io.Writer, resp *QueryResponse) error {
-	return FormatTable(w, resp)
+	return t
 }
 
 func formatTimestamp(v any) string {

--- a/internal/query/sql/formatter.go
+++ b/internal/query/sql/formatter.go
@@ -17,7 +17,7 @@ func FormatTable(w io.Writer, resp *QueryResponse) error {
 		return nil
 	}
 
-	return buildTable(resp).Render(w)
+	return buildTable(resp, formatValue).Render(w)
 }
 
 // FormatWideTable formats a QueryResponse as a wide table. SQL datasource
@@ -26,16 +26,15 @@ func FormatWideTable(w io.Writer, resp *QueryResponse) error {
 	return FormatTable(w, resp)
 }
 
-// FormatCSV formats a QueryResponse as CSV, same columns as FormatTable.
+// FormatCSV formats a QueryResponse as CSV, same columns as FormatTable. A
+// nil value renders as an empty field rather than table's "-", so a NULL
+// stays distinguishable from the literal string "-" and doesn't force the
+// whole column to VARCHAR in a CSV-consuming query engine.
 func FormatCSV(w io.Writer, resp *QueryResponse) error {
-	if len(resp.Rows) == 0 {
-		return nil
-	}
-
-	return buildTable(resp).RenderCSV(w)
+	return buildTable(resp, formatCSVValue).RenderCSV(w)
 }
 
-func buildTable(resp *QueryResponse) *style.TableBuilder {
+func buildTable(resp *QueryResponse, formatVal func(any) string) *style.TableBuilder {
 	timeColumns := make(map[int]bool, len(resp.Columns))
 	headers := make([]string, len(resp.Columns))
 	for i, col := range resp.Columns {
@@ -52,7 +51,7 @@ func buildTable(resp *QueryResponse) *style.TableBuilder {
 			if timeColumns[i] {
 				vals[i] = formatTimestamp(v)
 			} else {
-				vals[i] = formatValue(v)
+				vals[i] = formatVal(v)
 			}
 		}
 		t.Row(vals...)
@@ -79,7 +78,18 @@ func formatValue(v any) string {
 	if v == nil {
 		return "-"
 	}
-	switch val := v.(type) {
+	return formatNonNilValue(v)
+}
+
+func formatCSVValue(v any) string {
+	if v == nil {
+		return ""
+	}
+	return formatNonNilValue(v)
+}
+
+func formatNonNilValue(val any) string {
+	switch val := val.(type) {
 	case float64:
 		if val == float64(int64(val)) {
 			return strconv.FormatInt(int64(val), 10)

--- a/internal/query/sql/formatter_test.go
+++ b/internal/query/sql/formatter_test.go
@@ -57,3 +57,19 @@ func TestFormatWideTable(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), "ID")
 }
+
+func TestFormatCSV(t *testing.T) {
+	resp := &sql.QueryResponse{
+		Columns: []sql.Column{{Name: "id", Type: "number"}, {Name: "name", Type: "string"}},
+		Rows:    [][]any{{float64(1), "alice"}, {float64(2), "bob"}},
+	}
+	var buf bytes.Buffer
+	require.NoError(t, sql.FormatCSV(&buf, resp))
+	assert.Equal(t, "ID,NAME\n1,alice\n2,bob\n", buf.String())
+}
+
+func TestFormatCSV_NoData(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, sql.FormatCSV(&buf, &sql.QueryResponse{}))
+	assert.Empty(t, buf.String())
+}

--- a/internal/query/sql/formatter_test.go
+++ b/internal/query/sql/formatter_test.go
@@ -73,3 +73,13 @@ func TestFormatCSV_NoData(t *testing.T) {
 	require.NoError(t, sql.FormatCSV(&buf, &sql.QueryResponse{}))
 	assert.Empty(t, buf.String())
 }
+
+func TestFormatCSV_NilRendersEmptyNotDash(t *testing.T) {
+	resp := &sql.QueryResponse{
+		Columns: []sql.Column{{Name: "id", Type: "number"}, {Name: "name", Type: "string"}},
+		Rows:    [][]any{{float64(1), nil}},
+	}
+	var buf bytes.Buffer
+	require.NoError(t, sql.FormatCSV(&buf, resp))
+	assert.Equal(t, "ID,NAME\n1,\n", buf.String())
+}

--- a/internal/query/tempo/formatter.go
+++ b/internal/query/tempo/formatter.go
@@ -24,6 +24,16 @@ const invalidPercentCell = "—"
 
 // FormatSearchTable formats a search response as a table.
 func FormatSearchTable(w io.Writer, resp *SearchResponse) error {
+	return buildSearchTable(resp).Render(w)
+}
+
+// FormatSearchCSV formats a search response as CSV, same columns as
+// FormatSearchTable.
+func FormatSearchCSV(w io.Writer, resp *SearchResponse) error {
+	return buildSearchTable(resp).RenderCSV(w)
+}
+
+func buildSearchTable(resp *SearchResponse) *style.TableBuilder {
 	tbl := style.NewTable("TRACE_ID", "SERVICE", "NAME", "DURATION", "START")
 
 	for _, tr := range resp.Traces {
@@ -36,7 +46,7 @@ func FormatSearchTable(w io.Writer, resp *SearchResponse) error {
 		)
 	}
 
-	return tbl.Render(w)
+	return tbl
 }
 
 // FormatTagsTable formats a tags response as a table.

--- a/internal/query/tempo/formatter.go
+++ b/internal/query/tempo/formatter.go
@@ -127,6 +127,98 @@ func formatInstantMetricsTable(w io.Writer, resp *MetricsResponse) error {
 	return t.Render(w)
 }
 
+// FormatMetricsCSV formats a metrics response as CSV, one column per label —
+// unlike FormatMetricsTable's single formatted LABELS string, so each label
+// is independently queryable in DuckDB. Range queries get a TIMESTAMP
+// column (one row per sample, RFC3339 instead of a raw millisecond-epoch
+// string) — instant queries omit it (one row per series), matching
+// formatRangeMetricsTable/formatInstantMetricsTable.
+func FormatMetricsCSV(w io.Writer, resp *MetricsResponse) error {
+	if resp == nil || len(resp.Series) == 0 {
+		return nil
+	}
+
+	labelNames := collectMetricsLabelNames(resp.Series)
+	header := make([]string, 0, len(labelNames)+2)
+	for _, name := range labelNames {
+		header = append(header, strings.ToUpper(name))
+	}
+	if !resp.Instant {
+		header = append(header, "TIMESTAMP")
+	}
+	header = append(header, "VALUE")
+	t := style.NewTable(header...)
+
+	labelRow := func(series MetricsSeries) []string {
+		row := make([]string, 0, len(header))
+		byKey := metricsLabelValues(series.Labels)
+		for _, name := range labelNames {
+			row = append(row, byKey[name])
+		}
+		return row
+	}
+
+	if resp.Instant {
+		for _, series := range resp.Series {
+			if series.Value == nil {
+				continue
+			}
+			t.Row(append(labelRow(series), strconv.FormatFloat(*series.Value, 'f', -1, 64))...)
+		}
+		return t.RenderCSV(w)
+	}
+
+	for _, series := range resp.Series {
+		row := labelRow(series)
+		if len(series.Samples) > 0 {
+			for _, sample := range series.Samples {
+				full := append(append([]string{}, row...), formatTempoMillisString(sample.TimestampMs), strconv.FormatFloat(sample.Value, 'f', -1, 64))
+				t.Row(full...)
+			}
+			continue
+		}
+		if series.Value != nil {
+			full := append(append([]string{}, row...), formatTempoMillisString(series.TimestampMs), strconv.FormatFloat(*series.Value, 'f', -1, 64))
+			t.Row(full...)
+		}
+	}
+
+	return t.RenderCSV(w)
+}
+
+func collectMetricsLabelNames(series []MetricsSeries) []string {
+	nameSet := make(map[string]struct{})
+	for _, s := range series {
+		for _, l := range s.Labels {
+			nameSet[l.Key] = struct{}{}
+		}
+	}
+	names := make([]string, 0, len(nameSet))
+	for name := range nameSet {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func metricsLabelValues(labels []MetricsLabel) map[string]string {
+	values := make(map[string]string, len(labels))
+	for _, l := range labels {
+		values[l.Key] = extractLabelValue(l.Value)
+	}
+	return values
+}
+
+// formatTempoMillisString parses a Tempo "timestampMs" wire string into
+// RFC3339, falling back to the raw string if it doesn't parse.
+func formatTempoMillisString(raw string) string {
+	ms, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return raw
+	}
+	return time.UnixMilli(ms).UTC().Format(time.RFC3339)
+}
+
 // FormatMetricsLabels formats metrics labels as a {key="val", ...} string.
 func FormatMetricsLabels(labels []MetricsLabel) string {
 	if len(labels) == 0 {

--- a/internal/query/tempo/formatter.go
+++ b/internal/query/tempo/formatter.go
@@ -163,6 +163,98 @@ func formatInstantMetricsTable(w io.Writer, resp *MetricsResponse) error {
 	return t.Render(w)
 }
 
+// FormatMetricsCSV formats a metrics response as CSV, one column per label —
+// unlike FormatMetricsTable's single formatted LABELS string, so each label
+// is independently queryable in DuckDB. Range queries get a TIMESTAMP
+// column (one row per sample, RFC3339 instead of a raw millisecond-epoch
+// string) — instant queries omit it (one row per series), matching
+// formatRangeMetricsTable/formatInstantMetricsTable.
+func FormatMetricsCSV(w io.Writer, resp *MetricsResponse) error {
+	if resp == nil || len(resp.Series) == 0 {
+		return nil
+	}
+
+	labelNames := collectMetricsLabelNames(resp.Series)
+	header := make([]string, 0, len(labelNames)+2)
+	for _, name := range labelNames {
+		header = append(header, strings.ToUpper(name))
+	}
+	if !resp.Instant {
+		header = append(header, "TIMESTAMP")
+	}
+	header = append(header, "VALUE")
+	t := style.NewTable(header...)
+
+	labelRow := func(series MetricsSeries) []string {
+		row := make([]string, 0, len(header))
+		byKey := metricsLabelValues(series.Labels)
+		for _, name := range labelNames {
+			row = append(row, byKey[name])
+		}
+		return row
+	}
+
+	if resp.Instant {
+		for _, series := range resp.Series {
+			if series.Value == nil {
+				continue
+			}
+			t.Row(append(labelRow(series), strconv.FormatFloat(*series.Value, 'f', -1, 64))...)
+		}
+		return t.RenderCSV(w)
+	}
+
+	for _, series := range resp.Series {
+		row := labelRow(series)
+		if len(series.Samples) > 0 {
+			for _, sample := range series.Samples {
+				full := append(append([]string{}, row...), formatTempoMillisString(sample.TimestampMs), strconv.FormatFloat(sample.Value, 'f', -1, 64))
+				t.Row(full...)
+			}
+			continue
+		}
+		if series.Value != nil {
+			full := append(append([]string{}, row...), formatTempoMillisString(series.TimestampMs), strconv.FormatFloat(*series.Value, 'f', -1, 64))
+			t.Row(full...)
+		}
+	}
+
+	return t.RenderCSV(w)
+}
+
+func collectMetricsLabelNames(series []MetricsSeries) []string {
+	nameSet := make(map[string]struct{})
+	for _, s := range series {
+		for _, l := range s.Labels {
+			nameSet[l.Key] = struct{}{}
+		}
+	}
+	names := make([]string, 0, len(nameSet))
+	for name := range nameSet {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+func metricsLabelValues(labels []MetricsLabel) map[string]string {
+	values := make(map[string]string, len(labels))
+	for _, l := range labels {
+		values[l.Key] = extractLabelValue(l.Value)
+	}
+	return values
+}
+
+// formatTempoMillisString parses a Tempo "timestampMs" wire string into
+// RFC3339, falling back to the raw string if it doesn't parse.
+func formatTempoMillisString(raw string) string {
+	ms, err := strconv.ParseInt(raw, 10, 64)
+	if err != nil {
+		return raw
+	}
+	return time.UnixMilli(ms).UTC().Format(time.RFC3339)
+}
+
 // FormatMetricsLabels formats metrics labels as a {key="val", ...} string.
 func FormatMetricsLabels(labels []MetricsLabel) string {
 	if len(labels) == 0 {

--- a/internal/query/tempo/formatter.go
+++ b/internal/query/tempo/formatter.go
@@ -25,6 +25,16 @@ const invalidPercentCell = "—"
 
 // FormatSearchTable formats a search response as a table.
 func FormatSearchTable(w io.Writer, resp *SearchResponse) error {
+	return buildSearchTable(resp).Render(w)
+}
+
+// FormatSearchCSV formats a search response as CSV, same columns as
+// FormatSearchTable.
+func FormatSearchCSV(w io.Writer, resp *SearchResponse) error {
+	return buildSearchTable(resp).RenderCSV(w)
+}
+
+func buildSearchTable(resp *SearchResponse) *style.TableBuilder {
 	tbl := style.NewTable("TRACE_ID", "SERVICE", "NAME", "DURATION", "START")
 
 	for _, tr := range resp.Traces {
@@ -37,7 +47,7 @@ func FormatSearchTable(w io.Writer, resp *SearchResponse) error {
 		)
 	}
 
-	return tbl.Render(w)
+	return tbl
 }
 
 // FormatBaselineTable formats baseline candidates as a table, with a header

--- a/internal/query/tempo/formatter.go
+++ b/internal/query/tempo/formatter.go
@@ -168,9 +168,10 @@ func formatInstantMetricsTable(w io.Writer, resp *MetricsResponse) error {
 // is independently queryable in DuckDB. Range queries get a TIMESTAMP
 // column (one row per sample, RFC3339 instead of a raw millisecond-epoch
 // string) — instant queries omit it (one row per series), matching
-// formatRangeMetricsTable/formatInstantMetricsTable.
+// formatRangeMetricsTable/formatInstantMetricsTable. An empty (but non-nil)
+// response still emits the header row rather than zero bytes.
 func FormatMetricsCSV(w io.Writer, resp *MetricsResponse) error {
-	if resp == nil || len(resp.Series) == 0 {
+	if resp == nil {
 		return nil
 	}
 

--- a/internal/query/tempo/formatter_test.go
+++ b/internal/query/tempo/formatter_test.go
@@ -243,6 +243,61 @@ func TestFormatMetricsTable_EmptySeries(t *testing.T) {
 	assert.Len(t, lines, 1) // Only header
 }
 
+func TestFormatMetricsCSV_Range(t *testing.T) {
+	resp := &tempo.MetricsResponse{
+		Instant: false,
+		Series: []tempo.MetricsSeries{
+			{
+				Labels: []tempo.MetricsLabel{
+					{Key: "service", Value: map[string]any{"stringValue": "web"}},
+				},
+				Samples: []tempo.MetricsSample{
+					{TimestampMs: "1700000000000", Value: 42.5},
+					{TimestampMs: "1700000060000", Value: 43.0},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, tempo.FormatMetricsCSV(&buf, resp))
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	require.Len(t, lines, 3)
+	assert.Equal(t, "SERVICE,TIMESTAMP,VALUE", lines[0])
+	assert.Equal(t, "web,2023-11-14T22:13:20Z,42.5", lines[1])
+	assert.Equal(t, "web,2023-11-14T22:14:20Z,43", lines[2])
+}
+
+func TestFormatMetricsCSV_Instant(t *testing.T) {
+	val := float64(99)
+	resp := &tempo.MetricsResponse{
+		Instant: true,
+		Series: []tempo.MetricsSeries{
+			{
+				Labels: []tempo.MetricsLabel{
+					{Key: "service", Value: map[string]any{"stringValue": "api"}},
+				},
+				Value: &val,
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, tempo.FormatMetricsCSV(&buf, resp))
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	require.Len(t, lines, 2)
+	assert.Equal(t, "SERVICE,VALUE", lines[0])
+	assert.Equal(t, "api,99", lines[1])
+}
+
+func TestFormatMetricsCSV_NoData(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, tempo.FormatMetricsCSV(&buf, &tempo.MetricsResponse{}))
+	assert.Empty(t, buf.String())
+}
+
 // ==============================================================
 // Trace tree formatter tests (FormatTraceTable, FormatTraceWide,
 // formatDurationNanos). Cover the acceptance criteria from

--- a/internal/query/tempo/formatter_test.go
+++ b/internal/query/tempo/formatter_test.go
@@ -70,6 +70,28 @@ func TestFormatSearchTable_Empty(t *testing.T) {
 	assert.Len(t, lines, 1)
 }
 
+func TestFormatSearchCSV(t *testing.T) {
+	resp := &tempo.SearchResponse{
+		Traces: []tempo.SearchTrace{
+			{
+				TraceID:           "abc123",
+				RootServiceName:   "frontend",
+				RootTraceName:     "GET /api/users",
+				StartTimeUnixNano: "1700000000000000000",
+				DurationMs:        42,
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, tempo.FormatSearchCSV(&buf, resp))
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	require.Len(t, lines, 2)
+	assert.Equal(t, "TRACE_ID,SERVICE,NAME,DURATION,START", lines[0])
+	assert.Contains(t, lines[1], "abc123,frontend,GET /api/users,42ms,")
+}
+
 func TestFormatTagsTable(t *testing.T) {
 	resp := &tempo.TagsResponse{
 		Scopes: []tempo.TagScope{

--- a/internal/query/tempo/formatter_test.go
+++ b/internal/query/tempo/formatter_test.go
@@ -94,6 +94,28 @@ func TestFormatBaselineTable_DistinguishesKnownAndUnknownCounts(t *testing.T) {
 	assert.Regexp(t, `(?m)^unknown\s+svc\s+op\s+-\s+-\s+-\s+`, out)
 }
 
+func TestFormatSearchCSV(t *testing.T) {
+	resp := &tempo.SearchResponse{
+		Traces: []tempo.SearchTrace{
+			{
+				TraceID:           "abc123",
+				RootServiceName:   "frontend",
+				RootTraceName:     "GET /api/users",
+				StartTimeUnixNano: "1700000000000000000",
+				DurationMs:        42,
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, tempo.FormatSearchCSV(&buf, resp))
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	require.Len(t, lines, 2)
+	assert.Equal(t, "TRACE_ID,SERVICE,NAME,DURATION,START", lines[0])
+	assert.Contains(t, lines[1], "abc123,frontend,GET /api/users,42ms,")
+}
+
 func TestFormatTagsTable(t *testing.T) {
 	resp := &tempo.TagsResponse{
 		Scopes: []tempo.TagScope{

--- a/internal/query/tempo/formatter_test.go
+++ b/internal/query/tempo/formatter_test.go
@@ -267,6 +267,61 @@ func TestFormatMetricsTable_EmptySeries(t *testing.T) {
 	assert.Len(t, lines, 1) // Only header
 }
 
+func TestFormatMetricsCSV_Range(t *testing.T) {
+	resp := &tempo.MetricsResponse{
+		Instant: false,
+		Series: []tempo.MetricsSeries{
+			{
+				Labels: []tempo.MetricsLabel{
+					{Key: "service", Value: map[string]any{"stringValue": "web"}},
+				},
+				Samples: []tempo.MetricsSample{
+					{TimestampMs: "1700000000000", Value: 42.5},
+					{TimestampMs: "1700000060000", Value: 43.0},
+				},
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, tempo.FormatMetricsCSV(&buf, resp))
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	require.Len(t, lines, 3)
+	assert.Equal(t, "SERVICE,TIMESTAMP,VALUE", lines[0])
+	assert.Equal(t, "web,2023-11-14T22:13:20Z,42.5", lines[1])
+	assert.Equal(t, "web,2023-11-14T22:14:20Z,43", lines[2])
+}
+
+func TestFormatMetricsCSV_Instant(t *testing.T) {
+	val := float64(99)
+	resp := &tempo.MetricsResponse{
+		Instant: true,
+		Series: []tempo.MetricsSeries{
+			{
+				Labels: []tempo.MetricsLabel{
+					{Key: "service", Value: map[string]any{"stringValue": "api"}},
+				},
+				Value: &val,
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, tempo.FormatMetricsCSV(&buf, resp))
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	require.Len(t, lines, 2)
+	assert.Equal(t, "SERVICE,VALUE", lines[0])
+	assert.Equal(t, "api,99", lines[1])
+}
+
+func TestFormatMetricsCSV_NoData(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, tempo.FormatMetricsCSV(&buf, &tempo.MetricsResponse{}))
+	assert.Empty(t, buf.String())
+}
+
 // ==============================================================
 // Trace tree formatter tests (FormatTraceTable, FormatTraceWide,
 // formatDurationNanos). Cover the acceptance criteria from

--- a/internal/query/tempo/formatter_test.go
+++ b/internal/query/tempo/formatter_test.go
@@ -319,6 +319,12 @@ func TestFormatMetricsCSV_Instant(t *testing.T) {
 func TestFormatMetricsCSV_NoData(t *testing.T) {
 	var buf bytes.Buffer
 	require.NoError(t, tempo.FormatMetricsCSV(&buf, &tempo.MetricsResponse{}))
+	assert.Equal(t, "TIMESTAMP,VALUE\n", buf.String())
+}
+
+func TestFormatMetricsCSV_NilResponse(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, tempo.FormatMetricsCSV(&buf, nil))
 	assert.Empty(t, buf.String())
 }
 

--- a/internal/style/table.go
+++ b/internal/style/table.go
@@ -1,6 +1,7 @@
 package style
 
 import (
+	"encoding/csv"
 	"fmt"
 	"io"
 	"strings"
@@ -61,6 +62,27 @@ func (tb *TableBuilder) Render(w io.Writer) error {
 		return tb.renderPlain(w)
 	}
 	return tb.renderStyled(w)
+}
+
+// RenderCSV writes the table as CSV (RFC 4180 via encoding/csv), headers
+// first. Unlike Render, this ignores styling and MultilineCells entirely —
+// encoding/csv already quotes any cell value containing commas, quotes, or
+// newlines, so embedded newlines survive as valid multi-line CSV fields
+// rather than being flattened.
+func (tb *TableBuilder) RenderCSV(w io.Writer) error {
+	cw := csv.NewWriter(w)
+	if len(tb.headers) > 0 {
+		if err := cw.Write(tb.headers); err != nil {
+			return err
+		}
+	}
+	for _, row := range tb.rows {
+		if err := cw.Write(row); err != nil {
+			return err
+		}
+	}
+	cw.Flush()
+	return cw.Error()
 }
 
 func (tb *TableBuilder) renderPlain(w io.Writer) error {

--- a/internal/style/table.go
+++ b/internal/style/table.go
@@ -69,6 +69,13 @@ func (tb *TableBuilder) Render(w io.Writer) error {
 // encoding/csv already quotes any cell value containing commas, quotes, or
 // newlines, so embedded newlines survive as valid multi-line CSV fields
 // rather than being flattened.
+//
+// A row shorter than the header count is padded with empty fields rather
+// than written as-is: unlike Render (tabwriter pads, lipgloss fills) and
+// csv.Writer.Write (which doesn't validate field count), a short row here
+// would make the whole file unparseable — csv.Reader returns ErrFieldCount
+// and DuckDB's read_csv rejects the column-count mismatch — rather than
+// just that one row looking odd.
 func (tb *TableBuilder) RenderCSV(w io.Writer) error {
 	cw := csv.NewWriter(w)
 	if len(tb.headers) > 0 {
@@ -77,12 +84,23 @@ func (tb *TableBuilder) RenderCSV(w io.Writer) error {
 		}
 	}
 	for _, row := range tb.rows {
-		if err := cw.Write(row); err != nil {
+		if err := cw.Write(padRow(row, len(tb.headers))); err != nil {
 			return err
 		}
 	}
 	cw.Flush()
 	return cw.Error()
+}
+
+// padRow returns row padded with empty strings to length n. Rows at or
+// above n are returned unchanged.
+func padRow(row []string, n int) []string {
+	if len(row) >= n {
+		return row
+	}
+	padded := make([]string, n)
+	copy(padded, row)
+	return padded
 }
 
 func (tb *TableBuilder) renderPlain(w io.Writer) error {

--- a/internal/style/table_test.go
+++ b/internal/style/table_test.go
@@ -39,3 +39,32 @@ func TestTableBuilder_AgentModeRendersPlain(t *testing.T) {
 		t.Errorf("agent-mode table output missing data:\n%s", out)
 	}
 }
+
+func TestTableBuilder_RenderCSV(t *testing.T) {
+	tb := style.NewTable("NAME", "NOTE")
+	tb.Row("prod-eu", "ok")
+	tb.Row("has,comma", `has "quote"`+"\nand newline")
+
+	var buf bytes.Buffer
+	if err := tb.RenderCSV(&buf); err != nil {
+		t.Fatalf("RenderCSV() error: %v", err)
+	}
+
+	want := "NAME,NOTE\nprod-eu,ok\n\"has,comma\",\"has \"\"quote\"\"\nand newline\"\n"
+	if buf.String() != want {
+		t.Errorf("RenderCSV() = %q, want %q", buf.String(), want)
+	}
+}
+
+func TestTableBuilder_RenderCSV_NoRows(t *testing.T) {
+	tb := style.NewTable("NAME", "NOTE")
+
+	var buf bytes.Buffer
+	if err := tb.RenderCSV(&buf); err != nil {
+		t.Fatalf("RenderCSV() error: %v", err)
+	}
+
+	if want := "NAME,NOTE\n"; buf.String() != want {
+		t.Errorf("RenderCSV() = %q, want %q", buf.String(), want)
+	}
+}

--- a/internal/style/table_test.go
+++ b/internal/style/table_test.go
@@ -68,3 +68,23 @@ func TestTableBuilder_RenderCSV_NoRows(t *testing.T) {
 		t.Errorf("RenderCSV() = %q, want %q", buf.String(), want)
 	}
 }
+
+// TestTableBuilder_RenderCSV_PadsShortRow covers: a row with fewer fields
+// than the header count is padded with empty strings rather than written
+// as-is, so every line has the same field count and stays parseable by a
+// strict csv.Reader / DuckDB read_csv.
+func TestTableBuilder_RenderCSV_PadsShortRow(t *testing.T) {
+	tb := style.NewTable("NAME", "TIMESTAMP", "VALUE")
+	tb.Row("full-row", "2023-11-14T22:13:20Z", "1")
+	tb.Row("short-row") // missing TIMESTAMP and VALUE
+
+	var buf bytes.Buffer
+	if err := tb.RenderCSV(&buf); err != nil {
+		t.Fatalf("RenderCSV() error: %v", err)
+	}
+
+	want := "NAME,TIMESTAMP,VALUE\nfull-row,2023-11-14T22:13:20Z,1\nshort-row,,\n"
+	if buf.String() != want {
+		t.Errorf("RenderCSV() = %q, want %q", buf.String(), want)
+	}
+}


### PR DESCRIPTION
Part of https://github.com/grafana/gcx/issues/121

In some analysis cases it's better to use SQL with e.g. DuckDB. SQL has less harmful side effects than generated Python scripts and is easier to screen before giving the agent permission to execute the script.

That is why I'm proposing CSV as an additional output format as DuckDB can consume it from a file or stdin. I've also edited the skill to highlight that DuckDB is often more efficient.