### PR TITLE
chore(release): v1.1.0 changelog

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "gcx",
       "source": "./claude-plugin",
       "description": "Debug, explore, and instrument with Grafana using gcx CLI",
-      "version": "1.0.0"
+      "version": "1.1.0"
     }
   ]
 }

--- a/.release-notes.md
+++ b/.release-notes.md
@@ -1,17 +1,32 @@
-### Features
+**New features**
+- Add `gcx profiles data-range` for Pyroscope ingestion health.
+- Add the same `data-range` command under `gcx datasources pyroscope`.
+- Add `gcx instrumentation explain` and `list-explanations`.
+- Add `gcx assistant investigations list-evidence`.
+- Show the chat ID next to the investigation ID in `investigations get`.
+- Keep full v2 investigation summaries and totals in list output.
+- Filter IRM alert groups by escalation chain and by date window.
+- Add agent support to `gcx metrics list-names`.
+- Add agent support to metrics label matching.
 
-- alert: add ruler subtree for datasource-managed rule writes
-- kg: add `entities correlate` to resolve entities from alert labels
-- kg: add entity quality reports (`kg quality`), folded into `kg diagnose`
+**Improvements**
+- Check contexts concurrently in `gcx config check`.
+- Record `target_kind` in usage telemetry events.
 
-### Fixes
+**Fixes**
+- Make `gcx dev serve` exit on Ctrl-C.
+- Set `AllowsEdits` so gcx-managed dashboards stay editable in the UI.
+- Keep `configType` in Fleet so OTel pipelines round-trip.
+- Support UTF-8 label names in profiles.
+- Match experiment report types and trial counts to the API.
+- Send guard redaction config as `redact` with `{id, regex}`.
+- Drop `rule_id` from the rules update PATCH body.
+- Handle an unavailable keychain safely during verification.
 
-- alert: make GMA alert rules modifiable via the resources tier
-- cloud: drop status/createdAt/updatedAt from stack regions output
-- aio11y: point plugin id at renamed grafana-agento11y-app
-
-### Docs
-
-- GA: remove public preview warnings, add GA notes across docs and README
-- skills: harden agento11y-instrument and agento11y-prod-setup guidance
-- stop prescribing Editor/Admin for service-account tokens; installation fixes
+**Internal**
+- Rename the `aio11y` Go package to `agento11y`.
+- Add the `integrate-with-gcx` and `review-pr` contributor skills.
+- Add a command naming conventions guide.
+- Restructure the Grafana Cloud documentation.
+- Pin `GCX_AGENT_MODE=false` for the test tasks.
+- Add data sources code owners for `internal/datasources`.

--- a/.release-notes.md
+++ b/.release-notes.md
@@ -1,7 +1,11 @@
+**Breaking changes**
+- `gcx agento11y collections add-conversations` and `gcx agento11y collections remove-conversation` emit `type: gcx.agento11y.collection_membership` instead of `gcx.aio11y.collection_membership`. `schema_version` stays `1`. No fields changed. Scripts that read `type` must accept the new value.
+
 **New features**
 - Add `gcx profiles data-range` for Pyroscope ingestion health.
 - Add the same `data-range` command under `gcx datasources pyroscope`.
-- Add `gcx instrumentation explain` and `list-explanations`.
+- Add `gcx instrumentation explain` and `list-explanations` for the finding explanations that ship with `otel-checker` (now v0.3.1).
+- Add an `EXPLAIN_ID` column to `gcx instrumentation check` table output, and an `explain_id` field to its JSON output. Pass the value to `gcx instrumentation explain`.
 - Add `gcx assistant investigations list-evidence`.
 - Show the chat ID next to the investigation ID in `investigations get`.
 - Keep full v2 investigation summaries and totals in list output.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 ## v1.1.0 (2026-08-14)
 
+**Breaking changes**
+- `gcx agento11y collections add-conversations` and `gcx agento11y collections remove-conversation` emit `type: gcx.agento11y.collection_membership` instead of `gcx.aio11y.collection_membership`. `schema_version` stays `1`. No fields changed. Scripts that read `type` must accept the new value.
+
 **New features**
 - Add `gcx profiles data-range` for Pyroscope ingestion health.
 - Add the same `data-range` command under `gcx datasources pyroscope`.
-- Add `gcx instrumentation explain` and `list-explanations`.
+- Add `gcx instrumentation explain` and `list-explanations` for the finding explanations that ship with `otel-checker` (now v0.3.1).
+- Add an `EXPLAIN_ID` column to `gcx instrumentation check` table output, and an `explain_id` field to its JSON output. Pass the value to `gcx instrumentation explain`.
 - Add `gcx assistant investigations list-evidence`.
 - Show the chat ID next to the investigation ID in `investigations get`.
 - Keep full v2 investigation summaries and totals in list output.
@@ -35,15 +39,6 @@
 
 
 ## Unreleased
-
-### Breaking changes
-
-- `gcx agento11y collections add-conversations` and `gcx agento11y collections remove-conversation` emit `type: gcx.agento11y.collection_membership` instead of `gcx.aio11y.collection_membership`. `schema_version` stays `1` and no fields changed. Scripts that rely on `type` must accept the new value.
-
-### Features
-
-- Added `gcx instrumentation explain <id>` and `gcx instrumentation list-explanations` for looking up finding explanations bundled with `otel-checker` (bumped to v0.3.1).
-- `gcx instrumentation check` now surfaces an `EXPLAIN_ID` column in table output (and `explain_id` field in JSON), feedable directly into `gcx instrumentation explain`.
 
 ## v1.0.0 (2026-07-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,39 @@
+## v1.1.0 (2026-08-14)
+
+**New features**
+- Add `gcx profiles data-range` for Pyroscope ingestion health.
+- Add the same `data-range` command under `gcx datasources pyroscope`.
+- Add `gcx instrumentation explain` and `list-explanations`.
+- Add `gcx assistant investigations list-evidence`.
+- Show the chat ID next to the investigation ID in `investigations get`.
+- Keep full v2 investigation summaries and totals in list output.
+- Filter IRM alert groups by escalation chain and by date window.
+- Add agent support to `gcx metrics list-names`.
+- Add agent support to metrics label matching.
+
+**Improvements**
+- Check contexts concurrently in `gcx config check`.
+- Record `target_kind` in usage telemetry events.
+
+**Fixes**
+- Make `gcx dev serve` exit on Ctrl-C.
+- Set `AllowsEdits` so gcx-managed dashboards stay editable in the UI.
+- Keep `configType` in Fleet so OTel pipelines round-trip.
+- Support UTF-8 label names in profiles.
+- Match experiment report types and trial counts to the API.
+- Send guard redaction config as `redact` with `{id, regex}`.
+- Drop `rule_id` from the rules update PATCH body.
+- Handle an unavailable keychain safely during verification.
+
+**Internal**
+- Rename the `aio11y` Go package to `agento11y`.
+- Add the `integrate-with-gcx` and `review-pr` contributor skills.
+- Add a command naming conventions guide.
+- Restructure the Grafana Cloud documentation.
+- Pin `GCX_AGENT_MODE=false` for the test tasks.
+- Add data sources code owners for `internal/datasources`.
+
+
 ## Unreleased
 
 ### Breaking changes

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gcx",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Debug, explore, and instrument with Grafana using gcx CLI",
   "keywords": ["grafana", "observability", "monitoring", "prometheus", "loki", "dashboards"],
   "author": {


### PR DESCRIPTION
Release v1.1.0

Adds the v1.1.0 changelog entry and release notes. Bumps the plugin version to 1.1.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)