### PR TITLE
ci(review): pin the review model to Claude Opus 5

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -97,7 +97,11 @@ jobs:
             Base the report on both sets combined: drop duplicates, and where
             the two disagree, resolve it against the code and report one
             conclusion rather than both. Then post what survives.
-          claude_args: '--allowedTools "Read,Grep,Glob,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr review:*),mcp__github_inline_comment__create_inline_comment"'
+          # Pin the model instead of inheriting the action's default. That
+          # default moves as new models ship, so review behaviour changes with
+          # no commit to point at. Pinning keeps runs reproducible and makes
+          # each upgrade an explicit change someone reviewed.
+          claude_args: '--model claude-opus-5 --allowedTools "Read,Grep,Glob,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr review:*),mcp__github_inline_comment__create_inline_comment"'
 
       - name: Add claude-reviewed label
         if: success()


### PR DESCRIPTION
## What

Pins the review workflow to `claude-opus-5` in `claude_args`, instead of letting the action pick the model.

## Why

We weren't choosing the model — the action was, and its default moves as new models ship. Today's runs resolve to `claude-opus-4-7[1m]`. So review behaviour can change underneath us with no commit to point at, and any shift in what the reviewer reports becomes impossible to attribute. Pinning makes each upgrade an explicit change someone reviewed.

Opus 5 is the current Opus and prices the same per token as the default it replaces, so this isn't a cost change.

## What this does not do

It won't make the reviewer find more, and it might find less.

The plugin this workflow calls tells its finder agents "We only want HIGH SIGNAL issues" and "if you are not certain an issue is real, do not flag it". A more instruction-following model applies that more faithfully, not less — the documented behaviour is that conservative review prompts raise precision and depress measured recall.

The evidence that this is the prompt and not the model: since #1167 merged, four CI reviews have produced one `nit` between them. On #1108, the same commit reviewed locally an hour after the CI run produced ten inline comments. That gap wants its own change, and this isn't it.

## Notes

Two operational things if this misbehaves.

Opus 5 sits in its own rate-limit bucket — it doesn't draw from the combined Opus 4.x pool, so existing headroom doesn't carry over. At roughly 150 PRs opened a month that's worth an eye.

It also carries elevated cybersecurity safeguards and can decline a request outright rather than answering. gcx touches auth, tokens and keychain code, so a refusal would surface as a failed review run rather than a quiet one.

`claude.yml` is still unpinned. Left alone on purpose since it's the interactive `@claude` bot rather than the reviewer, but happy to pin it in the same PR if we'd rather they match.

## How to review this

One line of YAML plus a comment. The thing worth a second look is whether pinning is the right call at all versus tracking the action's default — I've argued for pinning on attribution grounds, but that's a preference, not a fact.

Note this PR can't be reviewed by the workflow it changes. The Claude App refuses the token exchange when the workflow file differs from the default branch (`Workflow validation failed. The workflow file must exist and have identical content to the version on the repository's default branch`), which is why #1167's own review run failed. This lands unexercised and the first real test is the next PR after merge.

## Testing

`GCX_AGENT_MODE=false mise run all` passes. Nothing else applies — one workflow file, no Go, no skills, no generated docs.

The review run on this PR fails with `401 Workflow validation failed`, which is the expected behaviour described above and not a defect in the change. Worth noting it dies at the App token exchange, before Claude Code starts, so it never evaluates `--model` and tells us nothing about the flag either way.

I could not verify the model string resolves before merge. `claude --model claude-opus-5 -p …` isn't usable here (subprocess doesn't inherit session auth), a bogus model ID fails identically so there's no client-side validation to differentiate against, and there's no API key or `ant` CLI to query the Models API with. `claude-opus-5` is the correct current model ID; what stays unverified is the CLI version the action installs at run time, which no local test can reach anyway.

So the first PR opened after this merges is the canary. If its review run fails at the CLI rather than at the token exchange, the model string is the cause and rolling back is reverting one line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

