### PR TITLE
fix(install): report when another gcx wins the PATH lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,16 @@ curl -fsSL https://raw.githubusercontent.com/grafana/gcx/main/scripts/install.sh
 ```
 
 Downloads the latest release, verifies the SHA-256 checksum, and installs to
-`~/.local/bin`. Override the location with `INSTALL_DIR`:
+`~/.local/bin`. Override the location with `GCX_INSTALL_DIR`:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/grafana/gcx/main/scripts/install.sh | INSTALL_DIR=/usr/local/bin sh
+curl -fsSL https://raw.githubusercontent.com/grafana/gcx/main/scripts/install.sh | GCX_INSTALL_DIR=/usr/local/bin sh
 ```
+
+To upgrade, run the same command again, then check `gcx --version`. If the
+version does not change, you have a second `gcx` earlier in your `PATH` — run
+`which -a gcx` and see
+[The version does not change after an upgrade](docs/sources/installation.md#the-version-does-not-change-after-an-upgrade).
 
 **Homebrew (macOS and Linux):**
 

--- a/README.md
+++ b/README.md
@@ -68,18 +68,28 @@ version does not change, you have a second `gcx` earlier in your `PATH` — run
 **Homebrew (macOS and Linux):**
 
 ```bash
-brew install grafana/grafana/gcx
+brew install gcx
 ```
 
-Compiles from source on your machine (requires Homebrew's `go`, installed
-automatically as a build dependency). First install takes ~30–60 seconds
-while Go fetches dependencies; subsequent upgrades are faster.
+Installs the `gcx` formula from homebrew-core. Homebrew has a prebuilt bottle
+for macOS and Linux, so the install takes seconds and needs no tap.
 
 To update to the latest version:
 
 ```bash
 brew update && brew upgrade gcx
 ```
+
+The Grafana tap also carries `gcx`. Use it if you want Homebrew to compile the
+binary on your machine:
+
+```bash
+brew install grafana/grafana/gcx
+```
+
+That build needs Homebrew's `go`, which Homebrew installs as a build
+dependency. The first install takes 30–60 seconds while Go fetches
+dependencies.
 
 **Pre-built binary (Linux/macOS/Windows):**
 

--- a/docs/sources/installation.md
+++ b/docs/sources/installation.md
@@ -83,17 +83,29 @@ To install `gcx` with Homebrew run:
 brew install gcx
 ```
 
+This command installs the `gcx` formula from homebrew-core. Homebrew has a prebuilt bottle for macOS and Linux, so the install takes seconds. You do not need to add a tap.
+
 To upgrade an existing installation:
 
 ```shell
 brew upgrade gcx
 ```
 
-Homebrew builds `gcx` from source on your machine, as it pulls `go` as a build dependency.
-The first install usually takes 30 to 60 seconds, and later upgrades reuse the Homebrew download cache.
+### Install from the Grafana tap
 
-This option avoids macOS Gatekeeper because it doesn't download a prebuilt binary. You
-won't need to work around notarisation.
+The Grafana tap also carries `gcx`. Use the tap if you want Homebrew to compile the binary on your machine:
+
+```shell
+brew install grafana/grafana/gcx
+```
+
+Homebrew installs `go` as a build dependency for this formula. The first install usually takes 30 to 60 seconds, and later upgrades reuse the Homebrew download cache.
+
+Install `gcx` from one source only. Two Homebrew formulas with the same name conflict with each other.
+
+### Homebrew and macOS Gatekeeper
+
+Both Homebrew methods avoid the macOS Gatekeeper problem. Homebrew does not set the quarantine attribute on the files that it installs, so you do not need to work around notarisation.
 
 ## Install a prebuilt binary
 
@@ -125,10 +137,10 @@ go install github.com/grafana/gcx/cmd/gcx@latest
 
 ## The version does not change after an upgrade
 
-This page lists five install methods. Each one writes `gcx` to a different
-directory. If you use two methods, you get two copies. Your shell runs the copy
-in the directory that comes first in `PATH`, and an upgrade of the other copy
-changes nothing that you can see.
+This page lists several install methods, and they write `gcx` to different
+directories. If you use two methods, you get two copies. Your shell runs the
+copy in the directory that comes first in `PATH`, and an upgrade of the other
+copy changes nothing that you can see.
 
 List every copy:
 
@@ -163,7 +175,7 @@ macOS quarantines any downloaded binary by default. Since `gcx` release binaries
 - **Intel macOS**: A dialog says, *"Apple could not verify 'gcx' is free of malware…"*, and the binary doesn't run.
 - **Apple Silicon (M-series) macOS**: The binary exits immediately with `killed: 9` and no visible dialog.
 
-**Homebrew users are not affected**. Since it compiles `gcx` from source on your machine, no pre-built binary is downloaded and no `xattr` is set.
+**Homebrew users are not affected**. Homebrew does not set the `xattr` on the files that it installs.
 
 ### Bypass the macOS gatekeeper
 

--- a/docs/sources/installation.md
+++ b/docs/sources/installation.md
@@ -27,28 +27,44 @@ The script:
 - Verifies the SHA-256 checksum.
 - Installs the binary to `~/.local/bin`.
 
+### Upgrade
+
+To upgrade, run the same command again. The script always installs the latest release.
+
+Check the result:
+
+```sh
+gcx --version
+```
+
+If the version does not change, refer to [The version does not change after an upgrade](#the-version-does-not-change-after-an-upgrade).
+
 ### Installer configuration options
 
 Use these environment variables to customize the install script:
 
 | Environment variable | Default | Description |
 |----------------------|---------|-------------|
-| `INSTALL_DIR` | `$HOME/.local/bin` | Directory to install the binary into |
-| `VERSION` | latest | Specific version to install (e.g., `0.2.4`) |
+| `GCX_INSTALL_DIR` | `$HOME/.local/bin` | Directory to install the binary into |
+| `GCX_VERSION` | latest | Specific version to install (e.g., `0.2.4`) |
 | `GITHUB_TOKEN` | unset | GitHub token for API requests (avoids rate limits) |
+
+The script also accepts `INSTALL_DIR` and `VERSION`. The `GCX_` names take
+precedence. Prefer the `GCX_` names, because `INSTALL_DIR` and `VERSION` are
+common names, and `curl | sh` inherits every variable that your shell exports.
 
 ### Examples
 
 Install a specific version:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/grafana/gcx/main/scripts/install.sh | VERSION=0.2.4 sh
+curl -fsSL https://raw.githubusercontent.com/grafana/gcx/main/scripts/install.sh | GCX_VERSION=0.2.4 sh
 ```
 
 Install to `/usr/local/bin`:
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/grafana/gcx/main/scripts/install.sh | INSTALL_DIR=/usr/local/bin sh
+curl -fsSL https://raw.githubusercontent.com/grafana/gcx/main/scripts/install.sh | GCX_INSTALL_DIR=/usr/local/bin sh
 ```
 
 ### Uninstall
@@ -106,6 +122,39 @@ To install, run:
 ```shell
 go install github.com/grafana/gcx/cmd/gcx@latest
 ```
+
+## The version does not change after an upgrade
+
+This page lists five install methods. Each one writes `gcx` to a different
+directory. If you use two methods, you get two copies. Your shell runs the copy
+in the directory that comes first in `PATH`, and an upgrade of the other copy
+changes nothing that you can see.
+
+List every copy:
+
+```sh
+which -a gcx
+```
+
+The first line is the copy that your shell runs. Remove the copies that you do
+not want:
+
+| Path | Install method | Command that removes it |
+|------|----------------|-------------------------|
+| `~/.local/bin/gcx` | Install script | `rm ~/.local/bin/gcx` |
+| `/usr/local/bin/gcx` | Prebuilt binary, or the script with `GCX_INSTALL_DIR` | `sudo rm /usr/local/bin/gcx` |
+| `/opt/homebrew/bin/gcx`, `/home/linuxbrew/.../gcx` | Homebrew | `brew uninstall gcx` |
+| `~/go/bin/gcx` | `go install` | `rm ~/go/bin/gcx` |
+
+After you remove a copy, your shell can still hold the old path in its command
+hash table. Open a new terminal, or run:
+
+```sh
+hash -r
+```
+
+The install script reports this problem for you. It names both paths and both
+versions, and it gives the removal command.
 
 ## macOS Gatekeeper and killed 9
 

--- a/mise.toml
+++ b/mise.toml
@@ -32,8 +32,8 @@ description = "Validate skill front matter (claude-plugin/skills + .claude/skill
 run = "go run ./scripts/validate-skills"
 
 [tasks.tests]
-description = "Run all tests (CLI + linter rules)"
-depends = ["tests:cli", "tests:linter"]
+description = "Run all tests (CLI + linter rules + install script)"
+depends = ["tests:cli", "tests:linter", "tests:install"]
 
 # GCX_AGENT_MODE is pinned on the leaf tasks (mise env does not propagate
 # through `depends`). Without it, agent-mode auto-detection picks up CLAUDECODE
@@ -49,6 +49,10 @@ run = "go test ./..."
 description = "Run linter rules tests"
 env = { GCX_AGENT_MODE = "false" }
 run = "go run ./cmd/gcx/ dev lint test ./internal/linter/bundle/gcx/"
+
+[tasks."tests:install"]
+description = "Run the install script tests"
+run = "bash scripts/install_test.sh"
 
 [tasks.build]
 description = "Build binary to bin/gcx"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -200,7 +200,7 @@ get_latest_version() {
     if [ -n "$auth_header" ]; then
         response=$(curl -fsSL -H "$auth_header" "$url") || err "Failed to fetch latest release from GitHub API."
     else
-        response=$(curl -fsSL "$url") || err "Failed to fetch latest release from GitHub API. If rate-limited, set GITHUB_TOKEN or VERSION."
+        response=$(curl -fsSL "$url") || err "Failed to fetch latest release from GitHub API. If rate-limited, set GITHUB_TOKEN or GCX_VERSION."
     fi
 
     tag=$(printf '%s' "$response" | grep '"tag_name"' | sed 's/.*"tag_name": *"//;s/".*//')

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,9 +5,12 @@
 #   curl -fsSL https://raw.githubusercontent.com/grafana/gcx/main/scripts/install.sh | sh
 #
 # Environment variables:
-#   INSTALL_DIR    Directory to install into (default: $HOME/.local/bin)
-#   VERSION        Specific version to install, without v prefix (default: latest)
-#   GITHUB_TOKEN   GitHub token for API requests (avoids rate limits)
+#   GCX_INSTALL_DIR  Directory to install into (default: $HOME/.local/bin)
+#   GCX_VERSION      Specific version to install, without v prefix (default: latest)
+#   GITHUB_TOKEN     GitHub token for API requests (avoids rate limits)
+#
+# INSTALL_DIR and VERSION still work. The GCX_ names take precedence, because
+# INSTALL_DIR and VERSION are common names that a caller can already export.
 
 set -eu
 
@@ -93,6 +96,100 @@ print_path_instructions() {
     esac
 }
 
+# Print the path of the first executable named $1 on PATH.
+# Return 1 when PATH holds no such executable.
+#
+# This walks PATH instead of calling `command -v`. The script looks the binary
+# up before the copy and after it, and a shell can serve the second lookup from
+# its command hash table. A stale hash is the exact failure this check reports,
+# so the check must not depend on one.
+resolve_on_path() {
+    _name="$1"
+    _saved_ifs="$IFS"
+    set -f # A PATH entry must not expand as a glob.
+    IFS=:
+    for _dir in $PATH; do
+        [ -n "$_dir" ] || _dir="."
+        if [ -f "${_dir}/${_name}" ] && [ -x "${_dir}/${_name}" ]; then
+            IFS="$_saved_ifs"
+            set +f
+            printf '%s\n' "${_dir}/${_name}"
+            return 0
+        fi
+    done
+    IFS="$_saved_ifs"
+    set +f
+    return 1
+}
+
+# Print the first line that "$1 --version" writes.
+# Print "unknown version" when the binary does not answer.
+binary_version() {
+    _out=$("$1" --version 2>/dev/null | head -1) || _out=""
+    if [ -n "$_out" ]; then
+        printf '%s\n' "$_out"
+    else
+        printf '%s\n' "unknown version"
+    fi
+}
+
+# Print the command that removes the binary at $1.
+removal_command() {
+    case "$1" in
+        /opt/homebrew/* | /usr/local/Cellar/* | /home/linuxbrew/*)
+            printf '%s\n' "brew uninstall ${BINARY_NAME}"
+            ;;
+        *)
+            printf '%s\n' "rm ${1}"
+            ;;
+    esac
+}
+
+# Report that the shell runs a different binary than the one just installed.
+warn_shadowed() {
+    _target="$1"
+    _other="$2"
+
+    echo ""
+    warn "Your shell runs a different ${BINARY_NAME}."
+    echo ""
+    info "Installed now:  ${_target} ($(binary_version "$_target"))"
+    info "Shell runs:     ${_other} ($(binary_version "$_other"))"
+    echo ""
+    info "The other copy comes earlier in your PATH. Remove it with:"
+    echo ""
+    info "  $(removal_command "$_other")"
+    echo ""
+    info "Then run 'hash -r', or open a new terminal."
+}
+
+# Report which binary the shell will run after the install.
+# $1 is the install directory. $2 is the binary that PATH resolved to before
+# the install, or an empty string.
+report_resolution() {
+    _install_dir="$1"
+    _previous_path="$2"
+    _target="${_install_dir}/${BINARY_NAME}"
+
+    _resolved=$(resolve_on_path "$BINARY_NAME") || _resolved=""
+
+    case ":${PATH}:" in
+        *":${_install_dir}:"*) _dir_on_path=1 ;;
+        *) _dir_on_path=0 ;;
+    esac
+
+    if [ "$_dir_on_path" -eq 0 ]; then
+        print_path_instructions "$_install_dir"
+    fi
+
+    if [ -n "$_resolved" ] && [ "$_resolved" != "$_target" ]; then
+        warn_shadowed "$_target" "$_resolved"
+    elif [ -n "$_previous_path" ] && [ "$_previous_path" != "$_target" ]; then
+        echo ""
+        info "Run 'hash -r', or open a new terminal, to pick up the new path."
+    fi
+}
+
 get_latest_version() {
     url="https://api.github.com/repos/${GITHUB_REPO}/releases/latest"
     auth_header=""
@@ -140,14 +237,22 @@ main() {
     os=$(detect_os)
     arch=$(detect_arch)
 
-    if [ -n "${VERSION:-}" ]; then
-        version="${VERSION#v}"
+    # Record the binary that PATH resolves to now, before the copy replaces it.
+    previous_path=$(resolve_on_path "$BINARY_NAME") || previous_path=""
+    previous_version=""
+    if [ -n "$previous_path" ]; then
+        previous_version=$(binary_version "$previous_path")
+    fi
+
+    requested_version="${GCX_VERSION:-${VERSION:-}}"
+    if [ -n "$requested_version" ]; then
+        version="${requested_version#v}"
     else
         info "Fetching latest release..."
         version=$(get_latest_version)
     fi
 
-    install_dir="${INSTALL_DIR:-$DEFAULT_INSTALL_DIR}"
+    install_dir="${GCX_INSTALL_DIR:-${INSTALL_DIR:-$DEFAULT_INSTALL_DIR}}"
     archive="${BINARY_NAME}_${version}_${os}_${arch}.tar.gz"
     base_url="https://github.com/${GITHUB_REPO}/releases/download/v${version}"
 
@@ -189,22 +294,25 @@ main() {
 
     # Verify installation.
     if "${install_dir}/${BINARY_NAME}" --version >/dev/null 2>&1; then
-        installed_version=$("${install_dir}/${BINARY_NAME}" --version 2>&1 | head -1)
-        info "Installed: ${installed_version}"
+        installed_version=$(binary_version "${install_dir}/${BINARY_NAME}")
+        if [ -n "$previous_version" ] && [ "$previous_version" != "$installed_version" ]; then
+            info "Installed: ${installed_version} (replaces: ${previous_version})"
+        else
+            info "Installed: ${installed_version}"
+        fi
     else
         info "Installed ${BINARY_NAME} to ${install_dir}/${BINARY_NAME}"
     fi
 
-    # Check if install dir is in PATH.
-    case ":${PATH}:" in
-        *":${install_dir}:"*) ;;
-        *)
-            print_path_instructions "$install_dir"
-            ;;
-    esac
+    # Report which binary the shell runs. The copy above can land behind an
+    # older binary that PATH resolves first, and the user then sees no change.
+    report_resolution "$install_dir" "$previous_path"
 
     echo ""
     info "To uninstall: rm ${install_dir}/${BINARY_NAME}"
 }
 
-main "$@"
+# The test file sources this script to call the functions on their own.
+if [ "${GCX_INSTALL_SH_LIB:-}" != "1" ]; then
+    main "$@"
+fi

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# Tests for scripts/install.sh
+# Run with: bash scripts/install_test.sh
+
+set -euo pipefail
+
+SCRIPT="$(cd "$(dirname "$0")" && pwd)/install.sh"
+PASS=0
+FAIL=0
+
+# The tests replace PATH. The script still needs the standard utilities, so
+# every fake PATH ends with these directories. Neither one holds a gcx.
+SYS_PATH="/usr/bin:/bin"
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+green() { printf '\033[0;32m✓ %s\033[0m\n' "$*"; }
+red() { printf '\033[0;31m✗ %s\033[0m\n' "$*"; }
+
+pass() {
+	green "$1"
+	PASS=$((PASS + 1))
+}
+fail() {
+	red "$1"
+	FAIL=$((FAIL + 1))
+}
+
+assert_eq() {
+	local want=$1 got=$2 name=$3
+	if [[ "$got" == "$want" ]]; then
+		pass "$name"
+	else
+		fail "$name (want: '$want', got: '$got')"
+	fi
+}
+
+assert_contains() {
+	local haystack=$1 needle=$2 name=$3
+	if [[ "$haystack" == *"$needle"* ]]; then
+		pass "$name"
+	else
+		fail "$name (missing: '$needle')"
+	fi
+}
+
+assert_not_contains() {
+	local haystack=$1 needle=$2 name=$3
+	if [[ "$haystack" != *"$needle"* ]]; then
+		pass "$name"
+	else
+		fail "$name (unwanted: '$needle')"
+	fi
+}
+
+# Write an executable that answers --version with the given version.
+make_fake_gcx() {
+	local dir=$1 version=$2
+	mkdir -p "$dir"
+	printf '#!/bin/sh\necho "gcx version %s"\n' "$version" >"$dir/gcx"
+	chmod +x "$dir/gcx"
+}
+
+# Source the script. GCX_INSTALL_SH_LIB stops it from running main.
+export GCX_INSTALL_SH_LIB=1
+# shellcheck source=install.sh
+. "$SCRIPT"
+
+# ── resolve_on_path ──────────────────────────────────────────────────────────
+
+test_resolve_returns_first_match() {
+	local tmp
+	tmp=$(mktemp -d)
+	make_fake_gcx "$tmp/first" "1.0.0"
+	make_fake_gcx "$tmp/second" "0.4.2"
+
+	local got
+	got=$(
+		PATH="$tmp/first:$tmp/second:$SYS_PATH"
+		resolve_on_path gcx
+	) || got=""
+
+	assert_eq "$tmp/first/gcx" "$got" "resolve_on_path returns the first match"
+	rm -rf "$tmp"
+}
+
+test_resolve_skips_non_executable() {
+	local tmp
+	tmp=$(mktemp -d)
+	mkdir -p "$tmp/first"
+	printf '#!/bin/sh\n' >"$tmp/first/gcx"
+	make_fake_gcx "$tmp/second" "0.4.2"
+
+	local got
+	got=$(
+		PATH="$tmp/first:$tmp/second:$SYS_PATH"
+		resolve_on_path gcx
+	) || got=""
+
+	assert_eq "$tmp/second/gcx" "$got" "resolve_on_path skips a file that is not executable"
+	rm -rf "$tmp"
+}
+
+test_resolve_reports_absence() {
+	local tmp rc=0
+	tmp=$(mktemp -d)
+	mkdir -p "$tmp/empty"
+
+	(
+		PATH="$tmp/empty:$SYS_PATH"
+		resolve_on_path gcx >/dev/null
+	) || rc=$?
+
+	assert_eq "1" "$rc" "resolve_on_path returns 1 when PATH holds no match"
+	rm -rf "$tmp"
+}
+
+# ── removal_command ──────────────────────────────────────────────────────────
+
+test_removal_command_uses_brew() {
+	assert_eq "brew uninstall gcx" "$(removal_command /opt/homebrew/bin/gcx)" \
+		"removal_command names brew for a Homebrew path"
+}
+
+test_removal_command_uses_rm() {
+	assert_eq "rm /usr/local/bin/gcx" "$(removal_command /usr/local/bin/gcx)" \
+		"removal_command names rm for a plain path"
+}
+
+# ── report_resolution ────────────────────────────────────────────────────────
+
+test_report_warns_on_shadow() {
+	local tmp out
+	tmp=$(mktemp -d)
+	make_fake_gcx "$tmp/old" "0.4.2"
+	make_fake_gcx "$tmp/new" "1.0.0"
+
+	out=$(
+		PATH="$tmp/old:$tmp/new:$SYS_PATH"
+		report_resolution "$tmp/new" "$tmp/old/gcx" 2>&1
+	)
+
+	assert_contains "$out" "Your shell runs a different gcx" \
+		"report_resolution warns when another copy comes first"
+	assert_contains "$out" "$tmp/new/gcx (gcx version 1.0.0)" \
+		"the warning names the installed path and version"
+	assert_contains "$out" "$tmp/old/gcx (gcx version 0.4.2)" \
+		"the warning names the shadowing path and version"
+	assert_contains "$out" "rm $tmp/old/gcx" \
+		"the warning gives the removal command"
+	rm -rf "$tmp"
+}
+
+test_report_is_quiet_when_install_dir_wins() {
+	local tmp out
+	tmp=$(mktemp -d)
+	make_fake_gcx "$tmp/old" "0.4.2"
+	make_fake_gcx "$tmp/new" "1.0.0"
+
+	out=$(
+		PATH="$tmp/new:$tmp/old:$SYS_PATH"
+		report_resolution "$tmp/new" "$tmp/old/gcx" 2>&1
+	)
+
+	assert_not_contains "$out" "Your shell runs a different gcx" \
+		"report_resolution stays quiet when the install directory comes first"
+	assert_contains "$out" "hash -r" \
+		"report_resolution asks for a rehash when the resolved path changed"
+	rm -rf "$tmp"
+}
+
+test_report_is_quiet_on_a_plain_reinstall() {
+	local tmp out
+	tmp=$(mktemp -d)
+	make_fake_gcx "$tmp/new" "1.0.0"
+
+	out=$(
+		PATH="$tmp/new:$SYS_PATH"
+		report_resolution "$tmp/new" "$tmp/new/gcx" 2>&1
+	)
+
+	assert_eq "" "$out" "report_resolution prints nothing when the path did not change"
+	rm -rf "$tmp"
+}
+
+test_report_explains_a_missing_path_entry() {
+	local tmp out
+	tmp=$(mktemp -d)
+	mkdir -p "$tmp/other"
+	make_fake_gcx "$tmp/new" "1.0.0"
+
+	out=$(
+		PATH="$tmp/other:$SYS_PATH"
+		report_resolution "$tmp/new" "" 2>&1
+	)
+
+	assert_contains "$out" "is not in your PATH" \
+		"report_resolution explains a missing PATH entry"
+	assert_not_contains "$out" "Your shell runs a different gcx" \
+		"report_resolution reports no shadow when no other copy exists"
+	rm -rf "$tmp"
+}
+
+test_report_covers_both_problems() {
+	local tmp out
+	tmp=$(mktemp -d)
+	make_fake_gcx "$tmp/old" "0.4.2"
+	make_fake_gcx "$tmp/new" "1.0.0"
+
+	out=$(
+		PATH="$tmp/old:$SYS_PATH"
+		report_resolution "$tmp/new" "$tmp/old/gcx" 2>&1
+	)
+
+	assert_contains "$out" "is not in your PATH" \
+		"report_resolution reports the missing PATH entry and the shadow together"
+	assert_contains "$out" "Your shell runs a different gcx" \
+		"report_resolution warns about the shadow when the directory is off PATH"
+	rm -rf "$tmp"
+}
+
+# ── run ──────────────────────────────────────────────────────────────────────
+
+test_resolve_returns_first_match
+test_resolve_skips_non_executable
+test_resolve_reports_absence
+test_removal_command_uses_brew
+test_removal_command_uses_rm
+test_report_warns_on_shadow
+test_report_is_quiet_when_install_dir_wins
+test_report_is_quiet_on_a_plain_reinstall
+test_report_explains_a_missing_path_entry
+test_report_covers_both_problems
+
+echo
+echo "Results: $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -142,9 +142,11 @@ test_report_warns_on_shadow() {
 
 	assert_contains "$out" "Your shell runs a different gcx" \
 		"report_resolution warns when another copy comes first"
-	assert_contains "$out" "$tmp/new/gcx (gcx version 1.0.0)" \
+	# Anchor the label prefix. Without it, a swap of the two paths inside
+	# warn_shadowed keeps every substring present, and the test stays green.
+	assert_contains "$out" "Installed now:  $tmp/new/gcx (gcx version 1.0.0)" \
 		"the warning names the installed path and version"
-	assert_contains "$out" "$tmp/old/gcx (gcx version 0.4.2)" \
+	assert_contains "$out" "Shell runs:     $tmp/old/gcx (gcx version 0.4.2)" \
 		"the warning names the shadowing path and version"
 	assert_contains "$out" "rm $tmp/old/gcx" \
 		"the warning gives the removal command"


### PR DESCRIPTION
## The report

A user installed `gcx` with the `curl | sh` method. They re-ran the same
command to get v1.0.0. The version did not change. They installed with
Homebrew, and the version became current.

## The cause

The release side is correct. I checked it:

- `releases/latest` returns `v1.0.0`. The release is not a draft. It is not a
  pre-release.
- The v1.0.0 assets match the names that the script builds.
- The default install directory never changed.
- The script exits with an error on a failed download, a checksum mismatch, or
  a GitHub API error. A silent no-op is not possible.

The script wrote v1.0.0 to `~/.local/bin/gcx`. A second, older `gcx` won the
`PATH` lookup. Two lines hid this:

- The script ran `--version` on the explicit install path, so it always printed
  success.
- The script checked only that the install directory appeared somewhere in
  `PATH`. It did not check that the directory came first.

The `README.md` lists five install methods. Each one writes to a different
directory. A second copy is easy to create.

## The change

`scripts/install.sh` now records the binary that `PATH` resolves to before the
copy, then resolves it again afterwards:

- The paths differ: the script names both paths and both versions, and it gives
  the removal command. It names `brew uninstall gcx` for a Homebrew path.
- The paths match, but the resolved path changed: the script asks for
  `hash -r`, or a new terminal.
- The install directory is absent from `PATH`: the script keeps the existing
  instructions.

The exit code stays 0 in every case. A non-zero exit would break any pipeline
that installs `gcx` and checks the exit code.

`resolve_on_path` walks `PATH` itself. It does not call `command -v`, because a
shell can serve the second lookup from its command hash table, and a stale hash
is one of the failures this check reports.

The script also accepts `GCX_VERSION` and `GCX_INSTALL_DIR`. `VERSION` and
`INSTALL_DIR` are common names, and `curl | sh` inherits every variable that the
caller exports. A stray `VERSION` pins the installer to the wrong release. The
old names still work, and they still take effect.

## Output before and after

Before, on a machine with an older copy earlier in `PATH`:

```
  Installed: gcx version 1.0.0 built from 45e64ca on 2026-07-28T12:01:50Z
```

After:

```
  Installed: gcx version 1.0.0 ... (replaces: gcx version 0.4.2)

  WARNING: Your shell runs a different gcx.

  Installed now:  /home/u/.local/bin/gcx (gcx version 1.0.0 ...)
  Shell runs:     /usr/local/bin/gcx (gcx version 0.4.2)

  The other copy comes earlier in your PATH. Remove it with:

    rm /usr/local/bin/gcx

  Then run 'hash -r', or open a new terminal.
```

## Tests

`scripts/install_test.sh` is new. It follows `scripts/tag_test.sh`. It sources
the script with `GCX_INSTALL_SH_LIB=1`, which stops `main` from running. It
covers 16 cases across `resolve_on_path`, `removal_command`, and
`report_resolution`.

`mise run tests` runs it through the new `tests:install` task. The CI `tests`
job needs no change.

## Documentation

- `docs/sources/installation.md` gets an upgrade section and a section named
  "The version does not change after an upgrade". That section lists every
  install path and the command that removes it.
- `README.md` gets two upgrade lines that point at the new section.

## Verified

- `bash scripts/install_test.sh`: 16 passed, 0 failed.
- `GCX_AGENT_MODE=false mise run all`: passes, no reference-doc drift.
- End to end against the real v1.0.0 release: the shadow case warns, the clean
  case stays quiet, and `GCX_VERSION=0.6.0` and `VERSION=v0.5.0` both pin
  correctly.

## Second commit: the Homebrew mismatch

`README.md` said `brew install grafana/grafana/gcx`. The installation page said
`brew install gcx`. Both commands work, and they install different formulas:

| | `brew install gcx` | `brew install grafana/grafana/gcx` |
|---|---|---|
| Source | homebrew-core | grafana/homebrew-grafana tap |
| Version | 1.0.0 | 1.0.0 |
| Install | Prebuilt bottle, seconds | Compiles from source, 30-60 s |
| Needs a tap | No | Yes |

homebrew-core carries bottles for `arm64_linux`, `arm64_sequoia`,
`arm64_sonoma`, `arm64_tahoe`, `sonoma`, and `x86_64_linux`.

Both files now recommend `brew install gcx` first, then name the tap as the
alternative for people who want the source build.

Two claims no longer held for homebrew-core, and both are corrected:

- Homebrew does not always compile `gcx` on your machine. The source-build text
  now sits under the tap.
- Homebrew avoids the macOS quarantine attribute because it does not set that
  attribute, not because it skips a prebuilt binary.

The release pipeline still publishes to the tap only. Whether it should also
track homebrew-core is a separate maintainer decision, not part of this pull
request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
