### PR TITLE
fix(irm): honour incident severity, and add an incidents update command

### DIFF
--- a/cmd/gcx/root/testdata/output_classes.json
+++ b/cmd/gcx/root/testdata/output_classes.json
@@ -293,6 +293,7 @@
  "gcx irm incidents list-contexts": "finite",
  "gcx irm incidents open": "interactive",
  "gcx irm incidents severities list": "finite",
+ "gcx irm incidents update": "finite",
  "gcx irm oncall alert-groups acknowledge": "finite",
  "gcx irm oncall alert-groups delete": "finite",
  "gcx irm oncall alert-groups get": "finite",

--- a/cmd/gcx/root/testdata/output_classes.json
+++ b/cmd/gcx/root/testdata/output_classes.json
@@ -270,6 +270,7 @@
  "gcx irm incidents list-contexts": "finite",
  "gcx irm incidents open": "interactive",
  "gcx irm incidents severities list": "finite",
+ "gcx irm incidents update": "finite",
  "gcx irm oncall alert-groups acknowledge": "finite",
  "gcx irm oncall alert-groups delete": "finite",
  "gcx irm oncall alert-groups get": "finite",

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -802,7 +802,8 @@ Provider command tree backed by fleet-management `Set/Get` + observed-state RPCs
 | `internal/providers/irm/oncall_commands.go` | OnCall CLI commands (schedules, integrations, escalation chains) |
 | `internal/providers/irm/oncall_adapter.go` | Resource adapter for OnCall resources |
 | `internal/providers/irm/incidents_client.go` | Incidents REST client |
-| `internal/providers/irm/incidents_commands.go` | IRM Incidents CLI commands (list, get, create, close, open, list-activity, list-contexts, activity add, severities) |
+| `internal/providers/irm/incidents_commands.go` | IRM Incidents CLI commands (list, get, create, close, open, list-activity, list-contexts, activity add, severities, update) |
+| `internal/providers/irm/incidents_update_command.go` | The `incidents update` command (severity, title) |
 
 ### Faro Provider
 

--- a/docs/reference/cli/gcx_dbo11y.md
+++ b/docs/reference/cli/gcx_dbo11y.md
@@ -12,7 +12,7 @@ Inspect Grafana Database Observability instances and query performance
 ### Options inherited from parent commands
 
 ```
-      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, OPENCODE, PI_CODING_AGENT, or GCX_AGENT_MODE env vars.
       --context string              Name of the context to use (overrides current-context in config)
       --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
       --no-color                    Disable color output

--- a/docs/reference/cli/gcx_dbo11y_instances.md
+++ b/docs/reference/cli/gcx_dbo11y_instances.md
@@ -11,7 +11,7 @@ Inspect Database Observability instances discovered from telemetry
 ### Options inherited from parent commands
 
 ```
-      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, OPENCODE, PI_CODING_AGENT, or GCX_AGENT_MODE env vars.
       --config string               Path to the configuration file to use
       --context string              Name of the context to use (overrides current-context in config)
       --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.

--- a/docs/reference/cli/gcx_dbo11y_instances_get.md
+++ b/docs/reference/cli/gcx_dbo11y_instances_get.md
@@ -69,7 +69,7 @@ gcx dbo11y instances get <name> [flags]
 ### Options inherited from parent commands
 
 ```
-      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, OPENCODE, PI_CODING_AGENT, or GCX_AGENT_MODE env vars.
       --config string               Path to the configuration file to use
       --context string              Name of the context to use (overrides current-context in config)
       --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.

--- a/docs/reference/cli/gcx_dbo11y_instances_list.md
+++ b/docs/reference/cli/gcx_dbo11y_instances_list.md
@@ -52,7 +52,7 @@ gcx dbo11y instances list [flags]
 ### Options inherited from parent commands
 
 ```
-      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, OPENCODE, PI_CODING_AGENT, or GCX_AGENT_MODE env vars.
       --config string               Path to the configuration file to use
       --context string              Name of the context to use (overrides current-context in config)
       --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.

--- a/docs/reference/cli/gcx_irm_incidents.md
+++ b/docs/reference/cli/gcx_irm_incidents.md
@@ -33,4 +33,5 @@ Manage incidents.
 * [gcx irm incidents list-contexts](gcx_irm_incidents_list-contexts.md)	 - List contexts attached to an incident.
 * [gcx irm incidents open](gcx_irm_incidents_open.md)	 - Open an incident in the browser.
 * [gcx irm incidents severities](gcx_irm_incidents_severities.md)	 - Manage incident severity levels.
+* [gcx irm incidents update](gcx_irm_incidents_update.md)	 - Update the severity or the title of an incident.
 

--- a/docs/reference/cli/gcx_irm_incidents.md
+++ b/docs/reference/cli/gcx_irm_incidents.md
@@ -32,4 +32,5 @@ Manage incidents.
 * [gcx irm incidents list-contexts](gcx_irm_incidents_list-contexts.md)	 - List contexts attached to an incident.
 * [gcx irm incidents open](gcx_irm_incidents_open.md)	 - Open an incident in the browser.
 * [gcx irm incidents severities](gcx_irm_incidents_severities.md)	 - Manage incident severity levels.
+* [gcx irm incidents update](gcx_irm_incidents_update.md)	 - Update the severity or the title of an incident.
 

--- a/docs/reference/cli/gcx_irm_incidents_create.md
+++ b/docs/reference/cli/gcx_irm_incidents_create.md
@@ -20,7 +20,6 @@ gcx irm incidents create [flags]
     status: active
     # The display label, not the identifier. Run
     # 'gcx irm incidents severities list' for the valid values.
-    # severityID has precedence: gcx ignores severity when you set both.
     severity: Minor
     isDrill: false
     incidentType: internal

--- a/docs/reference/cli/gcx_irm_incidents_create.md
+++ b/docs/reference/cli/gcx_irm_incidents_create.md
@@ -18,6 +18,10 @@ gcx irm incidents create [flags]
   spec:
     title: "Service degradation in production"
     status: active
+    # The display label, not the identifier. Run
+    # 'gcx irm incidents severities list' for the valid values.
+    # severityID has precedence: gcx ignores severity when you set both.
+    severity: Minor
     isDrill: false
     incidentType: internal
     labels:

--- a/docs/reference/cli/gcx_irm_incidents_update.md
+++ b/docs/reference/cli/gcx_irm_incidents_update.md
@@ -9,7 +9,8 @@ Update the severity or the title of an incident.
 The severity is the display label, not the identifier. Run
 `gcx irm incidents severities list` for the labels of your organization.
 
-The command emits the updated incident.
+gcx reads the incident first, so a value that already matches causes no write.
+The command emits the incident.
 
 ```
 gcx irm incidents update <id> [flags]

--- a/docs/reference/cli/gcx_irm_incidents_update.md
+++ b/docs/reference/cli/gcx_irm_incidents_update.md
@@ -11,7 +11,7 @@ The severity is the display label, not the identifier. Run
 
 gcx reads the incident first, so a value that already matches causes no write.
 The command prints one line that names the fields it changed. Use -o json or
--o yaml for the incident manifest.
+-o yaml for a structured update result.
 
 ```
 gcx irm incidents update <id> [flags]
@@ -41,7 +41,7 @@ gcx irm incidents update <id> [flags]
 ### Options inherited from parent commands
 
 ```
-      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, OPENCODE, PI_CODING_AGENT, or GCX_AGENT_MODE env vars.
       --config string               Path to the configuration file to use
       --context string              Name of the context to use (overrides current-context in config)
       --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.

--- a/docs/reference/cli/gcx_irm_incidents_update.md
+++ b/docs/reference/cli/gcx_irm_incidents_update.md
@@ -10,7 +10,8 @@ The severity is the display label, not the identifier. Run
 `gcx irm incidents severities list` for the labels of your organization.
 
 gcx reads the incident first, so a value that already matches causes no write.
-The command emits the incident.
+The command prints one line that names the fields it changed. Use -o json or
+-o yaml for the incident manifest.
 
 ```
 gcx irm incidents update <id> [flags]
@@ -32,7 +33,7 @@ gcx irm incidents update <id> [flags]
   -h, --help              help for update
       --jq string         jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string     Output format. One of: agents, json, yaml (default "yaml")
+  -o, --output string     Output format. One of: agents, json, text, yaml (default "text")
       --severity string   New severity label (run 'gcx irm incidents severities list' for the valid values)
       --title string      New title
 ```

--- a/docs/reference/cli/gcx_irm_incidents_update.md
+++ b/docs/reference/cli/gcx_irm_incidents_update.md
@@ -1,0 +1,54 @@
+## gcx irm incidents update
+
+Update the severity or the title of an incident.
+
+### Synopsis
+
+Update the severity or the title of an incident.
+
+The severity is the display label, not the identifier. Run
+`gcx irm incidents severities list` for the labels of your organization.
+
+The command emits the updated incident.
+
+```
+gcx irm incidents update <id> [flags]
+```
+
+### Examples
+
+```
+  # Raise the severity of an incident:
+  gcx irm incidents update 4 --severity Critical
+
+  # Correct the title:
+  gcx irm incidents update 4 --title "Checkout latency above the objective"
+```
+
+### Options
+
+```
+  -h, --help                                         help for update
+      --jq string                                    jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string                                  Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string                                Output format. One of: agents, json, yaml (default "yaml")
+      --severity gcx irm incidents severities list   New severity label (run gcx irm incidents severities list for the valid values)
+      --title string                                 New title
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx irm incidents](gcx_irm_incidents.md)	 - Manage incidents.
+

--- a/docs/reference/cli/gcx_irm_incidents_update.md
+++ b/docs/reference/cli/gcx_irm_incidents_update.md
@@ -28,12 +28,12 @@ gcx irm incidents update <id> [flags]
 ### Options
 
 ```
-  -h, --help                                         help for update
-      --jq string                                    jq expression to apply to JSON output. Mutually exclusive with --json.
-      --json string                                  Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string                                Output format. One of: agents, json, yaml (default "yaml")
-      --severity gcx irm incidents severities list   New severity label (run gcx irm incidents severities list for the valid values)
-      --title string                                 New title
+  -h, --help              help for update
+      --jq string         jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string     Output format. One of: agents, json, yaml (default "yaml")
+      --severity string   New severity label (run 'gcx irm incidents severities list' for the valid values)
+      --title string      New title
 ```
 
 ### Options inherited from parent commands

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -255,6 +255,7 @@ var commandAnnotations = map[string]annotation{
 	"gcx irm incidents list-contexts":   {Cost: "small"},
 	"gcx irm incidents open":            {Cost: "small"},
 	"gcx irm incidents severities list": {Cost: "small"},
+	"gcx irm incidents update":          {Cost: "small", Hint: "<id> --severity <label> --title <text>; the severity is the label, run `gcx irm incidents severities list` for the valid values"},
 
 	// -----------------------------------------------------------------------
 	// k6 provider

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -254,6 +254,7 @@ var commandAnnotations = map[string]annotation{
 	"gcx irm incidents list-contexts":   {Cost: "small"},
 	"gcx irm incidents open":            {Cost: "small"},
 	"gcx irm incidents severities list": {Cost: "small"},
+	"gcx irm incidents update":          {Cost: "small", Hint: "<id> --severity <label> --title <text>; the severity is the label, run `gcx irm incidents severities list` for the valid values"},
 
 	// -----------------------------------------------------------------------
 	// k6 provider

--- a/internal/providers/irm/incidents_client.go
+++ b/internal/providers/irm/incidents_client.go
@@ -35,6 +35,14 @@ const (
 	incGetPath        = incidentBasePath + "/IncidentsService.GetIncident"
 	incCreatePath     = incidentBasePath + "/IncidentsService.CreateIncident"
 	incUpdateStatPath = incidentBasePath + "/IncidentsService.UpdateStatus"
+
+	// UpdateSeverity and UpdateTitle are separate operations: CreateIncident
+	// ignores the severity of the request body. The method names are held
+	// apart from the base path, because updateIncidentField tries the
+	// versioned base path first and the unversioned one second.
+	incUpdateSeverityMethod = "IncidentsService.UpdateSeverity"
+	incUpdateTitleMethod    = "IncidentsService.UpdateTitle"
+
 	incQueryPath      = incidentBasePath + "/IncidentsService.QueryIncidentPreviews"
 	actQueryPath      = incidentBasePath + "/ActivityService.QueryActivity"
 	actAddPath        = incidentBasePath + "/ActivityService.AddActivity"
@@ -432,6 +440,134 @@ func (c *IncidentClient) Create(ctx context.Context, inc *Incident) (*Incident, 
 		return nil, fmt.Errorf("incidents: decode create response: %w", err)
 	}
 
+	return c.applyRequestedSeverity(ctx, &result.Incident, inc)
+}
+
+// applyRequestedSeverity sets the severity of a new incident when the caller
+// asked for one.
+//
+// CreateIncident ignores both severity and severityID of the request body:
+// every incident starts at the default severity. Severity is the first column
+// of any incident report, so a caller that cannot set it cannot provision
+// reporting by severity. UpdateSeverity is the only route, and it takes the
+// label, not the identifier.
+func (c *IncidentClient) applyRequestedSeverity(ctx context.Context, created, requested *Incident) (*Incident, error) {
+	label, err := c.resolveSeverityLabel(ctx, requested)
+	if err != nil {
+		return nil, err
+	}
+	if label == "" || strings.EqualFold(created.Severity, label) {
+		return created, nil
+	}
+
+	updated, err := c.UpdateSeverity(ctx, created.IncidentID, label)
+	if err != nil {
+		return nil, fmt.Errorf("incidents: create: set severity %q: %w", label, err)
+	}
+	return updated, nil
+}
+
+// resolveSeverityLabel returns the severity label the caller asked for.
+// spec.severity holds the label directly. spec.severityID holds an
+// identifier, which the organization severity list resolves to a label.
+// An empty result means the caller asked for no severity.
+func (c *IncidentClient) resolveSeverityLabel(ctx context.Context, inc *Incident) (string, error) {
+	if inc.Severity != "" {
+		return inc.Severity, nil
+	}
+	if inc.SeverityID == "" {
+		return "", nil
+	}
+
+	severities, err := c.GetSeverities(ctx)
+	if err != nil {
+		return "", fmt.Errorf("incidents: resolve severityID %q: %w", inc.SeverityID, err)
+	}
+	for _, s := range severities {
+		if s.SeverityID == inc.SeverityID {
+			return s.DisplayLabel, nil
+		}
+	}
+	return "", fmt.Errorf("incidents: unknown severityID %q, run `gcx irm incidents severities list` for the valid values", inc.SeverityID)
+}
+
+// UpdateSeverity sets the severity of an incident and returns the updated
+// incident. severity is the display label, not the identifier.
+func (c *IncidentClient) UpdateSeverity(ctx context.Context, id, severity string) (*Incident, error) {
+	req := updateSeverityRequest{IncidentID: id, Severity: severity}
+	return c.updateIncidentField(ctx, incUpdateSeverityMethod, req, "update severity")
+}
+
+// UpdateTitle sets the title of an incident and returns the updated incident.
+func (c *IncidentClient) UpdateTitle(ctx context.Context, id, title string) (*Incident, error) {
+	req := updateTitleRequest{IncidentID: id, Title: title}
+	return c.updateIncidentField(ctx, incUpdateTitleMethod, req, "update title")
+}
+
+// Update applies every field of inc that the IRM API exposes as its own
+// operation: status, title, and severity. The API has no single update
+// method, so each field costs one call, and gcx skips the fields the caller
+// left empty.
+func (c *IncidentClient) Update(ctx context.Context, id string, inc *Incident) (*Incident, error) {
+	current, err := c.UpdateStatus(ctx, id, inc.Status)
+	if err != nil {
+		return nil, err
+	}
+
+	if inc.Title != "" && inc.Title != current.Title {
+		current, err = c.UpdateTitle(ctx, id, inc.Title)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	label, err := c.resolveSeverityLabel(ctx, inc)
+	if err != nil {
+		return nil, err
+	}
+	if label != "" && !strings.EqualFold(current.Severity, label) {
+		current, err = c.UpdateSeverity(ctx, id, label)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return current, nil
+}
+
+// updateIncidentField posts a single-field update to IncidentsService and
+// returns the updated incident.
+//
+// IncidentsService answers on the versioned base path. A Grafana build that
+// predates that path answers on the unversioned one, so a 404 on the first
+// path retries on the second.
+func (c *IncidentClient) updateIncidentField(ctx context.Context, method string, req any, description string) (*Incident, error) {
+	data, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("incidents: marshal %s request: %w", description, err)
+	}
+
+	resp, err := c.doRequest(ctx, incidentBasePath+"/"+method, bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("incidents: %s: %w", description, err)
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		resp.Body.Close()
+		resp, err = c.doRequest(ctx, incidentLegacyBasePath+"/"+method, bytes.NewReader(data))
+		if err != nil {
+			return nil, fmt.Errorf("incidents: %s: %w", description, err)
+		}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, providers.HandleErrorResponse(resp)
+	}
+
+	var result updateStatusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("incidents: decode %s response: %w", description, err)
+	}
 	return &result.Incident, nil
 }
 

--- a/internal/providers/irm/incidents_client.go
+++ b/internal/providers/irm/incidents_client.go
@@ -446,7 +446,7 @@ func (c *IncidentClient) Update(ctx context.Context, id string, inc *Incident) (
 		return nil, err
 	}
 
-	if inc.Status != "" {
+	if inc.Status != "" && !strings.EqualFold(current.Status, inc.Status) {
 		current, err = c.UpdateStatus(ctx, id, inc.Status)
 		if err != nil {
 			return nil, err

--- a/internal/providers/irm/incidents_client.go
+++ b/internal/providers/irm/incidents_client.go
@@ -495,13 +495,13 @@ func (c *IncidentClient) resolveSeverityLabel(ctx context.Context, inc *Incident
 // incident. severity is the display label, not the identifier.
 func (c *IncidentClient) UpdateSeverity(ctx context.Context, id, severity string) (*Incident, error) {
 	req := updateSeverityRequest{IncidentID: id, Severity: severity}
-	return c.updateIncidentField(ctx, incUpdateSeverityMethod, req, "update severity")
+	return c.updateIncidentField(ctx, incUpdateSeverityMethod, id, req, "update severity")
 }
 
 // UpdateTitle sets the title of an incident and returns the updated incident.
 func (c *IncidentClient) UpdateTitle(ctx context.Context, id, title string) (*Incident, error) {
 	req := updateTitleRequest{IncidentID: id, Title: title}
-	return c.updateIncidentField(ctx, incUpdateTitleMethod, req, "update title")
+	return c.updateIncidentField(ctx, incUpdateTitleMethod, id, req, "update title")
 }
 
 // Update applies every field of inc that the IRM API exposes as its own
@@ -510,35 +510,56 @@ func (c *IncidentClient) UpdateTitle(ctx context.Context, id, title string) (*In
 // skips each field that the caller left empty or that already matches the
 // server. Nothing enforces the required fields of the schema on push, so a
 // manifest without a status must not send an empty status.
+//
+// A call that fails after an earlier call succeeded leaves the incident
+// between the two states. Update then reports the incident as the server
+// holds it, next to an error that names the fields it did apply.
 func (c *IncidentClient) Update(ctx context.Context, id string, inc *Incident) (*Incident, error) {
 	current, err := c.Get(ctx, id)
 	if err != nil {
 		return nil, err
 	}
 
-	if inc.Status != "" && !strings.EqualFold(current.Status, inc.Status) {
-		current, err = c.UpdateStatus(ctx, id, inc.Status)
-		if err != nil {
+	var applied []string
+	// fail reports a half-applied update: the incident as it stands on the
+	// server, and the fields that reached it before the failure.
+	fail := func(field string, err error) (*Incident, error) {
+		if len(applied) == 0 {
 			return nil, err
 		}
+		return current, fmt.Errorf("incidents: update %s: gcx applied the %s, but the %s update failed: %w",
+			id, strings.Join(applied, " and the "), field, err)
+	}
+
+	if inc.Status != "" && !strings.EqualFold(current.Status, inc.Status) {
+		updated, err := c.UpdateStatus(ctx, id, inc.Status)
+		if err != nil {
+			return fail("status", err)
+		}
+		current = updated
+		applied = append(applied, "status")
 	}
 
 	if inc.Title != "" && inc.Title != current.Title {
-		current, err = c.UpdateTitle(ctx, id, inc.Title)
+		updated, err := c.UpdateTitle(ctx, id, inc.Title)
 		if err != nil {
-			return nil, err
+			return fail("title", err)
 		}
+		current = updated
+		applied = append(applied, "title")
 	}
 
 	label, err := c.resolveSeverityLabel(ctx, inc)
 	if err != nil {
-		return nil, err
+		return fail("severity", err)
 	}
 	if label != "" && !strings.EqualFold(current.Severity, label) {
-		current, err = c.UpdateSeverity(ctx, id, label)
+		updated, err := c.UpdateSeverity(ctx, id, label)
 		if err != nil {
-			return nil, err
+			return fail("severity", err)
 		}
+		current = updated
+		applied = append(applied, "severity")
 	}
 
 	return current, nil
@@ -549,8 +570,9 @@ func (c *IncidentClient) Update(ctx context.Context, id string, inc *Incident) (
 //
 // IncidentsService answers on the versioned base path. A Grafana build that
 // predates that path answers on the unversioned one, so a 404 on the first
-// path retries on the second.
-func (c *IncidentClient) updateIncidentField(ctx context.Context, method string, req any, description string) (*Incident, error) {
+// path retries on the second. A 404 on both paths is not a missing route: the
+// incident does not exist, and GetIncident reports that state the same way.
+func (c *IncidentClient) updateIncidentField(ctx context.Context, method, id string, req any, description string) (*Incident, error) {
 	data, err := json.Marshal(req)
 	if err != nil {
 		return nil, fmt.Errorf("incidents: marshal %s request: %w", description, err)
@@ -565,6 +587,10 @@ func (c *IncidentClient) updateIncidentField(ctx context.Context, method string,
 		resp, err = c.doRequest(ctx, incidentLegacyBasePath+"/"+method, bytes.NewReader(data))
 		if err != nil {
 			return nil, fmt.Errorf("incidents: %s: %w", description, err)
+		}
+		if resp.StatusCode == http.StatusNotFound {
+			resp.Body.Close()
+			return nil, fmt.Errorf("incidents: %s %s: %w", description, id, ErrNotFound)
 		}
 	}
 	defer resp.Body.Close()
@@ -583,7 +609,7 @@ func (c *IncidentClient) updateIncidentField(ctx context.Context, method string,
 // UpdateStatus updates an incident's status and returns the updated incident.
 func (c *IncidentClient) UpdateStatus(ctx context.Context, id, status string) (*Incident, error) {
 	req := updateStatusRequest{IncidentID: id, Status: status}
-	return c.updateIncidentField(ctx, incUpdateStatusMethod, req, "update status")
+	return c.updateIncidentField(ctx, incUpdateStatusMethod, id, req, "update status")
 }
 
 // QueryActivity retrieves the activity timeline for an incident.

--- a/internal/providers/irm/incidents_client.go
+++ b/internal/providers/irm/incidents_client.go
@@ -434,30 +434,47 @@ func (c *IncidentClient) UpdateTitle(ctx context.Context, id, title string) (*In
 	return c.updateIncidentField(ctx, incUpdateTitleMethod, id, req, "update title")
 }
 
-// Update applies every field of inc that the IRM API exposes as its own
-// operation: status, title, and severity. The API has no single update
-// method, so each field costs one call. gcx reads the incident first, then
-// skips each field that the caller left empty or that already matches the
-// server. Nothing enforces the required fields of the schema on push, so a
-// manifest without a status must not send an empty status.
+// Update applies the three fields that the IRM API exposes as their own
+// operation: the status, the title, and the severity. The API has no single
+// update method, so each field costs one call. gcx reads the incident first,
+// then skips each field that the caller left empty or that already matches
+// the server. Nothing enforces the required fields of the schema on push, so
+// a manifest without a status must not send an empty status.
+//
+// Update drops every other field of inc, because the IRM API has no update
+// operation for it: a pushed manifest that changes labels, incidentType,
+// isDrill, description or fieldGroupUUID leaves those values on the server.
+//
+// The second result names the fields that reached the server. An empty list
+// means the incident already matched the request.
 //
 // A call that fails after an earlier call succeeded leaves the incident
-// between the two states. Update then reports the incident as the server
-// holds it, next to an error that names the fields it did apply.
-func (c *IncidentClient) Update(ctx context.Context, id string, inc *Incident) (*Incident, error) {
+// between the two states. Update then returns no incident, and an error that
+// names the fields it did apply.
+func (c *IncidentClient) Update(ctx context.Context, id string, inc *Incident) (*Incident, []string, error) {
 	current, err := c.Get(ctx, id)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
+	}
+
+	// The resolve reads the severity list of the organization, and writes
+	// nothing. It runs before the first write, because the IRM API cannot undo
+	// a write that a later step abandons: a manifest with an unknown
+	// spec.severityID then costs no half-applied incident.
+	label, err := c.resolveSeverityLabel(ctx, inc)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	var applied []string
-	// fail reports a half-applied update: the incident as it stands on the
-	// server, and the fields that reached it before the failure.
-	fail := func(field string, err error) (*Incident, error) {
+	// fail reports a half-applied update: the fields that reached the server
+	// before the failure. The incident stands between two states, so gcx
+	// returns no incident.
+	fail := func(field string, err error) (*Incident, []string, error) {
 		if len(applied) == 0 {
-			return nil, err
+			return nil, nil, err
 		}
-		return current, fmt.Errorf("incidents: update %s: gcx applied the %s, but the %s update failed: %w",
+		return nil, nil, fmt.Errorf("incidents: update %s: gcx applied the %s, but the %s update failed: %w",
 			id, strings.Join(applied, " and the "), field, err)
 	}
 
@@ -479,10 +496,6 @@ func (c *IncidentClient) Update(ctx context.Context, id string, inc *Incident) (
 		applied = append(applied, "title")
 	}
 
-	label, err := c.resolveSeverityLabel(ctx, inc)
-	if err != nil {
-		return fail("severity", err)
-	}
 	if label != "" && !strings.EqualFold(current.Severity, label) {
 		updated, err := c.UpdateSeverity(ctx, id, label)
 		if err != nil {
@@ -492,7 +505,7 @@ func (c *IncidentClient) Update(ctx context.Context, id string, inc *Incident) (
 		applied = append(applied, "severity")
 	}
 
-	return current, nil
+	return current, applied, nil
 }
 
 // updateIncidentField posts a single-field update to IncidentsService and

--- a/internal/providers/irm/incidents_client.go
+++ b/internal/providers/irm/incidents_client.go
@@ -30,14 +30,15 @@ const (
 	// 404 under the /v1 prefix — they only respond here.
 	incidentLegacyBasePath = "/api/plugins/grafana-irm-app/resources/api"
 
-	incGetPath        = incidentBasePath + "/IncidentsService.GetIncident"
-	incCreatePath     = incidentBasePath + "/IncidentsService.CreateIncident"
-	incUpdateStatPath = incidentBasePath + "/IncidentsService.UpdateStatus"
+	incGetPath    = incidentBasePath + "/IncidentsService.GetIncident"
+	incCreatePath = incidentBasePath + "/IncidentsService.CreateIncident"
 
-	// UpdateSeverity and UpdateTitle are separate operations: CreateIncident
-	// ignores the severity of the request body. The method names are held
-	// apart from the base path, because updateIncidentField tries the
-	// versioned base path first and the unversioned one second.
+	// The IRM API has one operation per mutable field: CreateIncident ignores
+	// the severity of the request body, and there is no combined update
+	// method. The method names are held apart from the base path, because
+	// updateIncidentField tries the versioned base path first and the
+	// unversioned one second.
+	incUpdateStatusMethod   = "IncidentsService.UpdateStatus"
 	incUpdateSeverityMethod = "IncidentsService.UpdateSeverity"
 	incUpdateTitleMethod    = "IncidentsService.UpdateTitle"
 
@@ -333,7 +334,19 @@ func (c *IncidentClient) Get(ctx context.Context, id string) (*Incident, error) 
 }
 
 // Create creates a new incident and returns the created incident.
+//
+// CreateIncident ignores both severity and severityID of the request body:
+// every incident starts at the default severity. Severity is the first column
+// of any incident report, so a caller that cannot set it cannot provision
+// reporting by severity. UpdateSeverity is the only route, and it takes the
+// label, not the identifier. The label resolves before the create call,
+// because the IRM API cannot delete an incident that a later step abandons.
 func (c *IncidentClient) Create(ctx context.Context, inc *Incident) (*Incident, error) {
+	label, err := c.resolveSeverityLabel(ctx, inc)
+	if err != nil {
+		return nil, err
+	}
+
 	req := createIncidentRequest{
 		Title:          inc.Title,
 		Status:         inc.Status,
@@ -370,43 +383,30 @@ func (c *IncidentClient) Create(ctx context.Context, inc *Incident) (*Incident, 
 		return nil, fmt.Errorf("incidents: decode create response: %w", err)
 	}
 
-	return c.applyRequestedSeverity(ctx, &result.Incident, inc)
-}
-
-// applyRequestedSeverity sets the severity of a new incident when the caller
-// asked for one.
-//
-// CreateIncident ignores both severity and severityID of the request body:
-// every incident starts at the default severity. Severity is the first column
-// of any incident report, so a caller that cannot set it cannot provision
-// reporting by severity. UpdateSeverity is the only route, and it takes the
-// label, not the identifier.
-func (c *IncidentClient) applyRequestedSeverity(ctx context.Context, created, requested *Incident) (*Incident, error) {
-	label, err := c.resolveSeverityLabel(ctx, requested)
-	if err != nil {
-		return nil, err
-	}
+	created := &result.Incident
 	if label == "" || strings.EqualFold(created.Severity, label) {
 		return created, nil
 	}
 
 	updated, err := c.UpdateSeverity(ctx, created.IncidentID, label)
 	if err != nil {
-		return nil, fmt.Errorf("incidents: create: set severity %q: %w", label, err)
+		// The incident exists at the default severity, and the IRM API has no
+		// delete method. The caller needs the identifier to repair it.
+		return created, fmt.Errorf(
+			"incidents: create: incident %s exists, but the severity update failed: %w: run `gcx irm incidents update %s --severity %q` to set the severity",
+			created.IncidentID, err, created.IncidentID, label)
 	}
 	return updated, nil
 }
 
 // resolveSeverityLabel returns the severity label the caller asked for.
-// spec.severity holds the label directly. spec.severityID holds an
-// identifier, which the organization severity list resolves to a label.
-// An empty result means the caller asked for no severity.
+// spec.severityID has precedence: when it is not empty, the organization
+// severity list resolves it to a label, and gcx ignores spec.severity.
+// spec.severity holds the label directly. An empty result means the caller
+// asked for no severity.
 func (c *IncidentClient) resolveSeverityLabel(ctx context.Context, inc *Incident) (string, error) {
-	if inc.Severity != "" {
-		return inc.Severity, nil
-	}
 	if inc.SeverityID == "" {
-		return "", nil
+		return inc.Severity, nil
 	}
 
 	severities, err := c.GetSeverities(ctx)
@@ -436,12 +436,21 @@ func (c *IncidentClient) UpdateTitle(ctx context.Context, id, title string) (*In
 
 // Update applies every field of inc that the IRM API exposes as its own
 // operation: status, title, and severity. The API has no single update
-// method, so each field costs one call, and gcx skips the fields the caller
-// left empty.
+// method, so each field costs one call. gcx reads the incident first, then
+// skips each field that the caller left empty or that already matches the
+// server. Nothing enforces the required fields of the schema on push, so a
+// manifest without a status must not send an empty status.
 func (c *IncidentClient) Update(ctx context.Context, id string, inc *Incident) (*Incident, error) {
-	current, err := c.UpdateStatus(ctx, id, inc.Status)
+	current, err := c.Get(ctx, id)
 	if err != nil {
 		return nil, err
+	}
+
+	if inc.Status != "" {
+		current, err = c.UpdateStatus(ctx, id, inc.Status)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if inc.Title != "" && inc.Title != current.Title {
@@ -503,32 +512,8 @@ func (c *IncidentClient) updateIncidentField(ctx context.Context, method string,
 
 // UpdateStatus updates an incident's status and returns the updated incident.
 func (c *IncidentClient) UpdateStatus(ctx context.Context, id, status string) (*Incident, error) {
-	req := updateStatusRequest{
-		IncidentID: id,
-		Status:     status,
-	}
-
-	body, err := json.Marshal(req)
-	if err != nil {
-		return nil, fmt.Errorf("incidents: marshal update request: %w", err)
-	}
-
-	resp, err := c.doRequest(ctx, incUpdateStatPath, bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("incidents: update status %s: %w", id, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, providers.HandleErrorResponse(resp)
-	}
-
-	var result updateStatusResponse
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("incidents: decode update response: %w", err)
-	}
-
-	return &result.Incident, nil
+	req := updateStatusRequest{IncidentID: id, Status: status}
+	return c.updateIncidentField(ctx, incUpdateStatusMethod, req, "update status")
 }
 
 // QueryActivity retrieves the activity timeline for an incident.

--- a/internal/providers/irm/incidents_client.go
+++ b/internal/providers/irm/incidents_client.go
@@ -504,30 +504,47 @@ func (c *IncidentClient) UpdateTitle(ctx context.Context, id, title string) (*In
 	return c.updateIncidentField(ctx, incUpdateTitleMethod, id, req, "update title")
 }
 
-// Update applies every field of inc that the IRM API exposes as its own
-// operation: status, title, and severity. The API has no single update
-// method, so each field costs one call. gcx reads the incident first, then
-// skips each field that the caller left empty or that already matches the
-// server. Nothing enforces the required fields of the schema on push, so a
-// manifest without a status must not send an empty status.
+// Update applies the three fields that the IRM API exposes as their own
+// operation: the status, the title, and the severity. The API has no single
+// update method, so each field costs one call. gcx reads the incident first,
+// then skips each field that the caller left empty or that already matches
+// the server. Nothing enforces the required fields of the schema on push, so
+// a manifest without a status must not send an empty status.
+//
+// Update drops every other field of inc, because the IRM API has no update
+// operation for it: a pushed manifest that changes labels, incidentType,
+// isDrill, description or fieldGroupUUID leaves those values on the server.
+//
+// The second result names the fields that reached the server. An empty list
+// means the incident already matched the request.
 //
 // A call that fails after an earlier call succeeded leaves the incident
-// between the two states. Update then reports the incident as the server
-// holds it, next to an error that names the fields it did apply.
-func (c *IncidentClient) Update(ctx context.Context, id string, inc *Incident) (*Incident, error) {
+// between the two states. Update then returns no incident, and an error that
+// names the fields it did apply.
+func (c *IncidentClient) Update(ctx context.Context, id string, inc *Incident) (*Incident, []string, error) {
 	current, err := c.Get(ctx, id)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
+	}
+
+	// The resolve reads the severity list of the organization, and writes
+	// nothing. It runs before the first write, because the IRM API cannot undo
+	// a write that a later step abandons: a manifest with an unknown
+	// spec.severityID then costs no half-applied incident.
+	label, err := c.resolveSeverityLabel(ctx, inc)
+	if err != nil {
+		return nil, nil, err
 	}
 
 	var applied []string
-	// fail reports a half-applied update: the incident as it stands on the
-	// server, and the fields that reached it before the failure.
-	fail := func(field string, err error) (*Incident, error) {
+	// fail reports a half-applied update: the fields that reached the server
+	// before the failure. The incident stands between two states, so gcx
+	// returns no incident.
+	fail := func(field string, err error) (*Incident, []string, error) {
 		if len(applied) == 0 {
-			return nil, err
+			return nil, nil, err
 		}
-		return current, fmt.Errorf("incidents: update %s: gcx applied the %s, but the %s update failed: %w",
+		return nil, nil, fmt.Errorf("incidents: update %s: gcx applied the %s, but the %s update failed: %w",
 			id, strings.Join(applied, " and the "), field, err)
 	}
 
@@ -549,10 +566,6 @@ func (c *IncidentClient) Update(ctx context.Context, id string, inc *Incident) (
 		applied = append(applied, "title")
 	}
 
-	label, err := c.resolveSeverityLabel(ctx, inc)
-	if err != nil {
-		return fail("severity", err)
-	}
 	if label != "" && !strings.EqualFold(current.Severity, label) {
 		updated, err := c.UpdateSeverity(ctx, id, label)
 		if err != nil {
@@ -562,7 +575,7 @@ func (c *IncidentClient) Update(ctx context.Context, id string, inc *Incident) (
 		applied = append(applied, "severity")
 	}
 
-	return current, nil
+	return current, applied, nil
 }
 
 // updateIncidentField posts a single-field update to IncidentsService and

--- a/internal/providers/irm/incidents_client.go
+++ b/internal/providers/irm/incidents_client.go
@@ -516,7 +516,7 @@ func (c *IncidentClient) Update(ctx context.Context, id string, inc *Incident) (
 		return nil, err
 	}
 
-	if inc.Status != "" {
+	if inc.Status != "" && !strings.EqualFold(current.Status, inc.Status) {
 		current, err = c.UpdateStatus(ctx, id, inc.Status)
 		if err != nil {
 			return nil, err

--- a/internal/providers/irm/incidents_client.go
+++ b/internal/providers/irm/incidents_client.go
@@ -32,7 +32,6 @@ const (
 	// 404 under the /v1 prefix — they only respond here.
 	incidentLegacyBasePath = "/api/plugins/grafana-irm-app/resources/api"
 
-	incGetPath    = incidentBasePath + "/IncidentsService.GetIncident"
 	incCreatePath = incidentBasePath + "/IncidentsService.CreateIncident"
 
 	// The IRM API has one operation per mutable field: CreateIncident ignores
@@ -40,15 +39,16 @@ const (
 	// method. The method names are held apart from the base path, because
 	// updateIncidentField tries the versioned base path first and the
 	// unversioned one second.
+	incGetMethod            = "IncidentsService.GetIncident"
 	incUpdateStatusMethod   = "IncidentsService.UpdateStatus"
 	incUpdateSeverityMethod = "IncidentsService.UpdateSeverity"
 	incUpdateTitleMethod    = "IncidentsService.UpdateTitle"
 
-	incQueryPath      = incidentBasePath + "/IncidentsService.QueryIncidentPreviews"
-	actQueryPath      = incidentBasePath + "/ActivityService.QueryActivity"
-	actAddPath        = incidentBasePath + "/ActivityService.AddActivity"
-	sevGetPath        = incidentLegacyBasePath + "/SeveritiesService.GetOrgSeverities"
-	ctxQueryPath      = incidentLegacyBasePath + "/IncidentContextService.QueryIncidentContext"
+	incQueryPath = incidentBasePath + "/IncidentsService.QueryIncidentPreviews"
+	actQueryPath = incidentBasePath + "/ActivityService.QueryActivity"
+	actAddPath   = incidentBasePath + "/ActivityService.AddActivity"
+	sevGetPath   = incidentLegacyBasePath + "/SeveritiesService.GetOrgSeverities"
+	ctxQueryPath = incidentLegacyBasePath + "/IncidentContextService.QueryIncidentContext"
 	// IntegrationService is likewise not part of the documented v1 API and
 	// is served from the unversioned base path.
 	hookRunsPath = incidentLegacyBasePath + "/IntegrationService.GetHookRuns"
@@ -376,7 +376,7 @@ func (c *IncidentClient) Get(ctx context.Context, id string) (*Incident, error) 
 		return nil, fmt.Errorf("incidents: marshal get request: %w", err)
 	}
 
-	resp, err := c.doRequest(ctx, incGetPath, bytes.NewReader(body))
+	resp, err := c.doIncidentMethod(ctx, incGetMethod, body)
 	if err != nil {
 		return nil, fmt.Errorf("incidents: get %s: %w", id, err)
 	}
@@ -468,27 +468,38 @@ func (c *IncidentClient) Create(ctx context.Context, inc *Incident) (*Incident, 
 	return updated, nil
 }
 
-// resolveSeverityLabel returns the severity label the caller asked for.
-// A hand-written spec.severityID has precedence: when it is not empty, the
-// organization severity list resolves it to a label, and gcx ignores
-// spec.severity. A pulled manifest carries spec.severity alone, because the
-// pull removes spec.severityID. An empty result means the caller asked for no
-// severity.
+// resolveSeverityLabel returns the canonical severity label that the caller
+// asked for. It resolves both accepted inputs against the organization list
+// before a write. This prevents an unknown label from becoming a successful
+// no-op on a backend that accepts it with status 200.
+//
+// A hand-written spec.severityID has precedence when it is not empty. A pulled
+// manifest carries spec.severity alone because the read removes severityID.
+// An empty result means that the caller asked for no severity.
 func (c *IncidentClient) resolveSeverityLabel(ctx context.Context, inc *Incident) (string, error) {
-	if inc.SeverityID == "" {
-		return inc.Severity, nil
+	if inc.SeverityID == "" && inc.Severity == "" {
+		return "", nil
 	}
 
 	severities, err := c.GetSeverities(ctx)
 	if err != nil {
-		return "", fmt.Errorf("incidents: resolve severityID %q: %w", inc.SeverityID, err)
+		return "", fmt.Errorf("incidents: resolve severity: %w", err)
 	}
+	if inc.SeverityID != "" {
+		for _, s := range severities {
+			if s.SeverityID == inc.SeverityID {
+				return s.DisplayLabel, nil
+			}
+		}
+		return "", fmt.Errorf("incidents: unknown severityID %q, run `gcx irm incidents severities list` for the valid values", inc.SeverityID)
+	}
+
 	for _, s := range severities {
-		if s.SeverityID == inc.SeverityID {
+		if strings.EqualFold(s.DisplayLabel, inc.Severity) {
 			return s.DisplayLabel, nil
 		}
 	}
-	return "", fmt.Errorf("incidents: unknown severityID %q, run `gcx irm incidents severities list` for the valid values", inc.SeverityID)
+	return "", fmt.Errorf("incidents: unknown severity %q, run `gcx irm incidents severities list` for the valid values", inc.Severity)
 }
 
 // UpdateSeverity sets the severity of an incident and returns the updated
@@ -510,6 +521,10 @@ func (c *IncidentClient) UpdateTitle(ctx context.Context, id, title string) (*In
 // then skips each field that the caller left empty or that already matches
 // the server. Nothing enforces the required fields of the schema on push, so
 // a manifest without a status must not send an empty status.
+//
+// The resources push pipeline reads the incident before it calls Update to
+// select create or update. Update cannot reuse that value through the
+// TypedCRUD contract, so a push reads the incident a second time here.
 //
 // Update drops every other field of inc, because the IRM API has no update
 // operation for it: a pushed manifest that changes labels, incidentType,
@@ -574,6 +589,7 @@ func (c *IncidentClient) Update(ctx context.Context, id string, inc *Incident) (
 		applied = append(applied, "severity")
 	}
 
+	current.updatedFields = applied
 	return current, applied, nil
 }
 
@@ -582,28 +598,27 @@ func (c *IncidentClient) Update(ctx context.Context, id string, inc *Incident) (
 //
 // IncidentsService answers on the versioned base path. A Grafana build that
 // predates that path answers on the unversioned one, so a 404 on the first
-// path retries on the second. A 404 on both paths is not a missing route: the
-// incident does not exist, and GetIncident reports that state the same way.
+// path retries on the second. If both update paths return 404, Get determines
+// whether the incident is missing or the update operation is unavailable.
 func (c *IncidentClient) updateIncidentField(ctx context.Context, method, id string, req any, description string) (*Incident, error) {
 	data, err := json.Marshal(req)
 	if err != nil {
 		return nil, fmt.Errorf("incidents: marshal %s request: %w", description, err)
 	}
 
-	resp, err := c.doRequest(ctx, incidentBasePath+"/"+method, bytes.NewReader(data))
+	resp, err := c.doIncidentMethod(ctx, method, data)
 	if err != nil {
 		return nil, fmt.Errorf("incidents: %s: %w", description, err)
 	}
 	if resp.StatusCode == http.StatusNotFound {
 		resp.Body.Close()
-		resp, err = c.doRequest(ctx, incidentLegacyBasePath+"/"+method, bytes.NewReader(data))
-		if err != nil {
-			return nil, fmt.Errorf("incidents: %s: %w", description, err)
+		if _, getErr := c.Get(ctx, id); getErr != nil {
+			if errors.Is(getErr, ErrNotFound) {
+				return nil, fmt.Errorf("incidents: %s %s: %w", description, id, ErrNotFound)
+			}
+			return nil, fmt.Errorf("incidents: %s %s: verify incident after both API paths returned 404: %w", description, id, getErr)
 		}
-		if resp.StatusCode == http.StatusNotFound {
-			resp.Body.Close()
-			return nil, fmt.Errorf("incidents: %s %s: %w", description, id, ErrNotFound)
-		}
+		return nil, fmt.Errorf("incidents: %s %s: operation is unavailable on the versioned and unversioned API paths", description, id)
 	}
 	defer resp.Body.Close()
 
@@ -616,6 +631,22 @@ func (c *IncidentClient) updateIncidentField(ctx context.Context, method, id str
 		return nil, fmt.Errorf("incidents: decode %s response: %w", description, err)
 	}
 	return &result.Incident, nil
+}
+
+// doIncidentMethod posts to an IncidentsService method. A 404 retries the
+// unversioned base path so Get and the field-update methods support the same
+// Grafana builds. The caller owns and must close the response body.
+func (c *IncidentClient) doIncidentMethod(ctx context.Context, method string, data []byte) (*http.Response, error) {
+	resp, err := c.doRequest(ctx, incidentBasePath+"/"+method, bytes.NewReader(data))
+	if err != nil {
+		return nil, err
+	}
+	if resp.StatusCode != http.StatusNotFound {
+		return resp, nil
+	}
+
+	resp.Body.Close()
+	return c.doRequest(ctx, incidentLegacyBasePath+"/"+method, bytes.NewReader(data))
 }
 
 // UpdateStatus updates an incident's status and returns the updated incident.

--- a/internal/providers/irm/incidents_client.go
+++ b/internal/providers/irm/incidents_client.go
@@ -32,14 +32,15 @@ const (
 	// 404 under the /v1 prefix — they only respond here.
 	incidentLegacyBasePath = "/api/plugins/grafana-irm-app/resources/api"
 
-	incGetPath        = incidentBasePath + "/IncidentsService.GetIncident"
-	incCreatePath     = incidentBasePath + "/IncidentsService.CreateIncident"
-	incUpdateStatPath = incidentBasePath + "/IncidentsService.UpdateStatus"
+	incGetPath    = incidentBasePath + "/IncidentsService.GetIncident"
+	incCreatePath = incidentBasePath + "/IncidentsService.CreateIncident"
 
-	// UpdateSeverity and UpdateTitle are separate operations: CreateIncident
-	// ignores the severity of the request body. The method names are held
-	// apart from the base path, because updateIncidentField tries the
-	// versioned base path first and the unversioned one second.
+	// The IRM API has one operation per mutable field: CreateIncident ignores
+	// the severity of the request body, and there is no combined update
+	// method. The method names are held apart from the base path, because
+	// updateIncidentField tries the versioned base path first and the
+	// unversioned one second.
+	incUpdateStatusMethod   = "IncidentsService.UpdateStatus"
 	incUpdateSeverityMethod = "IncidentsService.UpdateSeverity"
 	incUpdateTitleMethod    = "IncidentsService.UpdateTitle"
 
@@ -403,7 +404,19 @@ func (c *IncidentClient) Get(ctx context.Context, id string) (*Incident, error) 
 }
 
 // Create creates a new incident and returns the created incident.
+//
+// CreateIncident ignores both severity and severityID of the request body:
+// every incident starts at the default severity. Severity is the first column
+// of any incident report, so a caller that cannot set it cannot provision
+// reporting by severity. UpdateSeverity is the only route, and it takes the
+// label, not the identifier. The label resolves before the create call,
+// because the IRM API cannot delete an incident that a later step abandons.
 func (c *IncidentClient) Create(ctx context.Context, inc *Incident) (*Incident, error) {
+	label, err := c.resolveSeverityLabel(ctx, inc)
+	if err != nil {
+		return nil, err
+	}
+
 	req := createIncidentRequest{
 		Title:          inc.Title,
 		Status:         inc.Status,
@@ -440,43 +453,30 @@ func (c *IncidentClient) Create(ctx context.Context, inc *Incident) (*Incident, 
 		return nil, fmt.Errorf("incidents: decode create response: %w", err)
 	}
 
-	return c.applyRequestedSeverity(ctx, &result.Incident, inc)
-}
-
-// applyRequestedSeverity sets the severity of a new incident when the caller
-// asked for one.
-//
-// CreateIncident ignores both severity and severityID of the request body:
-// every incident starts at the default severity. Severity is the first column
-// of any incident report, so a caller that cannot set it cannot provision
-// reporting by severity. UpdateSeverity is the only route, and it takes the
-// label, not the identifier.
-func (c *IncidentClient) applyRequestedSeverity(ctx context.Context, created, requested *Incident) (*Incident, error) {
-	label, err := c.resolveSeverityLabel(ctx, requested)
-	if err != nil {
-		return nil, err
-	}
+	created := &result.Incident
 	if label == "" || strings.EqualFold(created.Severity, label) {
 		return created, nil
 	}
 
 	updated, err := c.UpdateSeverity(ctx, created.IncidentID, label)
 	if err != nil {
-		return nil, fmt.Errorf("incidents: create: set severity %q: %w", label, err)
+		// The incident exists at the default severity, and the IRM API has no
+		// delete method. The caller needs the identifier to repair it.
+		return created, fmt.Errorf(
+			"incidents: create: incident %s exists, but the severity update failed: %w: run `gcx irm incidents update %s --severity %q` to set the severity",
+			created.IncidentID, err, created.IncidentID, label)
 	}
 	return updated, nil
 }
 
 // resolveSeverityLabel returns the severity label the caller asked for.
-// spec.severity holds the label directly. spec.severityID holds an
-// identifier, which the organization severity list resolves to a label.
-// An empty result means the caller asked for no severity.
+// spec.severityID has precedence: when it is not empty, the organization
+// severity list resolves it to a label, and gcx ignores spec.severity.
+// spec.severity holds the label directly. An empty result means the caller
+// asked for no severity.
 func (c *IncidentClient) resolveSeverityLabel(ctx context.Context, inc *Incident) (string, error) {
-	if inc.Severity != "" {
-		return inc.Severity, nil
-	}
 	if inc.SeverityID == "" {
-		return "", nil
+		return inc.Severity, nil
 	}
 
 	severities, err := c.GetSeverities(ctx)
@@ -506,12 +506,21 @@ func (c *IncidentClient) UpdateTitle(ctx context.Context, id, title string) (*In
 
 // Update applies every field of inc that the IRM API exposes as its own
 // operation: status, title, and severity. The API has no single update
-// method, so each field costs one call, and gcx skips the fields the caller
-// left empty.
+// method, so each field costs one call. gcx reads the incident first, then
+// skips each field that the caller left empty or that already matches the
+// server. Nothing enforces the required fields of the schema on push, so a
+// manifest without a status must not send an empty status.
 func (c *IncidentClient) Update(ctx context.Context, id string, inc *Incident) (*Incident, error) {
-	current, err := c.UpdateStatus(ctx, id, inc.Status)
+	current, err := c.Get(ctx, id)
 	if err != nil {
 		return nil, err
+	}
+
+	if inc.Status != "" {
+		current, err = c.UpdateStatus(ctx, id, inc.Status)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	if inc.Title != "" && inc.Title != current.Title {
@@ -573,32 +582,8 @@ func (c *IncidentClient) updateIncidentField(ctx context.Context, method string,
 
 // UpdateStatus updates an incident's status and returns the updated incident.
 func (c *IncidentClient) UpdateStatus(ctx context.Context, id, status string) (*Incident, error) {
-	req := updateStatusRequest{
-		IncidentID: id,
-		Status:     status,
-	}
-
-	body, err := json.Marshal(req)
-	if err != nil {
-		return nil, fmt.Errorf("incidents: marshal update request: %w", err)
-	}
-
-	resp, err := c.doRequest(ctx, incUpdateStatPath, bytes.NewReader(body))
-	if err != nil {
-		return nil, fmt.Errorf("incidents: update status %s: %w", id, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, providers.HandleErrorResponse(resp)
-	}
-
-	var result updateStatusResponse
-	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return nil, fmt.Errorf("incidents: decode update response: %w", err)
-	}
-
-	return &result.Incident, nil
+	req := updateStatusRequest{IncidentID: id, Status: status}
+	return c.updateIncidentField(ctx, incUpdateStatusMethod, req, "update status")
 }
 
 // QueryActivity retrieves the activity timeline for an incident.

--- a/internal/providers/irm/incidents_client.go
+++ b/internal/providers/irm/incidents_client.go
@@ -425,13 +425,13 @@ func (c *IncidentClient) resolveSeverityLabel(ctx context.Context, inc *Incident
 // incident. severity is the display label, not the identifier.
 func (c *IncidentClient) UpdateSeverity(ctx context.Context, id, severity string) (*Incident, error) {
 	req := updateSeverityRequest{IncidentID: id, Severity: severity}
-	return c.updateIncidentField(ctx, incUpdateSeverityMethod, req, "update severity")
+	return c.updateIncidentField(ctx, incUpdateSeverityMethod, id, req, "update severity")
 }
 
 // UpdateTitle sets the title of an incident and returns the updated incident.
 func (c *IncidentClient) UpdateTitle(ctx context.Context, id, title string) (*Incident, error) {
 	req := updateTitleRequest{IncidentID: id, Title: title}
-	return c.updateIncidentField(ctx, incUpdateTitleMethod, req, "update title")
+	return c.updateIncidentField(ctx, incUpdateTitleMethod, id, req, "update title")
 }
 
 // Update applies every field of inc that the IRM API exposes as its own
@@ -440,35 +440,56 @@ func (c *IncidentClient) UpdateTitle(ctx context.Context, id, title string) (*In
 // skips each field that the caller left empty or that already matches the
 // server. Nothing enforces the required fields of the schema on push, so a
 // manifest without a status must not send an empty status.
+//
+// A call that fails after an earlier call succeeded leaves the incident
+// between the two states. Update then reports the incident as the server
+// holds it, next to an error that names the fields it did apply.
 func (c *IncidentClient) Update(ctx context.Context, id string, inc *Incident) (*Incident, error) {
 	current, err := c.Get(ctx, id)
 	if err != nil {
 		return nil, err
 	}
 
-	if inc.Status != "" && !strings.EqualFold(current.Status, inc.Status) {
-		current, err = c.UpdateStatus(ctx, id, inc.Status)
-		if err != nil {
+	var applied []string
+	// fail reports a half-applied update: the incident as it stands on the
+	// server, and the fields that reached it before the failure.
+	fail := func(field string, err error) (*Incident, error) {
+		if len(applied) == 0 {
 			return nil, err
 		}
+		return current, fmt.Errorf("incidents: update %s: gcx applied the %s, but the %s update failed: %w",
+			id, strings.Join(applied, " and the "), field, err)
+	}
+
+	if inc.Status != "" && !strings.EqualFold(current.Status, inc.Status) {
+		updated, err := c.UpdateStatus(ctx, id, inc.Status)
+		if err != nil {
+			return fail("status", err)
+		}
+		current = updated
+		applied = append(applied, "status")
 	}
 
 	if inc.Title != "" && inc.Title != current.Title {
-		current, err = c.UpdateTitle(ctx, id, inc.Title)
+		updated, err := c.UpdateTitle(ctx, id, inc.Title)
 		if err != nil {
-			return nil, err
+			return fail("title", err)
 		}
+		current = updated
+		applied = append(applied, "title")
 	}
 
 	label, err := c.resolveSeverityLabel(ctx, inc)
 	if err != nil {
-		return nil, err
+		return fail("severity", err)
 	}
 	if label != "" && !strings.EqualFold(current.Severity, label) {
-		current, err = c.UpdateSeverity(ctx, id, label)
+		updated, err := c.UpdateSeverity(ctx, id, label)
 		if err != nil {
-			return nil, err
+			return fail("severity", err)
 		}
+		current = updated
+		applied = append(applied, "severity")
 	}
 
 	return current, nil
@@ -479,8 +500,9 @@ func (c *IncidentClient) Update(ctx context.Context, id string, inc *Incident) (
 //
 // IncidentsService answers on the versioned base path. A Grafana build that
 // predates that path answers on the unversioned one, so a 404 on the first
-// path retries on the second.
-func (c *IncidentClient) updateIncidentField(ctx context.Context, method string, req any, description string) (*Incident, error) {
+// path retries on the second. A 404 on both paths is not a missing route: the
+// incident does not exist, and GetIncident reports that state the same way.
+func (c *IncidentClient) updateIncidentField(ctx context.Context, method, id string, req any, description string) (*Incident, error) {
 	data, err := json.Marshal(req)
 	if err != nil {
 		return nil, fmt.Errorf("incidents: marshal %s request: %w", description, err)
@@ -495,6 +517,10 @@ func (c *IncidentClient) updateIncidentField(ctx context.Context, method string,
 		resp, err = c.doRequest(ctx, incidentLegacyBasePath+"/"+method, bytes.NewReader(data))
 		if err != nil {
 			return nil, fmt.Errorf("incidents: %s: %w", description, err)
+		}
+		if resp.StatusCode == http.StatusNotFound {
+			resp.Body.Close()
+			return nil, fmt.Errorf("incidents: %s %s: %w", description, id, ErrNotFound)
 		}
 	}
 	defer resp.Body.Close()
@@ -513,7 +539,7 @@ func (c *IncidentClient) updateIncidentField(ctx context.Context, method string,
 // UpdateStatus updates an incident's status and returns the updated incident.
 func (c *IncidentClient) UpdateStatus(ctx context.Context, id, status string) (*Incident, error) {
 	req := updateStatusRequest{IncidentID: id, Status: status}
-	return c.updateIncidentField(ctx, incUpdateStatusMethod, req, "update status")
+	return c.updateIncidentField(ctx, incUpdateStatusMethod, id, req, "update status")
 }
 
 // QueryActivity retrieves the activity timeline for an incident.

--- a/internal/providers/irm/incidents_client.go
+++ b/internal/providers/irm/incidents_client.go
@@ -424,7 +424,6 @@ func (c *IncidentClient) Create(ctx context.Context, inc *Incident) (*Incident, 
 		Labels:         inc.Labels,
 		IncidentType:   inc.IncidentType,
 		FieldGroupUUID: inc.FieldGroupUUID,
-		SeverityID:     inc.SeverityID,
 	}
 	if req.Status == "" {
 		req.Status = "active"

--- a/internal/providers/irm/incidents_client.go
+++ b/internal/providers/irm/incidents_client.go
@@ -400,10 +400,11 @@ func (c *IncidentClient) Create(ctx context.Context, inc *Incident) (*Incident, 
 }
 
 // resolveSeverityLabel returns the severity label the caller asked for.
-// spec.severityID has precedence: when it is not empty, the organization
-// severity list resolves it to a label, and gcx ignores spec.severity.
-// spec.severity holds the label directly. An empty result means the caller
-// asked for no severity.
+// A hand-written spec.severityID has precedence: when it is not empty, the
+// organization severity list resolves it to a label, and gcx ignores
+// spec.severity. A pulled manifest carries spec.severity alone, because the
+// pull removes spec.severityID. An empty result means the caller asked for no
+// severity.
 func (c *IncidentClient) resolveSeverityLabel(ctx context.Context, inc *Incident) (string, error) {
 	if inc.SeverityID == "" {
 		return inc.Severity, nil

--- a/internal/providers/irm/incidents_client.go
+++ b/internal/providers/irm/incidents_client.go
@@ -33,11 +33,19 @@ const (
 	incGetPath        = incidentBasePath + "/IncidentsService.GetIncident"
 	incCreatePath     = incidentBasePath + "/IncidentsService.CreateIncident"
 	incUpdateStatPath = incidentBasePath + "/IncidentsService.UpdateStatus"
-	incQueryPath      = incidentBasePath + "/IncidentsService.QueryIncidentPreviews"
-	actQueryPath      = incidentBasePath + "/ActivityService.QueryActivity"
-	actAddPath        = incidentBasePath + "/ActivityService.AddActivity"
-	sevGetPath        = incidentLegacyBasePath + "/SeveritiesService.GetOrgSeverities"
-	ctxQueryPath      = incidentLegacyBasePath + "/IncidentContextService.QueryIncidentContext"
+
+	// UpdateSeverity and UpdateTitle are separate operations: CreateIncident
+	// ignores the severity of the request body. The method names are held
+	// apart from the base path, because updateIncidentField tries the
+	// versioned base path first and the unversioned one second.
+	incUpdateSeverityMethod = "IncidentsService.UpdateSeverity"
+	incUpdateTitleMethod    = "IncidentsService.UpdateTitle"
+
+	incQueryPath = incidentBasePath + "/IncidentsService.QueryIncidentPreviews"
+	actQueryPath = incidentBasePath + "/ActivityService.QueryActivity"
+	actAddPath   = incidentBasePath + "/ActivityService.AddActivity"
+	sevGetPath   = incidentLegacyBasePath + "/SeveritiesService.GetOrgSeverities"
+	ctxQueryPath = incidentLegacyBasePath + "/IncidentContextService.QueryIncidentContext"
 )
 
 // Client is an HTTP client for the Grafana IRM Incidents API.
@@ -362,6 +370,134 @@ func (c *IncidentClient) Create(ctx context.Context, inc *Incident) (*Incident, 
 		return nil, fmt.Errorf("incidents: decode create response: %w", err)
 	}
 
+	return c.applyRequestedSeverity(ctx, &result.Incident, inc)
+}
+
+// applyRequestedSeverity sets the severity of a new incident when the caller
+// asked for one.
+//
+// CreateIncident ignores both severity and severityID of the request body:
+// every incident starts at the default severity. Severity is the first column
+// of any incident report, so a caller that cannot set it cannot provision
+// reporting by severity. UpdateSeverity is the only route, and it takes the
+// label, not the identifier.
+func (c *IncidentClient) applyRequestedSeverity(ctx context.Context, created, requested *Incident) (*Incident, error) {
+	label, err := c.resolveSeverityLabel(ctx, requested)
+	if err != nil {
+		return nil, err
+	}
+	if label == "" || strings.EqualFold(created.Severity, label) {
+		return created, nil
+	}
+
+	updated, err := c.UpdateSeverity(ctx, created.IncidentID, label)
+	if err != nil {
+		return nil, fmt.Errorf("incidents: create: set severity %q: %w", label, err)
+	}
+	return updated, nil
+}
+
+// resolveSeverityLabel returns the severity label the caller asked for.
+// spec.severity holds the label directly. spec.severityID holds an
+// identifier, which the organization severity list resolves to a label.
+// An empty result means the caller asked for no severity.
+func (c *IncidentClient) resolveSeverityLabel(ctx context.Context, inc *Incident) (string, error) {
+	if inc.Severity != "" {
+		return inc.Severity, nil
+	}
+	if inc.SeverityID == "" {
+		return "", nil
+	}
+
+	severities, err := c.GetSeverities(ctx)
+	if err != nil {
+		return "", fmt.Errorf("incidents: resolve severityID %q: %w", inc.SeverityID, err)
+	}
+	for _, s := range severities {
+		if s.SeverityID == inc.SeverityID {
+			return s.DisplayLabel, nil
+		}
+	}
+	return "", fmt.Errorf("incidents: unknown severityID %q, run `gcx irm incidents severities list` for the valid values", inc.SeverityID)
+}
+
+// UpdateSeverity sets the severity of an incident and returns the updated
+// incident. severity is the display label, not the identifier.
+func (c *IncidentClient) UpdateSeverity(ctx context.Context, id, severity string) (*Incident, error) {
+	req := updateSeverityRequest{IncidentID: id, Severity: severity}
+	return c.updateIncidentField(ctx, incUpdateSeverityMethod, req, "update severity")
+}
+
+// UpdateTitle sets the title of an incident and returns the updated incident.
+func (c *IncidentClient) UpdateTitle(ctx context.Context, id, title string) (*Incident, error) {
+	req := updateTitleRequest{IncidentID: id, Title: title}
+	return c.updateIncidentField(ctx, incUpdateTitleMethod, req, "update title")
+}
+
+// Update applies every field of inc that the IRM API exposes as its own
+// operation: status, title, and severity. The API has no single update
+// method, so each field costs one call, and gcx skips the fields the caller
+// left empty.
+func (c *IncidentClient) Update(ctx context.Context, id string, inc *Incident) (*Incident, error) {
+	current, err := c.UpdateStatus(ctx, id, inc.Status)
+	if err != nil {
+		return nil, err
+	}
+
+	if inc.Title != "" && inc.Title != current.Title {
+		current, err = c.UpdateTitle(ctx, id, inc.Title)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	label, err := c.resolveSeverityLabel(ctx, inc)
+	if err != nil {
+		return nil, err
+	}
+	if label != "" && !strings.EqualFold(current.Severity, label) {
+		current, err = c.UpdateSeverity(ctx, id, label)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return current, nil
+}
+
+// updateIncidentField posts a single-field update to IncidentsService and
+// returns the updated incident.
+//
+// IncidentsService answers on the versioned base path. A Grafana build that
+// predates that path answers on the unversioned one, so a 404 on the first
+// path retries on the second.
+func (c *IncidentClient) updateIncidentField(ctx context.Context, method string, req any, description string) (*Incident, error) {
+	data, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("incidents: marshal %s request: %w", description, err)
+	}
+
+	resp, err := c.doRequest(ctx, incidentBasePath+"/"+method, bytes.NewReader(data))
+	if err != nil {
+		return nil, fmt.Errorf("incidents: %s: %w", description, err)
+	}
+	if resp.StatusCode == http.StatusNotFound {
+		resp.Body.Close()
+		resp, err = c.doRequest(ctx, incidentLegacyBasePath+"/"+method, bytes.NewReader(data))
+		if err != nil {
+			return nil, fmt.Errorf("incidents: %s: %w", description, err)
+		}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, providers.HandleErrorResponse(resp)
+	}
+
+	var result updateStatusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return nil, fmt.Errorf("incidents: decode %s response: %w", description, err)
+	}
 	return &result.Incident, nil
 }
 

--- a/internal/providers/irm/incidents_client.go
+++ b/internal/providers/irm/incidents_client.go
@@ -354,7 +354,6 @@ func (c *IncidentClient) Create(ctx context.Context, inc *Incident) (*Incident, 
 		Labels:         inc.Labels,
 		IncidentType:   inc.IncidentType,
 		FieldGroupUUID: inc.FieldGroupUUID,
-		SeverityID:     inc.SeverityID,
 	}
 	if req.Status == "" {
 		req.Status = "active"

--- a/internal/providers/irm/incidents_client.go
+++ b/internal/providers/irm/incidents_client.go
@@ -470,10 +470,11 @@ func (c *IncidentClient) Create(ctx context.Context, inc *Incident) (*Incident, 
 }
 
 // resolveSeverityLabel returns the severity label the caller asked for.
-// spec.severityID has precedence: when it is not empty, the organization
-// severity list resolves it to a label, and gcx ignores spec.severity.
-// spec.severity holds the label directly. An empty result means the caller
-// asked for no severity.
+// A hand-written spec.severityID has precedence: when it is not empty, the
+// organization severity list resolves it to a label, and gcx ignores
+// spec.severity. A pulled manifest carries spec.severity alone, because the
+// pull removes spec.severityID. An empty result means the caller asked for no
+// severity.
 func (c *IncidentClient) resolveSeverityLabel(ctx context.Context, inc *Incident) (string, error) {
 	if inc.SeverityID == "" {
 		return inc.Severity, nil

--- a/internal/providers/irm/incidents_client.go
+++ b/internal/providers/irm/incidents_client.go
@@ -467,21 +467,20 @@ func (c *IncidentClient) Update(ctx context.Context, id string, inc *Incident) (
 	}
 
 	var applied []string
-	// fail reports a half-applied update: the fields that reached the server
-	// before the failure. The incident stands between two states, so gcx
-	// returns no incident.
-	fail := func(field string, err error) (*Incident, []string, error) {
+	// fail builds the error of a half-applied update: it names the fields that
+	// reached the server before the failure.
+	fail := func(field string, err error) error {
 		if len(applied) == 0 {
-			return nil, nil, err
+			return err
 		}
-		return nil, nil, fmt.Errorf("incidents: update %s: gcx applied the %s, but the %s update failed: %w",
+		return fmt.Errorf("incidents: update %s: gcx applied the %s, but the %s update failed: %w",
 			id, strings.Join(applied, " and the "), field, err)
 	}
 
 	if inc.Status != "" && !strings.EqualFold(current.Status, inc.Status) {
 		updated, err := c.UpdateStatus(ctx, id, inc.Status)
 		if err != nil {
-			return fail("status", err)
+			return nil, nil, fail("status", err)
 		}
 		current = updated
 		applied = append(applied, "status")
@@ -490,7 +489,7 @@ func (c *IncidentClient) Update(ctx context.Context, id string, inc *Incident) (
 	if inc.Title != "" && inc.Title != current.Title {
 		updated, err := c.UpdateTitle(ctx, id, inc.Title)
 		if err != nil {
-			return fail("title", err)
+			return nil, nil, fail("title", err)
 		}
 		current = updated
 		applied = append(applied, "title")
@@ -499,7 +498,7 @@ func (c *IncidentClient) Update(ctx context.Context, id string, inc *Incident) (
 	if label != "" && !strings.EqualFold(current.Severity, label) {
 		updated, err := c.UpdateSeverity(ctx, id, label)
 		if err != nil {
-			return fail("severity", err)
+			return nil, nil, fail("severity", err)
 		}
 		current = updated
 		applied = append(applied, "severity")

--- a/internal/providers/irm/incidents_client.go
+++ b/internal/providers/irm/incidents_client.go
@@ -537,21 +537,20 @@ func (c *IncidentClient) Update(ctx context.Context, id string, inc *Incident) (
 	}
 
 	var applied []string
-	// fail reports a half-applied update: the fields that reached the server
-	// before the failure. The incident stands between two states, so gcx
-	// returns no incident.
-	fail := func(field string, err error) (*Incident, []string, error) {
+	// fail builds the error of a half-applied update: it names the fields that
+	// reached the server before the failure.
+	fail := func(field string, err error) error {
 		if len(applied) == 0 {
-			return nil, nil, err
+			return err
 		}
-		return nil, nil, fmt.Errorf("incidents: update %s: gcx applied the %s, but the %s update failed: %w",
+		return fmt.Errorf("incidents: update %s: gcx applied the %s, but the %s update failed: %w",
 			id, strings.Join(applied, " and the "), field, err)
 	}
 
 	if inc.Status != "" && !strings.EqualFold(current.Status, inc.Status) {
 		updated, err := c.UpdateStatus(ctx, id, inc.Status)
 		if err != nil {
-			return fail("status", err)
+			return nil, nil, fail("status", err)
 		}
 		current = updated
 		applied = append(applied, "status")
@@ -560,7 +559,7 @@ func (c *IncidentClient) Update(ctx context.Context, id string, inc *Incident) (
 	if inc.Title != "" && inc.Title != current.Title {
 		updated, err := c.UpdateTitle(ctx, id, inc.Title)
 		if err != nil {
-			return fail("title", err)
+			return nil, nil, fail("title", err)
 		}
 		current = updated
 		applied = append(applied, "title")
@@ -569,7 +568,7 @@ func (c *IncidentClient) Update(ctx context.Context, id string, inc *Incident) (
 	if label != "" && !strings.EqualFold(current.Severity, label) {
 		updated, err := c.UpdateSeverity(ctx, id, label)
 		if err != nil {
-			return fail("severity", err)
+			return nil, nil, fail("severity", err)
 		}
 		current = updated
 		applied = append(applied, "severity")

--- a/internal/providers/irm/incidents_commands.go
+++ b/internal/providers/irm/incidents_commands.go
@@ -15,6 +15,7 @@ func newIncidentsCmd(loader GrafanaConfigLoader) *cobra.Command {
 		NewListCommand(loader),
 		NewGetCommand(loader),
 		NewCreateCommand(loader),
+		NewUpdateCommand(loader),
 		NewCloseCommand(loader),
 		NewActivityCommand(loader),
 		NewListActivityCommand(loader),

--- a/internal/providers/irm/incidents_commands.go
+++ b/internal/providers/irm/incidents_commands.go
@@ -16,6 +16,7 @@ func newIncidentsCmd(loader GrafanaConfigLoader) *cobra.Command {
 		NewGetCommand(loader),
 		NewGetPIRCommand(loader),
 		NewCreateCommand(loader),
+		NewUpdateCommand(loader),
 		NewCloseCommand(loader),
 		NewActivityCommand(loader),
 		NewListActivityCommand(loader),

--- a/internal/providers/irm/incidents_commands_impl.go
+++ b/internal/providers/irm/incidents_commands_impl.go
@@ -319,6 +319,10 @@ func NewCreateCommand(loader GrafanaConfigLoader) *cobra.Command {
   spec:
     title: "Service degradation in production"
     status: active
+    # The display label, not the identifier. Run
+    # 'gcx irm incidents severities list' for the valid values.
+    # severityID has precedence: gcx ignores severity when you set both.
+    severity: Minor
     isDrill: false
     incidentType: internal
     labels:

--- a/internal/providers/irm/incidents_commands_impl.go
+++ b/internal/providers/irm/incidents_commands_impl.go
@@ -384,6 +384,13 @@ func NewCreateCommand(loader GrafanaConfigLoader) *cobra.Command {
 
 			created, err := client.Create(ctx, inc)
 			if err != nil {
+				// Create reports the incident next to the error when the
+				// incident exists but a later step failed. That error already
+				// names the incident and the repair command, so a
+				// "failed to create incident" prefix would contradict it.
+				if created != nil {
+					return err
+				}
 				return fmt.Errorf("failed to create incident: %w", err)
 			}
 

--- a/internal/providers/irm/incidents_commands_impl.go
+++ b/internal/providers/irm/incidents_commands_impl.go
@@ -422,7 +422,6 @@ func NewCreateCommand(loader GrafanaConfigLoader) *cobra.Command {
     status: active
     # The display label, not the identifier. Run
     # 'gcx irm incidents severities list' for the valid values.
-    # severityID has precedence: gcx ignores severity when you set both.
     severity: Minor
     isDrill: false
     incidentType: internal

--- a/internal/providers/irm/incidents_commands_impl.go
+++ b/internal/providers/irm/incidents_commands_impl.go
@@ -420,6 +420,10 @@ func NewCreateCommand(loader GrafanaConfigLoader) *cobra.Command {
   spec:
     title: "Service degradation in production"
     status: active
+    # The display label, not the identifier. Run
+    # 'gcx irm incidents severities list' for the valid values.
+    # severityID has precedence: gcx ignores severity when you set both.
+    severity: Minor
     isDrill: false
     incidentType: internal
     labels:

--- a/internal/providers/irm/incidents_commands_impl.go
+++ b/internal/providers/irm/incidents_commands_impl.go
@@ -485,6 +485,13 @@ func NewCreateCommand(loader GrafanaConfigLoader) *cobra.Command {
 
 			created, err := client.Create(ctx, inc)
 			if err != nil {
+				// Create reports the incident next to the error when the
+				// incident exists but a later step failed. That error already
+				// names the incident and the repair command, so a
+				// "failed to create incident" prefix would contradict it.
+				if created != nil {
+					return err
+				}
 				return fmt.Errorf("failed to create incident: %w", err)
 			}
 

--- a/internal/providers/irm/incidents_commands_impl.go
+++ b/internal/providers/irm/incidents_commands_impl.go
@@ -321,7 +321,6 @@ func NewCreateCommand(loader GrafanaConfigLoader) *cobra.Command {
     status: active
     # The display label, not the identifier. Run
     # 'gcx irm incidents severities list' for the valid values.
-    # severityID has precedence: gcx ignores severity when you set both.
     severity: Minor
     isDrill: false
     incidentType: internal

--- a/internal/providers/irm/incidents_resource_adapter.go
+++ b/internal/providers/irm/incidents_resource_adapter.go
@@ -161,7 +161,9 @@ func newIncidentCRUD(client *IncidentClient, namespace string, query IncidentQue
 		GetFn:    func(ctx context.Context, name string) (*Incident, error) { return client.Get(ctx, name) },
 		CreateFn: func(ctx context.Context, inc *Incident) (*Incident, error) { return client.Create(ctx, inc) },
 		UpdateFn: func(ctx context.Context, name string, inc *Incident) (*Incident, error) {
-			return client.Update(ctx, name, inc)
+			// The push reports the manifest, not the list of changed fields.
+			updated, _, err := client.Update(ctx, name, inc)
+			return updated, err
 		},
 		DeleteFn: func(_ context.Context, _ string) error {
 			return errors.New("incidents: delete is not supported by the IRM API")

--- a/internal/providers/irm/incidents_resource_adapter.go
+++ b/internal/providers/irm/incidents_resource_adapter.go
@@ -76,6 +76,7 @@ func IncidentExample() json.RawMessage {
 		"spec": map[string]any{
 			"title":        "Service degradation in production",
 			"status":       "active",
+			"severity":     "Minor",
 			"isDrill":      false,
 			"incidentType": "internal",
 			"labels": []map[string]any{
@@ -140,7 +141,7 @@ func newIncidentCRUD(client *IncidentClient, namespace string, query IncidentQue
 		GetFn:    func(ctx context.Context, name string) (*Incident, error) { return client.Get(ctx, name) },
 		CreateFn: func(ctx context.Context, inc *Incident) (*Incident, error) { return client.Create(ctx, inc) },
 		UpdateFn: func(ctx context.Context, name string, inc *Incident) (*Incident, error) {
-			return client.UpdateStatus(ctx, name, inc.Status)
+			return client.Update(ctx, name, inc)
 		},
 		DeleteFn: func(_ context.Context, _ string) error {
 			return errors.New("incidents: delete is not supported by the IRM API")

--- a/internal/providers/irm/incidents_resource_adapter.go
+++ b/internal/providers/irm/incidents_resource_adapter.go
@@ -146,7 +146,12 @@ func newIncidentCRUD(client *IncidentClient, namespace string, query IncidentQue
 		DeleteFn: func(_ context.Context, _ string) error {
 			return errors.New("incidents: delete is not supported by the IRM API")
 		},
-		StripFields: []string{"incidentID"},
+		// The pull removes severityID next to incidentID. A manifest that
+		// carries the identifier and the label together makes an edit of the
+		// label unreachable, because the identifier has precedence in the
+		// client. The identifiers are also specific to one organization, so a
+		// manifest that carries one does not push to a second stack.
+		StripFields: []string{"incidentID", "severityID"},
 		Namespace:   namespace,
 		Descriptor:  incidentStaticDescriptor,
 	}

--- a/internal/providers/irm/incidents_resource_adapter.go
+++ b/internal/providers/irm/incidents_resource_adapter.go
@@ -25,6 +25,19 @@ var incidentStaticDescriptor = resources.Descriptor{
 	Plural:   "incidents",
 }
 
+// incidentStripFields lists the spec keys that a read removes. Both access
+// paths use it: the resources commands through TypedCRUD.StripFields, and the
+// provider commands through ToResource. One list keeps the two outputs equal.
+//
+// incidentID lives in metadata.name. severityID goes with it, because the
+// identifier has precedence over the severity label in the client, and a
+// manifest that carries both makes an edit of the label unreachable. The
+// identifiers are also specific to one organization, so a manifest that
+// carries one does not push to a second stack.
+//
+//nolint:gochecknoglobals // Static list shared by the two access paths.
+var incidentStripFields = []string{"incidentID", "severityID"}
+
 // incidentSchema returns a JSON Schema for the Incident resource type.
 func IncidentSchema() json.RawMessage {
 	schema := map[string]any{
@@ -44,10 +57,17 @@ func IncidentSchema() json.RawMessage {
 			"spec": map[string]any{
 				"type": "object",
 				"properties": map[string]any{
-					"title":        map[string]any{"type": "string"},
-					"status":       map[string]any{"type": "string"},
-					"severity":     map[string]any{"type": "string"},
-					"severityID":   map[string]any{"type": "string"},
+					"title":  map[string]any{"type": "string"},
+					"status": map[string]any{"type": "string"},
+					"severity": map[string]any{
+						"type":        "string",
+						"description": "Severity display label, for example \"Critical\". Run `gcx irm incidents severities list` for the labels of the organization.",
+					},
+					"severityID": map[string]any{
+						"type": "string",
+						"description": "Write-only severity identifier. A push accepts it, where it has precedence over spec.severity. " +
+							"A read never returns it, so a pulled manifest carries spec.severity alone.",
+					},
 					"isDrill":      map[string]any{"type": "boolean"},
 					"incidentType": map[string]any{"type": "string"},
 					"description":  map[string]any{"type": "string"},
@@ -146,12 +166,7 @@ func newIncidentCRUD(client *IncidentClient, namespace string, query IncidentQue
 		DeleteFn: func(_ context.Context, _ string) error {
 			return errors.New("incidents: delete is not supported by the IRM API")
 		},
-		// The pull removes severityID next to incidentID. A manifest that
-		// carries the identifier and the label together makes an edit of the
-		// label unreachable, because the identifier has precedence in the
-		// client. The identifiers are also specific to one organization, so a
-		// manifest that carries one does not push to a second stack.
-		StripFields: []string{"incidentID", "severityID"},
+		StripFields: incidentStripFields,
 		Namespace:   namespace,
 		Descriptor:  incidentStaticDescriptor,
 	}

--- a/internal/providers/irm/incidents_resource_adapter_test.go
+++ b/internal/providers/irm/incidents_resource_adapter_test.go
@@ -390,8 +390,7 @@ func specKeys(t *testing.T, obj *unstructured.Unstructured) []string {
 	spec, found, err := unstructured.NestedMap(obj.Object, "spec")
 	require.NoError(t, err)
 	require.True(t, found, "spec field should be present")
-	keys := slices.Sorted(maps.Keys(spec))
-	return keys
+	return slices.Sorted(maps.Keys(spec))
 }
 
 func TestResourceAdapter_ListPopulatesMetadata(t *testing.T) {

--- a/internal/providers/irm/incidents_resource_adapter_test.go
+++ b/internal/providers/irm/incidents_resource_adapter_test.go
@@ -2,8 +2,10 @@ package irm_test
 
 import (
 	"encoding/json"
+	"maps"
 	"net/http"
 	"net/http/httptest"
+	"slices"
 	"strings"
 	"testing"
 
@@ -342,6 +344,54 @@ func TestResourceAdapter_PullDropsSeverityID(t *testing.T) {
 		assert.NotContains(t, spec, "severityID", "%s: the pull removes severityID", name)
 		assert.NotContains(t, spec, "incidentID", "%s: the pull removes incidentID", name)
 	}
+}
+
+// TestBothAccessPathsEmitTheSameSpecKeys proves that the two access paths
+// describe one incident with one key set. `gcx irm incidents get|create|update`
+// converts with ToResource, and `gcx resources get|list|pull` converts through
+// the adapter. CONSTITUTION.md requires the two outputs to be identical, so a
+// `--jq .spec.severityID` caller gets one answer, whichever command produced
+// the manifest.
+func TestBothAccessPathsEmitTheSameSpecKeys(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		writeJSON(w, map[string]any{
+			"incident": map[string]any{
+				"incidentID": "inc-1", "title": "Outage", "status": "active",
+				"severity": "Major", "severityID": "sev-2",
+				"incidentType": "internal", "description": "the disk is full",
+				"labels": []map[string]any{{"key": "team", "label": "platform"}},
+			},
+		})
+	}))
+	defer server.Close()
+
+	// The resources path.
+	a := newTestAdapter(t, server, "stack-123")
+	viaAdapter, err := a.Get(t.Context(), "inc-1", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	// The provider path.
+	inc, err := newTestClient(t, server).Get(t.Context(), "inc-1")
+	require.NoError(t, err)
+	res, err := irm.ToResource(*inc, "stack-123")
+	require.NoError(t, err)
+	viaProvider := res.ToUnstructured()
+
+	adapterKeys := specKeys(t, viaAdapter)
+	providerKeys := specKeys(t, &viaProvider)
+	assert.Equal(t, adapterKeys, providerKeys, "the two access paths must emit the same spec keys")
+	assert.NotContains(t, adapterKeys, "severityID")
+	assert.NotContains(t, adapterKeys, "incidentID")
+}
+
+// specKeys returns the sorted spec keys of a manifest.
+func specKeys(t *testing.T, obj *unstructured.Unstructured) []string {
+	t.Helper()
+	spec, found, err := unstructured.NestedMap(obj.Object, "spec")
+	require.NoError(t, err)
+	require.True(t, found, "spec field should be present")
+	keys := slices.Sorted(maps.Keys(spec))
+	return keys
 }
 
 func TestResourceAdapter_ListPopulatesMetadata(t *testing.T) {

--- a/internal/providers/irm/incidents_resource_adapter_test.go
+++ b/internal/providers/irm/incidents_resource_adapter_test.go
@@ -299,6 +299,51 @@ func TestResourceAdapter_RoundTrip(t *testing.T) {
 	assert.Equal(t, originalInc.Description, restored.Description)
 }
 
+// TestResourceAdapter_PullDropsSeverityID proves that a pulled manifest
+// carries the severity label alone. A manifest with both fields makes an edit
+// of the label unreachable, because severityID has precedence in the client.
+func TestResourceAdapter_PullDropsSeverityID(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "IncidentsService.GetIncident") {
+			writeJSON(w, map[string]any{
+				"incident": map[string]any{
+					"incidentID": "inc-1", "title": "Outage", "status": "active",
+					"severity": "Major", "severityID": "sev-2",
+				},
+			})
+			return
+		}
+		writeJSON(w, map[string]any{
+			"incidentPreviews": []map[string]any{
+				{
+					"incidentID": "inc-1", "title": "Outage", "status": "active",
+					"severityLabel": "Major", "severityID": "sev-2",
+				},
+			},
+			"cursor": map[string]any{"hasMore": false},
+		})
+	}))
+	defer server.Close()
+
+	a := newTestAdapter(t, server, "stack-123")
+
+	got, err := a.Get(t.Context(), "inc-1", metav1.GetOptions{})
+	require.NoError(t, err)
+
+	list, err := a.List(t.Context(), metav1.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, list.Items, 1)
+
+	for name, obj := range map[string]*unstructured.Unstructured{"get": got, "list": &list.Items[0]} {
+		spec, found, err := unstructured.NestedMap(obj.Object, "spec")
+		require.NoError(t, err)
+		require.True(t, found, "%s: spec field should be present", name)
+		assert.Equal(t, "Major", spec["severity"], "%s: the pull keeps the severity label", name)
+		assert.NotContains(t, spec, "severityID", "%s: the pull removes severityID", name)
+		assert.NotContains(t, spec, "incidentID", "%s: the pull removes incidentID", name)
+	}
+}
+
 func TestResourceAdapter_ListPopulatesMetadata(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		writeJSON(w, map[string]any{

--- a/internal/providers/irm/incidents_resource_adapter_test.go
+++ b/internal/providers/irm/incidents_resource_adapter_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/grafana/gcx/internal/config"
@@ -208,14 +209,26 @@ func TestResourceAdapter_Create(t *testing.T) {
 }
 
 func TestResourceAdapter_Update(t *testing.T) {
+	// Update reads the incident first, so the title and the severity guards
+	// compare the manifest against the server.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Contains(t, r.URL.Path, "IncidentsService.UpdateStatus")
 		var body map[string]any
 		_ = json.NewDecoder(r.Body).Decode(&body)
 		assert.Equal(t, "inc-789", body["incidentID"])
-		writeJSON(w, map[string]any{
-			"incident": map[string]any{"incidentID": "inc-789", "title": "Updated", "status": "resolved"},
-		})
+
+		switch {
+		case strings.Contains(r.URL.Path, "IncidentsService.GetIncident"):
+			writeJSON(w, map[string]any{
+				"incident": map[string]any{"incidentID": "inc-789", "title": "Old", "status": "active"},
+			})
+		case strings.Contains(r.URL.Path, "IncidentsService.UpdateStatus"),
+			strings.Contains(r.URL.Path, "IncidentsService.UpdateTitle"):
+			writeJSON(w, map[string]any{
+				"incident": map[string]any{"incidentID": "inc-789", "title": "Updated", "status": "resolved"},
+			})
+		default:
+			t.Errorf("unexpected call to %q", r.URL.Path)
+		}
 	}))
 	defer server.Close()
 

--- a/internal/providers/irm/incidents_severity_test.go
+++ b/internal/providers/irm/incidents_severity_test.go
@@ -311,15 +311,15 @@ func TestUpdateFieldReportsAMissingIncident(t *testing.T) {
 }
 
 // TestUpdateReportsAHalfAppliedChange covers a failure after an earlier field
-// reached the server. The caller needs the incident as the server holds it,
-// and the name of the field that gcx applied.
+// reached the server. The incident stands between two states, so gcx returns
+// no incident, and the error names the field that gcx applied.
 func TestUpdateReportsAHalfAppliedChange(t *testing.T) {
 	t.Parallel()
 
 	srv := &severityServer{title: "old title", status: "active", failTitleUpdate: true}
 	client := newSeverityTestClient(t, srv)
 
-	got, err := client.Update(context.Background(), "1", &irm.Incident{
+	got, _, err := client.Update(context.Background(), "1", &irm.Incident{
 		Status:   "resolved",
 		Title:    "new title",
 		Severity: "Critical",
@@ -327,8 +327,8 @@ func TestUpdateReportsAHalfAppliedChange(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected an error from the failed title update")
 	}
-	if got == nil || got.Status != "resolved" {
-		t.Fatalf("expected the incident with the applied status next to the error, got %+v", got)
+	if got != nil {
+		t.Fatalf("expected no incident next to the error, got %+v", got)
 	}
 	for _, want := range []string{"update 1", "gcx applied the status", "title update failed"} {
 		if !strings.Contains(err.Error(), want) {
@@ -343,6 +343,41 @@ func TestUpdateReportsAHalfAppliedChange(t *testing.T) {
 	}
 }
 
+// TestUpdateRejectsAnUnknownSeverityIDBeforeItWrites covers a manifest with an
+// unknown spec.severityID. The resolve reads only, so it runs before the first
+// write: the IRM API cannot undo a write that a later step abandons. The error
+// must not report a failed severity update either, because gcx tried none.
+func TestUpdateRejectsAnUnknownSeverityIDBeforeItWrites(t *testing.T) {
+	t.Parallel()
+
+	srv := &severityServer{
+		title:      "old title",
+		status:     "active",
+		severities: []map[string]any{{"severityID": "sev-1", "displayLabel": "Critical", "level": 1}},
+	}
+	client := newSeverityTestClient(t, srv)
+
+	got, _, err := client.Update(context.Background(), "1", &irm.Incident{
+		Status:     "resolved",
+		Title:      "new title",
+		SeverityID: "does-not-exist",
+	})
+	if err == nil || !strings.Contains(err.Error(), "unknown severityID") {
+		t.Fatalf("expected an unknown-severityID error, got %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected no incident, got %+v", got)
+	}
+	if strings.Contains(err.Error(), "update failed") {
+		t.Errorf("gcx tried no update, so the error must not report one: %v", err)
+	}
+	for _, call := range srv.calls {
+		if strings.HasPrefix(call, "IncidentsService.Update") {
+			t.Fatalf("the client wrote before it resolved the severity: %v", srv.calls)
+		}
+	}
+}
+
 // TestUpdateReportsTheFirstFailureAlone covers a failure before any field
 // reached the server: the error stands on its own, and there is no incident
 // to report.
@@ -352,7 +387,7 @@ func TestUpdateReportsTheFirstFailureAlone(t *testing.T) {
 	srv := &severityServer{title: "old title", status: "active", failTitleUpdate: true}
 	client := newSeverityTestClient(t, srv)
 
-	got, err := client.Update(context.Background(), "1", &irm.Incident{Title: "new title"})
+	got, _, err := client.Update(context.Background(), "1", &irm.Incident{Title: "new title"})
 	if err == nil {
 		t.Fatal("expected an error from the failed title update")
 	}
@@ -418,13 +453,16 @@ func TestUpdateAppliesEveryChangedField(t *testing.T) {
 	srv := &severityServer{title: "old title"}
 	client := newSeverityTestClient(t, srv)
 
-	got, err := client.Update(context.Background(), "1", &irm.Incident{
+	got, changed, err := client.Update(context.Background(), "1", &irm.Incident{
 		Status:   "active",
 		Title:    "new title",
 		Severity: "Critical",
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Join(changed, ",") != "status,title,severity" {
+		t.Errorf("got changed fields %v, want status, title and severity", changed)
 	}
 
 	want := []string{
@@ -472,12 +510,16 @@ func TestUpdateSkipsUnchangedFields(t *testing.T) {
 			}
 			client := newSeverityTestClient(t, srv)
 
-			if _, err := client.Update(context.Background(), "1", &irm.Incident{
+			_, changed, err := client.Update(context.Background(), "1", &irm.Incident{
 				Status:   tt.status,
 				Title:    "same title",
 				Severity: "Critical",
-			}); err != nil {
+			})
+			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(changed) != 0 {
+				t.Errorf("got changed fields %v, want none", changed)
 			}
 
 			want := []string{"IncidentsService.GetIncident"}
@@ -497,7 +539,7 @@ func TestUpdateSkipsAnEmptyStatus(t *testing.T) {
 	srv := &severityServer{title: "old title", status: "active"}
 	client := newSeverityTestClient(t, srv)
 
-	if _, err := client.Update(context.Background(), "1", &irm.Incident{
+	if _, _, err := client.Update(context.Background(), "1", &irm.Incident{
 		Title:    "new title",
 		Severity: "Critical",
 	}); err != nil {

--- a/internal/providers/irm/incidents_severity_test.go
+++ b/internal/providers/irm/incidents_severity_test.go
@@ -1,0 +1,281 @@
+package irm_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers/irm"
+)
+
+// severityServer records every incident call and answers CreateIncident with
+// the default severity, the way the live backend does: CreateIncident ignores
+// the severity of the request body.
+type severityServer struct {
+	calls      []string
+	bodies     []map[string]any
+	severities []map[string]any
+	// severityAfterUpdate is the label the server reports once UpdateSeverity
+	// has run.
+	severityAfterUpdate string
+	title               string
+	// notFoundOnVersioned makes the versioned base path answer 404, so the
+	// test can drive the unversioned fallback.
+	notFoundOnVersioned bool
+}
+
+func (s *severityServer) handler(t *testing.T) http.Handler {
+	t.Helper()
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		method := r.URL.Path[strings.LastIndex(r.URL.Path, "/")+1:]
+		versioned := strings.Contains(r.URL.Path, "/api/v1/")
+
+		var body map[string]any
+		json.NewDecoder(r.Body).Decode(&body) //nolint:errcheck
+		s.calls = append(s.calls, method)
+		s.bodies = append(s.bodies, body)
+
+		if s.notFoundOnVersioned && versioned &&
+			(method == "IncidentsService.UpdateSeverity" || method == "IncidentsService.UpdateTitle") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		switch method {
+		case "SeveritiesService.GetOrgSeverities":
+			json.NewEncoder(w).Encode(map[string]any{"severities": s.severities}) //nolint:errcheck
+		case "IncidentsService.CreateIncident":
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"incident": map[string]any{"incidentID": "1", "title": s.title, "severity": "Pending"},
+			})
+		case "IncidentsService.UpdateSeverity":
+			s.severityAfterUpdate, _ = body["severity"].(string)
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"incident": map[string]any{"incidentID": "1", "title": s.title, "severity": s.severityAfterUpdate},
+			})
+		case "IncidentsService.UpdateTitle":
+			s.title, _ = body["title"].(string)
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"incident": map[string]any{"incidentID": "1", "title": s.title, "severity": s.severityAfterUpdate},
+			})
+		case "IncidentsService.UpdateStatus":
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"incident": map[string]any{
+					"incidentID": "1", "title": s.title, "severity": s.severityAfterUpdate,
+					"status": body["status"],
+				},
+			})
+		default:
+			t.Errorf("unexpected call to %q", r.URL.Path)
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+}
+
+func newSeverityTestClient(t *testing.T, s *severityServer) *irm.IncidentClient {
+	t.Helper()
+	srv := httptest.NewServer(s.handler(t))
+	t.Cleanup(srv.Close)
+	return newTestClient(t, srv)
+}
+
+// TestCreateAppliesSeverity is the regression test for the reported defect:
+// every incident was created at the default severity, whichever severity the
+// manifest asked for.
+func TestCreateAppliesSeverity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		incident     irm.Incident
+		wantSeverity string
+		wantCalls    []string
+	}{
+		{
+			name:         "severity label on the spec",
+			incident:     irm.Incident{Title: "probe", Severity: "Critical"},
+			wantSeverity: "Critical",
+			wantCalls:    []string{"IncidentsService.CreateIncident", "IncidentsService.UpdateSeverity"},
+		},
+		{
+			name:         "severityID resolved through the organization severities",
+			incident:     irm.Incident{Title: "probe", SeverityID: "sev-2"},
+			wantSeverity: "Major",
+			wantCalls: []string{
+				"IncidentsService.CreateIncident",
+				"SeveritiesService.GetOrgSeverities",
+				"IncidentsService.UpdateSeverity",
+			},
+		},
+		{
+			name:         "no severity asked for leaves the default alone",
+			incident:     irm.Incident{Title: "probe"},
+			wantSeverity: "",
+			wantCalls:    []string{"IncidentsService.CreateIncident"},
+		},
+		{
+			name:         "the default severity needs no second call",
+			incident:     irm.Incident{Title: "probe", Severity: "Pending"},
+			wantSeverity: "",
+			wantCalls:    []string{"IncidentsService.CreateIncident"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := &severityServer{
+				title: "probe",
+				severities: []map[string]any{
+					{"severityID": "sev-1", "displayLabel": "Critical", "level": 1},
+					{"severityID": "sev-2", "displayLabel": "Major", "level": 2},
+				},
+			}
+			client := newSeverityTestClient(t, srv)
+
+			inc := tt.incident
+			got, err := client.Create(context.Background(), &inc)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(srv.calls) != len(tt.wantCalls) {
+				t.Fatalf("got calls %v, want %v", srv.calls, tt.wantCalls)
+			}
+			for i, want := range tt.wantCalls {
+				if srv.calls[i] != want {
+					t.Errorf("call %d: got %q, want %q", i, srv.calls[i], want)
+				}
+			}
+			if srv.severityAfterUpdate != tt.wantSeverity {
+				t.Errorf("got severity %q on the server, want %q", srv.severityAfterUpdate, tt.wantSeverity)
+			}
+			if tt.wantSeverity != "" && got.Severity != tt.wantSeverity {
+				t.Errorf("got severity %q in the result, want %q", got.Severity, tt.wantSeverity)
+			}
+		})
+	}
+}
+
+func TestCreateRejectsUnknownSeverityID(t *testing.T) {
+	t.Parallel()
+
+	srv := &severityServer{
+		title:      "probe",
+		severities: []map[string]any{{"severityID": "sev-1", "displayLabel": "Critical", "level": 1}},
+	}
+	client := newSeverityTestClient(t, srv)
+
+	inc := irm.Incident{Title: "probe", SeverityID: "does-not-exist"}
+	_, err := client.Create(context.Background(), &inc)
+	if err == nil || !strings.Contains(err.Error(), "unknown severityID") {
+		t.Errorf("expected an unknown-severityID error, got %v", err)
+	}
+}
+
+func TestUpdateSeverityAndTitle(t *testing.T) {
+	t.Parallel()
+
+	srv := &severityServer{title: "old title"}
+	client := newSeverityTestClient(t, srv)
+
+	if _, err := client.UpdateTitle(context.Background(), "1", "new title"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got, err := client.UpdateSeverity(context.Background(), "1", "Critical")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got.Title != "new title" || got.Severity != "Critical" {
+		t.Errorf("unexpected incident: %+v", got)
+	}
+	if srv.bodies[0]["incidentID"] != "1" || srv.bodies[0]["title"] != "new title" {
+		t.Errorf("unexpected UpdateTitle body: %v", srv.bodies[0])
+	}
+	if srv.bodies[1]["incidentID"] != "1" || srv.bodies[1]["severity"] != "Critical" {
+		t.Errorf("unexpected UpdateSeverity body: %v", srv.bodies[1])
+	}
+}
+
+// TestUpdateFallsBackToUnversionedPath covers a Grafana build that predates
+// the versioned base path of IncidentsService.
+func TestUpdateFallsBackToUnversionedPath(t *testing.T) {
+	t.Parallel()
+
+	srv := &severityServer{title: "probe", notFoundOnVersioned: true}
+	client := newSeverityTestClient(t, srv)
+
+	got, err := client.UpdateSeverity(context.Background(), "1", "Critical")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Severity != "Critical" {
+		t.Errorf("got severity %q, want Critical", got.Severity)
+	}
+	// One call on the versioned path, one on the unversioned path.
+	if len(srv.calls) != 2 {
+		t.Errorf("expected a retry on the unversioned path, got calls %v", srv.calls)
+	}
+}
+
+// TestUpdateAppliesEveryChangedField covers the push path: the adapter calls
+// Update, which must carry the title and the severity, not the status alone.
+func TestUpdateAppliesEveryChangedField(t *testing.T) {
+	t.Parallel()
+
+	srv := &severityServer{title: "old title"}
+	client := newSeverityTestClient(t, srv)
+
+	got, err := client.Update(context.Background(), "1", &irm.Incident{
+		Status:   "active",
+		Title:    "new title",
+		Severity: "Critical",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []string{
+		"IncidentsService.UpdateStatus",
+		"IncidentsService.UpdateTitle",
+		"IncidentsService.UpdateSeverity",
+	}
+	if len(srv.calls) != len(want) {
+		t.Fatalf("got calls %v, want %v", srv.calls, want)
+	}
+	for i, w := range want {
+		if srv.calls[i] != w {
+			t.Errorf("call %d: got %q, want %q", i, srv.calls[i], w)
+		}
+	}
+	if got.Title != "new title" || got.Severity != "Critical" {
+		t.Errorf("unexpected incident: %+v", got)
+	}
+}
+
+// TestUpdateSkipsUnchangedFields keeps the push path cheap: a manifest that
+// matches the server costs one call, not three.
+func TestUpdateSkipsUnchangedFields(t *testing.T) {
+	t.Parallel()
+
+	srv := &severityServer{title: "same title", severityAfterUpdate: "Critical"}
+	client := newSeverityTestClient(t, srv)
+
+	if _, err := client.Update(context.Background(), "1", &irm.Incident{
+		Status:   "active",
+		Title:    "same title",
+		Severity: "Critical",
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(srv.calls) != 1 || srv.calls[0] != "IncidentsService.UpdateStatus" {
+		t.Errorf("expected only a status call, got %v", srv.calls)
+	}
+}

--- a/internal/providers/irm/incidents_severity_test.go
+++ b/internal/providers/irm/incidents_severity_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/grafana/gcx/internal/providers/irm"
+	"github.com/spf13/cobra"
 )
 
 // severityServer records every incident call and answers CreateIncident with
@@ -236,6 +237,38 @@ func TestCreateReportsTheIncidentAfterAFailedSeverityUpdate(t *testing.T) {
 		if !strings.Contains(err.Error(), want) {
 			t.Errorf("expected %q in the error, got %v", want, err)
 		}
+	}
+}
+
+const createSeverityManifest = `apiVersion: incident.ext.grafana.app/v1alpha1
+kind: Incident
+metadata:
+  name: my-incident
+spec:
+  title: "probe"
+  status: active
+  severity: Critical
+`
+
+// TestCreateCommandKeepsTheRepairErrorAlone covers the second failure path of
+// the create command. The incident exists, so the command must not report a
+// failed create next to the repair command that the client error carries.
+func TestCreateCommandKeepsTheRepairErrorAlone(t *testing.T) {
+	srv := &severityServer{title: "probe", failSeverityUpdate: true}
+	server := httptest.NewServer(srv.handler(t))
+	t.Cleanup(server.Close)
+
+	_, _, err := runIncidentCmd(t, func() *cobra.Command {
+		return irm.NewCreateCommand(incidentLoader(server))
+	}, createSeverityManifest, "-f", "-")
+	if err == nil {
+		t.Fatal("expected the failed-severity error")
+	}
+	if strings.Contains(err.Error(), "failed to create incident") {
+		t.Errorf("the incident exists, so the error must not report a failed create: %v", err)
+	}
+	if !strings.Contains(err.Error(), "incident 1 exists") {
+		t.Errorf("expected the repair error of the client, got %v", err)
 	}
 }
 

--- a/internal/providers/irm/incidents_severity_test.go
+++ b/internal/providers/irm/incidents_severity_test.go
@@ -3,6 +3,7 @@ package irm_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -30,6 +31,12 @@ type severityServer struct {
 	// failSeverityUpdate makes UpdateSeverity answer 500, so the test can
 	// drive the failure path of Create.
 	failSeverityUpdate bool
+	// failTitleUpdate makes UpdateTitle answer 500, so the test can drive a
+	// partial update.
+	failTitleUpdate bool
+	// incidentMissing makes every update method answer 404 on both base paths,
+	// the way the API reports an unknown incidentID.
+	incidentMissing bool
 }
 
 func (s *severityServer) handler(t *testing.T) http.Handler {
@@ -47,7 +54,15 @@ func (s *severityServer) handler(t *testing.T) http.Handler {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
+		if s.incidentMissing && strings.HasPrefix(method, "IncidentsService.Update") {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
 		if s.failSeverityUpdate && method == "IncidentsService.UpdateSeverity" {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		if s.failTitleUpdate && method == "IncidentsService.UpdateTitle" {
 			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
@@ -269,6 +284,83 @@ func TestCreateCommandKeepsTheRepairErrorAlone(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "incident 1 exists") {
 		t.Errorf("expected the repair error of the client, got %v", err)
+	}
+}
+
+// TestUpdateFieldReportsAMissingIncident covers an unknown incidentID. Both
+// base paths answer 404, so a missing route is not the cause. The caller must
+// read the identifier and the not-found classification that Get produces, not
+// a bare status line.
+func TestUpdateFieldReportsAMissingIncident(t *testing.T) {
+	t.Parallel()
+
+	srv := &severityServer{title: "probe", incidentMissing: true}
+	client := newSeverityTestClient(t, srv)
+
+	_, err := client.UpdateSeverity(context.Background(), "does-not-exist", "Critical")
+	if !errors.Is(err, irm.ErrNotFound) {
+		t.Fatalf("expected a not-found error, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "does-not-exist") {
+		t.Errorf("expected the incident identifier in the error, got %v", err)
+	}
+	// One call on the versioned path, one on the unversioned path.
+	if len(srv.calls) != 2 {
+		t.Errorf("expected two calls, got %v", srv.calls)
+	}
+}
+
+// TestUpdateReportsAHalfAppliedChange covers a failure after an earlier field
+// reached the server. The caller needs the incident as the server holds it,
+// and the name of the field that gcx applied.
+func TestUpdateReportsAHalfAppliedChange(t *testing.T) {
+	t.Parallel()
+
+	srv := &severityServer{title: "old title", status: "active", failTitleUpdate: true}
+	client := newSeverityTestClient(t, srv)
+
+	got, err := client.Update(context.Background(), "1", &irm.Incident{
+		Status:   "resolved",
+		Title:    "new title",
+		Severity: "Critical",
+	})
+	if err == nil {
+		t.Fatal("expected an error from the failed title update")
+	}
+	if got == nil || got.Status != "resolved" {
+		t.Fatalf("expected the incident with the applied status next to the error, got %+v", got)
+	}
+	for _, want := range []string{"update 1", "gcx applied the status", "title update failed"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("expected %q in the error, got %v", want, err)
+		}
+	}
+	// The severity call must not run after the title failed.
+	for _, call := range srv.calls {
+		if call == "IncidentsService.UpdateSeverity" {
+			t.Fatalf("the client continued after a failed update: %v", srv.calls)
+		}
+	}
+}
+
+// TestUpdateReportsTheFirstFailureAlone covers a failure before any field
+// reached the server: the error stands on its own, and there is no incident
+// to report.
+func TestUpdateReportsTheFirstFailureAlone(t *testing.T) {
+	t.Parallel()
+
+	srv := &severityServer{title: "old title", status: "active", failTitleUpdate: true}
+	client := newSeverityTestClient(t, srv)
+
+	got, err := client.Update(context.Background(), "1", &irm.Incident{Title: "new title"})
+	if err == nil {
+		t.Fatal("expected an error from the failed title update")
+	}
+	if got != nil {
+		t.Errorf("expected no incident, got %+v", got)
+	}
+	if strings.Contains(err.Error(), "gcx applied") {
+		t.Errorf("expected no applied field in the error, got %v", err)
 	}
 }
 

--- a/internal/providers/irm/incidents_severity_test.go
+++ b/internal/providers/irm/incidents_severity_test.go
@@ -322,24 +322,44 @@ func TestUpdateAppliesEveryChangedField(t *testing.T) {
 }
 
 // TestUpdateSkipsUnchangedFields keeps the push path cheap: a manifest that
-// matches the server costs the read and one write, not three writes.
+// matches the server costs the read alone, and `gcx resources push` writes
+// nothing on a second run. The status compares like the severity, so a
+// difference in letter case causes no write either.
 func TestUpdateSkipsUnchangedFields(t *testing.T) {
 	t.Parallel()
 
-	srv := &severityServer{title: "same title", severityAfterUpdate: "Critical"}
-	client := newSeverityTestClient(t, srv)
-
-	if _, err := client.Update(context.Background(), "1", &irm.Incident{
-		Status:   "active",
-		Title:    "same title",
-		Severity: "Critical",
-	}); err != nil {
-		t.Fatalf("unexpected error: %v", err)
+	tests := []struct {
+		name   string
+		status string
+	}{
+		{name: "the same status", status: "active"},
+		{name: "the same status in other letter case", status: "ACTIVE"},
 	}
 
-	want := []string{"IncidentsService.GetIncident", "IncidentsService.UpdateStatus"}
-	if len(srv.calls) != len(want) || srv.calls[0] != want[0] || srv.calls[1] != want[1] {
-		t.Errorf("got calls %v, want %v", srv.calls, want)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := &severityServer{
+				title:               "same title",
+				status:              "active",
+				severityAfterUpdate: "Critical",
+			}
+			client := newSeverityTestClient(t, srv)
+
+			if _, err := client.Update(context.Background(), "1", &irm.Incident{
+				Status:   tt.status,
+				Title:    "same title",
+				Severity: "Critical",
+			}); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			want := []string{"IncidentsService.GetIncident"}
+			if len(srv.calls) != len(want) || srv.calls[0] != want[0] {
+				t.Errorf("got calls %v, want %v", srv.calls, want)
+			}
+		})
 	}
 }
 

--- a/internal/providers/irm/incidents_severity_test.go
+++ b/internal/providers/irm/incidents_severity_test.go
@@ -25,18 +25,29 @@ type severityServer struct {
 	severityAfterUpdate string
 	title               string
 	status              string
-	// notFoundOnVersioned makes the versioned base path answer 404, so the
-	// test can drive the unversioned fallback.
+	// notFoundOnVersioned makes versioned IncidentsService methods answer 404,
+	// so the test can drive the unversioned fallback through Get and Update.
 	notFoundOnVersioned bool
+	// updatesUnavailable makes both paths reject update methods while Get
+	// still proves that the incident exists.
+	updatesUnavailable bool
 	// failSeverityUpdate makes UpdateSeverity answer 500, so the test can
 	// drive the failure path of Create.
 	failSeverityUpdate bool
 	// failTitleUpdate makes UpdateTitle answer 500, so the test can drive a
 	// partial update.
 	failTitleUpdate bool
-	// incidentMissing makes every update method answer 404 on both base paths,
-	// the way the API reports an unknown incidentID.
+	// incidentMissing makes Get and every update method answer 404 on both base
+	// paths, the way the API reports an unknown incidentID.
 	incidentMissing bool
+}
+
+func knownSeverities() []map[string]any {
+	return []map[string]any{
+		{"severityID": "sev-0", "displayLabel": "Pending", "level": 0},
+		{"severityID": "sev-1", "displayLabel": "Critical", "level": 1},
+		{"severityID": "sev-2", "displayLabel": "Major", "level": 2},
+	}
 }
 
 func (s *severityServer) handler(t *testing.T) http.Handler {
@@ -50,11 +61,15 @@ func (s *severityServer) handler(t *testing.T) http.Handler {
 		s.calls = append(s.calls, method)
 		s.bodies = append(s.bodies, body)
 
-		if s.notFoundOnVersioned && versioned && strings.HasPrefix(method, "IncidentsService.Update") {
+		if s.notFoundOnVersioned && versioned && strings.HasPrefix(method, "IncidentsService.") {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
-		if s.incidentMissing && strings.HasPrefix(method, "IncidentsService.Update") {
+		if s.incidentMissing && (method == "IncidentsService.GetIncident" || strings.HasPrefix(method, "IncidentsService.Update")) {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if s.updatesUnavailable && strings.HasPrefix(method, "IncidentsService.Update") {
 			w.WriteHeader(http.StatusNotFound)
 			return
 		}
@@ -70,7 +85,11 @@ func (s *severityServer) handler(t *testing.T) http.Handler {
 		w.Header().Set("Content-Type", "application/json")
 		switch method {
 		case "SeveritiesService.GetOrgSeverities":
-			json.NewEncoder(w).Encode(map[string]any{"severities": s.severities}) //nolint:errcheck
+			severities := s.severities
+			if severities == nil {
+				severities = knownSeverities()
+			}
+			json.NewEncoder(w).Encode(map[string]any{"severities": severities}) //nolint:errcheck
 		case "IncidentsService.GetIncident":
 			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
 				"incident": map[string]any{
@@ -130,7 +149,11 @@ func TestCreateAppliesSeverity(t *testing.T) {
 			name:         "severity label on the spec",
 			incident:     irm.Incident{Title: "probe", Severity: "Critical"},
 			wantSeverity: "Critical",
-			wantCalls:    []string{"IncidentsService.CreateIncident", "IncidentsService.UpdateSeverity"},
+			wantCalls: []string{
+				"SeveritiesService.GetOrgSeverities",
+				"IncidentsService.CreateIncident",
+				"IncidentsService.UpdateSeverity",
+			},
 		},
 		{
 			name:         "severityID resolved through the organization severities",
@@ -166,7 +189,7 @@ func TestCreateAppliesSeverity(t *testing.T) {
 			name:         "the default severity needs no second call",
 			incident:     irm.Incident{Title: "probe", Severity: "Pending"},
 			wantSeverity: "",
-			wantCalls:    []string{"IncidentsService.CreateIncident"},
+			wantCalls:    []string{"SeveritiesService.GetOrgSeverities", "IncidentsService.CreateIncident"},
 		},
 	}
 
@@ -175,11 +198,8 @@ func TestCreateAppliesSeverity(t *testing.T) {
 			t.Parallel()
 
 			srv := &severityServer{
-				title: "probe",
-				severities: []map[string]any{
-					{"severityID": "sev-1", "displayLabel": "Critical", "level": 1},
-					{"severityID": "sev-2", "displayLabel": "Major", "level": 2},
-				},
+				title:      "probe",
+				severities: knownSeverities(),
 			}
 			client := newSeverityTestClient(t, srv)
 
@@ -202,6 +222,51 @@ func TestCreateAppliesSeverity(t *testing.T) {
 			}
 			if tt.wantSeverity != "" && got.Severity != tt.wantSeverity {
 				t.Errorf("got severity %q in the result, want %q", got.Severity, tt.wantSeverity)
+			}
+		})
+	}
+}
+
+// TestSeverityLabelValidationRejectsUnknownLabels proves that gcx validates a
+// display label before Create or Update writes it. This closes the backend
+// case that accepts an unknown label with status 200 but changes nothing.
+func TestSeverityLabelValidationRejectsUnknownLabels(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		run  func(context.Context, *irm.IncidentClient) error
+	}{
+		{
+			name: "create",
+			run: func(ctx context.Context, client *irm.IncidentClient) error {
+				_, err := client.Create(ctx, &irm.Incident{Title: "probe", Severity: "Criticl"})
+				return err
+			},
+		},
+		{
+			name: "update",
+			run: func(ctx context.Context, client *irm.IncidentClient) error {
+				_, _, err := client.Update(ctx, "1", &irm.Incident{Severity: "Criticl"})
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			srv := &severityServer{title: "probe", severities: knownSeverities()}
+			client := newSeverityTestClient(t, srv)
+			err := tt.run(context.Background(), client)
+			if err == nil || !strings.Contains(err.Error(), `unknown severity "Criticl"`) {
+				t.Fatalf("expected an unknown-severity error, got %v", err)
+			}
+			for _, call := range srv.calls {
+				if call == "IncidentsService.CreateIncident" || strings.HasPrefix(call, "IncidentsService.Update") {
+					t.Fatalf("the client wrote an unknown severity: %v", srv.calls)
+				}
 			}
 		})
 	}
@@ -304,9 +369,9 @@ func TestUpdateFieldReportsAMissingIncident(t *testing.T) {
 	if !strings.Contains(err.Error(), "does-not-exist") {
 		t.Errorf("expected the incident identifier in the error, got %v", err)
 	}
-	// One call on the versioned path, one on the unversioned path.
-	if len(srv.calls) != 2 {
-		t.Errorf("expected two calls, got %v", srv.calls)
+	// The update and the verification Get each try both base paths.
+	if len(srv.calls) != 4 {
+		t.Errorf("expected four calls, got %v", srv.calls)
 	}
 }
 
@@ -445,6 +510,50 @@ func TestUpdateFallsBackToUnversionedPath(t *testing.T) {
 	}
 }
 
+// TestUpdateUsesTheLegacyPathForGetAndWrite covers the public Update path on
+// a Grafana build where IncidentsService exists only on the unversioned path.
+func TestUpdateUsesTheLegacyPathForGetAndWrite(t *testing.T) {
+	t.Parallel()
+
+	srv := &severityServer{title: "probe", notFoundOnVersioned: true}
+	client := newSeverityTestClient(t, srv)
+
+	got, changed, err := client.Update(context.Background(), "1", &irm.Incident{Severity: "Critical"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Severity != "Critical" || strings.Join(changed, ",") != "severity" {
+		t.Fatalf("unexpected result: incident=%+v changed=%v", got, changed)
+	}
+	want := []string{
+		"IncidentsService.GetIncident",
+		"IncidentsService.GetIncident",
+		"SeveritiesService.GetOrgSeverities",
+		"IncidentsService.UpdateSeverity",
+		"IncidentsService.UpdateSeverity",
+	}
+	if strings.Join(srv.calls, ",") != strings.Join(want, ",") {
+		t.Errorf("got calls %v, want %v", srv.calls, want)
+	}
+}
+
+// TestUpdateDoesNotMisreportAnUnavailableMethodAsAMissingIncident covers a
+// server that has GetIncident but has neither update route.
+func TestUpdateDoesNotMisreportAnUnavailableMethodAsAMissingIncident(t *testing.T) {
+	t.Parallel()
+
+	srv := &severityServer{title: "probe", updatesUnavailable: true}
+	client := newSeverityTestClient(t, srv)
+
+	_, err := client.UpdateSeverity(context.Background(), "1", "Critical")
+	if err == nil || !strings.Contains(err.Error(), "operation is unavailable") {
+		t.Fatalf("expected an unavailable-operation error, got %v", err)
+	}
+	if errors.Is(err, irm.ErrNotFound) {
+		t.Fatalf("the incident exists, but the error reports it as missing: %v", err)
+	}
+}
+
 // TestUpdateAppliesEveryChangedField covers the push path: the adapter calls
 // Update, which must carry the title and the severity, not the status alone.
 func TestUpdateAppliesEveryChangedField(t *testing.T) {
@@ -467,6 +576,7 @@ func TestUpdateAppliesEveryChangedField(t *testing.T) {
 
 	want := []string{
 		"IncidentsService.GetIncident",
+		"SeveritiesService.GetOrgSeverities",
 		"IncidentsService.UpdateStatus",
 		"IncidentsService.UpdateTitle",
 		"IncidentsService.UpdateSeverity",
@@ -522,8 +632,8 @@ func TestUpdateSkipsUnchangedFields(t *testing.T) {
 				t.Errorf("got changed fields %v, want none", changed)
 			}
 
-			want := []string{"IncidentsService.GetIncident"}
-			if len(srv.calls) != len(want) || srv.calls[0] != want[0] {
+			want := []string{"IncidentsService.GetIncident", "SeveritiesService.GetOrgSeverities"}
+			if strings.Join(srv.calls, ",") != strings.Join(want, ",") {
 				t.Errorf("got calls %v, want %v", srv.calls, want)
 			}
 		})
@@ -553,6 +663,7 @@ func TestUpdateSkipsAnEmptyStatus(t *testing.T) {
 	}
 	want := []string{
 		"IncidentsService.GetIncident",
+		"SeveritiesService.GetOrgSeverities",
 		"IncidentsService.UpdateTitle",
 		"IncidentsService.UpdateSeverity",
 	}

--- a/internal/providers/irm/incidents_severity_test.go
+++ b/internal/providers/irm/incidents_severity_test.go
@@ -129,9 +129,9 @@ func TestCreateAppliesSeverity(t *testing.T) {
 			},
 		},
 		{
-			// A pulled incident carries both fields, so an edit of severityID
-			// alone must reach the server. severityID has precedence.
-			name:         "severityID beats a stale severity label",
+			// A hand-written manifest can carry both fields. severityID has
+			// precedence there. A pulled manifest carries the label alone.
+			name:         "severityID beats a severity label in the same manifest",
 			incident:     irm.Incident{Title: "probe", Severity: "Pending", SeverityID: "sev-1"},
 			wantSeverity: "Critical",
 			wantCalls: []string{

--- a/internal/providers/irm/incidents_severity_test.go
+++ b/internal/providers/irm/incidents_severity_test.go
@@ -22,9 +22,13 @@ type severityServer struct {
 	// has run.
 	severityAfterUpdate string
 	title               string
+	status              string
 	// notFoundOnVersioned makes the versioned base path answer 404, so the
 	// test can drive the unversioned fallback.
 	notFoundOnVersioned bool
+	// failSeverityUpdate makes UpdateSeverity answer 500, so the test can
+	// drive the failure path of Create.
+	failSeverityUpdate bool
 }
 
 func (s *severityServer) handler(t *testing.T) http.Handler {
@@ -38,9 +42,12 @@ func (s *severityServer) handler(t *testing.T) http.Handler {
 		s.calls = append(s.calls, method)
 		s.bodies = append(s.bodies, body)
 
-		if s.notFoundOnVersioned && versioned &&
-			(method == "IncidentsService.UpdateSeverity" || method == "IncidentsService.UpdateTitle") {
+		if s.notFoundOnVersioned && versioned && strings.HasPrefix(method, "IncidentsService.Update") {
 			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if s.failSeverityUpdate && method == "IncidentsService.UpdateSeverity" {
+			w.WriteHeader(http.StatusInternalServerError)
 			return
 		}
 
@@ -48,6 +55,13 @@ func (s *severityServer) handler(t *testing.T) http.Handler {
 		switch method {
 		case "SeveritiesService.GetOrgSeverities":
 			json.NewEncoder(w).Encode(map[string]any{"severities": s.severities}) //nolint:errcheck
+		case "IncidentsService.GetIncident":
+			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
+				"incident": map[string]any{
+					"incidentID": "1", "title": s.title,
+					"severity": s.severityAfterUpdate, "status": s.status,
+				},
+			})
 		case "IncidentsService.CreateIncident":
 			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
 				"incident": map[string]any{"incidentID": "1", "title": s.title, "severity": "Pending"},
@@ -63,10 +77,11 @@ func (s *severityServer) handler(t *testing.T) http.Handler {
 				"incident": map[string]any{"incidentID": "1", "title": s.title, "severity": s.severityAfterUpdate},
 			})
 		case "IncidentsService.UpdateStatus":
+			s.status, _ = body["status"].(string)
 			json.NewEncoder(w).Encode(map[string]any{ //nolint:errcheck
 				"incident": map[string]any{
 					"incidentID": "1", "title": s.title, "severity": s.severityAfterUpdate,
-					"status": body["status"],
+					"status": s.status,
 				},
 			})
 		default:
@@ -105,9 +120,23 @@ func TestCreateAppliesSeverity(t *testing.T) {
 			name:         "severityID resolved through the organization severities",
 			incident:     irm.Incident{Title: "probe", SeverityID: "sev-2"},
 			wantSeverity: "Major",
+			// The label resolves before the create call, so a bad severityID
+			// leaves no incident behind.
 			wantCalls: []string{
-				"IncidentsService.CreateIncident",
 				"SeveritiesService.GetOrgSeverities",
+				"IncidentsService.CreateIncident",
+				"IncidentsService.UpdateSeverity",
+			},
+		},
+		{
+			// A pulled incident carries both fields, so an edit of severityID
+			// alone must reach the server. severityID has precedence.
+			name:         "severityID beats a stale severity label",
+			incident:     irm.Incident{Title: "probe", Severity: "Pending", SeverityID: "sev-1"},
+			wantSeverity: "Critical",
+			wantCalls: []string{
+				"SeveritiesService.GetOrgSeverities",
+				"IncidentsService.CreateIncident",
 				"IncidentsService.UpdateSeverity",
 			},
 		},
@@ -162,6 +191,9 @@ func TestCreateAppliesSeverity(t *testing.T) {
 	}
 }
 
+// TestCreateRejectsUnknownSeverityID proves that a bad severityID leaves no
+// incident behind. The IRM API has no delete method, so gcx must resolve the
+// label before it creates the incident.
 func TestCreateRejectsUnknownSeverityID(t *testing.T) {
 	t.Parallel()
 
@@ -175,6 +207,35 @@ func TestCreateRejectsUnknownSeverityID(t *testing.T) {
 	_, err := client.Create(context.Background(), &inc)
 	if err == nil || !strings.Contains(err.Error(), "unknown severityID") {
 		t.Errorf("expected an unknown-severityID error, got %v", err)
+	}
+	for _, call := range srv.calls {
+		if call == "IncidentsService.CreateIncident" {
+			t.Fatalf("the client created an incident it cannot delete: %v", srv.calls)
+		}
+	}
+}
+
+// TestCreateReportsTheIncidentAfterAFailedSeverityUpdate covers the second
+// failure path: the incident exists, and the caller needs its identifier to
+// repair the severity.
+func TestCreateReportsTheIncidentAfterAFailedSeverityUpdate(t *testing.T) {
+	t.Parallel()
+
+	srv := &severityServer{title: "probe", failSeverityUpdate: true}
+	client := newSeverityTestClient(t, srv)
+
+	inc := irm.Incident{Title: "probe", Severity: "Critical"}
+	created, err := client.Create(context.Background(), &inc)
+	if err == nil {
+		t.Fatal("expected a failed-severity error")
+	}
+	if created == nil || created.IncidentID != "1" {
+		t.Fatalf("expected the created incident next to the error, got %+v", created)
+	}
+	for _, want := range []string{"incident 1 exists", `gcx irm incidents update 1 --severity "Critical"`} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("expected %q in the error, got %v", want, err)
+		}
 	}
 }
 
@@ -242,6 +303,7 @@ func TestUpdateAppliesEveryChangedField(t *testing.T) {
 	}
 
 	want := []string{
+		"IncidentsService.GetIncident",
 		"IncidentsService.UpdateStatus",
 		"IncidentsService.UpdateTitle",
 		"IncidentsService.UpdateSeverity",
@@ -260,7 +322,7 @@ func TestUpdateAppliesEveryChangedField(t *testing.T) {
 }
 
 // TestUpdateSkipsUnchangedFields keeps the push path cheap: a manifest that
-// matches the server costs one call, not three.
+// matches the server costs the read and one write, not three writes.
 func TestUpdateSkipsUnchangedFields(t *testing.T) {
 	t.Parallel()
 
@@ -275,7 +337,39 @@ func TestUpdateSkipsUnchangedFields(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	if len(srv.calls) != 1 || srv.calls[0] != "IncidentsService.UpdateStatus" {
-		t.Errorf("expected only a status call, got %v", srv.calls)
+	want := []string{"IncidentsService.GetIncident", "IncidentsService.UpdateStatus"}
+	if len(srv.calls) != len(want) || srv.calls[0] != want[0] || srv.calls[1] != want[1] {
+		t.Errorf("got calls %v, want %v", srv.calls, want)
+	}
+}
+
+// TestUpdateSkipsAnEmptyStatus covers a manifest without a status: nothing
+// enforces the required fields of the schema on push, and an empty status
+// must not block the title and the severity.
+func TestUpdateSkipsAnEmptyStatus(t *testing.T) {
+	t.Parallel()
+
+	srv := &severityServer{title: "old title", status: "active"}
+	client := newSeverityTestClient(t, srv)
+
+	if _, err := client.Update(context.Background(), "1", &irm.Incident{
+		Title:    "new title",
+		Severity: "Critical",
+	}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, call := range srv.calls {
+		if call == "IncidentsService.UpdateStatus" {
+			t.Fatalf("the client sent an empty status: %v", srv.calls)
+		}
+	}
+	want := []string{
+		"IncidentsService.GetIncident",
+		"IncidentsService.UpdateTitle",
+		"IncidentsService.UpdateSeverity",
+	}
+	if len(srv.calls) != len(want) {
+		t.Fatalf("got calls %v, want %v", srv.calls, want)
 	}
 }

--- a/internal/providers/irm/incidents_types.go
+++ b/internal/providers/irm/incidents_types.go
@@ -48,10 +48,10 @@ type Incident struct {
 	// Severity is the display label, for example "Critical". gcx ignores it
 	// when SeverityID is not empty.
 	Severity string `json:"severity,omitempty"`
-	// SeverityID is the severity identifier. It has precedence over Severity:
-	// when it is not empty, gcx resolves the label from the organization
-	// severity list. A pulled incident carries both fields, so an edit of
-	// SeverityID alone must still reach the server.
+	// SeverityID is the severity identifier of the organization. A
+	// hand-written manifest can carry it, and gcx then resolves the label from
+	// the organization severity list. A pulled manifest carries the label
+	// alone, because the pull removes this field.
 	SeverityID              string               `json:"severityID,omitempty"`
 	IsDrill                 bool                 `json:"isDrill"`
 	IncidentType            string               `json:"incidentType,omitempty"`

--- a/internal/providers/irm/incidents_types.go
+++ b/internal/providers/irm/incidents_types.go
@@ -339,9 +339,23 @@ type updateStatusRequest struct {
 	Status     string `json:"status"`
 }
 
-// updateStatusResponse wraps the updated incident.
+// updateStatusResponse wraps the updated incident. UpdateSeverity and
+// UpdateTitle answer with the same envelope.
 type updateStatusResponse struct {
 	Incident Incident `json:"incident"`
+}
+
+// updateSeverityRequest is the request body for IncidentsService.UpdateSeverity.
+// The API takes the severity label, not the severity identifier.
+type updateSeverityRequest struct {
+	IncidentID string `json:"incidentID"`
+	Severity   string `json:"severity"`
+}
+
+// updateTitleRequest is the request body for IncidentsService.UpdateTitle.
+type updateTitleRequest struct {
+	IncidentID string `json:"incidentID"`
+	Title      string `json:"title"`
 }
 
 // Severity represents an organization-defined severity level.

--- a/internal/providers/irm/incidents_types.go
+++ b/internal/providers/irm/incidents_types.go
@@ -299,9 +299,23 @@ type updateStatusRequest struct {
 	Status     string `json:"status"`
 }
 
-// updateStatusResponse wraps the updated incident.
+// updateStatusResponse wraps the updated incident. UpdateSeverity and
+// UpdateTitle answer with the same envelope.
 type updateStatusResponse struct {
 	Incident Incident `json:"incident"`
+}
+
+// updateSeverityRequest is the request body for IncidentsService.UpdateSeverity.
+// The API takes the severity label, not the severity identifier.
+type updateSeverityRequest struct {
+	IncidentID string `json:"incidentID"`
+	Severity   string `json:"severity"`
+}
+
+// updateTitleRequest is the request body for IncidentsService.UpdateTitle.
+type updateTitleRequest struct {
+	IncidentID string `json:"incidentID"`
+	Title      string `json:"title"`
 }
 
 // Severity represents an organization-defined severity level.

--- a/internal/providers/irm/incidents_types.go
+++ b/internal/providers/irm/incidents_types.go
@@ -323,7 +323,10 @@ func (p IncidentPreview) ToIncident() Incident {
 	}
 }
 
-// createIncidentRequest is the request body for creating an incident.
+// createIncidentRequest is the request body for creating an incident. It
+// carries no severity field: CreateIncident ignores both severity and
+// severityID, and UpdateSeverity is the only route to a severity other than
+// the default one.
 type createIncidentRequest struct {
 	Title          string          `json:"title"`
 	Status         string          `json:"status"`
@@ -331,7 +334,6 @@ type createIncidentRequest struct {
 	Labels         []IncidentLabel `json:"labels"`
 	IncidentType   string          `json:"incidentType,omitempty"`
 	FieldGroupUUID string          `json:"fieldGroupUUID,omitempty"`
-	SeverityID     string          `json:"severityID,omitempty"`
 }
 
 // createIncidentResponse wraps the created incident.

--- a/internal/providers/irm/incidents_types.go
+++ b/internal/providers/irm/incidents_types.go
@@ -38,14 +38,20 @@ func (i *Incident) SetResourceName(name string) { i.IncidentID = name }
 //
 //nolint:recvcheck // Mixed receivers are intentional for Go generics TypedCRUD compatibility.
 type Incident struct {
-	IncidentID              string               `json:"incidentID,omitempty"`
-	Title                   string               `json:"title"`
-	Slug                    string               `json:"slug,omitempty"`
-	Prefix                  string               `json:"prefix,omitempty"`
-	Status                  string               `json:"status"`
-	StatusID                string               `json:"statusID,omitempty"`
-	State                   string               `json:"state,omitempty"`
-	Severity                string               `json:"severity,omitempty"`
+	IncidentID string `json:"incidentID,omitempty"`
+	Title      string `json:"title"`
+	Slug       string `json:"slug,omitempty"`
+	Prefix     string `json:"prefix,omitempty"`
+	Status     string `json:"status"`
+	StatusID   string `json:"statusID,omitempty"`
+	State      string `json:"state,omitempty"`
+	// Severity is the display label, for example "Critical". gcx ignores it
+	// when SeverityID is not empty.
+	Severity string `json:"severity,omitempty"`
+	// SeverityID is the severity identifier. It has precedence over Severity:
+	// when it is not empty, gcx resolves the label from the organization
+	// severity list. A pulled incident carries both fields, so an edit of
+	// SeverityID alone must still reach the server.
 	SeverityID              string               `json:"severityID,omitempty"`
 	IsDrill                 bool                 `json:"isDrill"`
 	IncidentType            string               `json:"incidentType,omitempty"`

--- a/internal/providers/irm/incidents_types.go
+++ b/internal/providers/irm/incidents_types.go
@@ -78,6 +78,10 @@ type Incident struct {
 	IncidentEnd             FlexTime             `json:"incidentEnd,omitzero"`
 	DescriptionModifiedTime FlexTime             `json:"descriptionModifiedTime,omitzero"`
 	StatusModifiedTime      FlexTime             `json:"statusModifiedTime,omitzero"`
+
+	// updatedFields carries command result metadata through TypedCRUD.Update.
+	// It is not an IRM API field and is never serialized in a resource.
+	updatedFields []string
 }
 
 // IncidentUser represents a user referenced in incident fields.

--- a/internal/providers/irm/incidents_types.go
+++ b/internal/providers/irm/incidents_types.go
@@ -283,7 +283,10 @@ func (p IncidentPreview) ToIncident() Incident {
 	}
 }
 
-// createIncidentRequest is the request body for creating an incident.
+// createIncidentRequest is the request body for creating an incident. It
+// carries no severity field: CreateIncident ignores both severity and
+// severityID, and UpdateSeverity is the only route to a severity other than
+// the default one.
 type createIncidentRequest struct {
 	Title          string          `json:"title"`
 	Status         string          `json:"status"`
@@ -291,7 +294,6 @@ type createIncidentRequest struct {
 	Labels         []IncidentLabel `json:"labels"`
 	IncidentType   string          `json:"incidentType,omitempty"`
 	FieldGroupUUID string          `json:"fieldGroupUUID,omitempty"`
-	SeverityID     string          `json:"severityID,omitempty"`
 }
 
 // createIncidentResponse wraps the created incident.

--- a/internal/providers/irm/incidents_types_adapter.go
+++ b/internal/providers/irm/incidents_types_adapter.go
@@ -18,6 +18,11 @@ const (
 // ToResource converts an Incident to a gcx Resource, wrapping the incident
 // fields in a Kubernetes-style object envelope with apiVersion, kind, and metadata.
 // The incidentID field is mapped to metadata.name and stripped from the spec.
+//
+// The strip list matches TypedCRUD.StripFields in
+// incidents_resource_adapter.go. The provider commands convert here, and the
+// resources commands convert through the adapter, so a key that one path
+// removes and the other keeps makes the two outputs disagree.
 func ToResource(inc Incident, namespace string) (*resources.Resource, error) {
 	data, err := json.Marshal(inc)
 	if err != nil {
@@ -29,8 +34,12 @@ func ToResource(inc Incident, namespace string) (*resources.Resource, error) {
 		return nil, fmt.Errorf("failed to unmarshal incident to map: %w", err)
 	}
 
-	// Strip the ID from spec — it lives in metadata.name.
-	delete(specMap, "incidentID")
+	// The identifier lives in metadata.name. severityID goes with it: the
+	// identifier has precedence over the severity label in the client, so a
+	// manifest that carries both makes an edit of the label unreachable.
+	for _, field := range incidentStripFields {
+		delete(specMap, field)
+	}
 
 	obj := map[string]any{
 		"apiVersion": IncidentAPIVersion,

--- a/internal/providers/irm/incidents_update_command.go
+++ b/internal/providers/irm/incidents_update_command.go
@@ -1,0 +1,100 @@
+package irm
+
+import (
+	"errors"
+	"fmt"
+
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// The IRM API has no single update method for an incident. Each mutable
+// field is its own operation, so this command applies one flag per call and
+// echoes the incident once, after the last call.
+
+type incidentUpdateOpts struct {
+	IO       cmdio.Options
+	Severity string
+	Title    string
+}
+
+func (o *incidentUpdateOpts) setup(flags *pflag.FlagSet) {
+	o.IO.DefaultFormat("yaml")
+	o.IO.BindFlags(flags)
+	flags.StringVar(&o.Severity, "severity", "",
+		"New severity label (run `gcx irm incidents severities list` for the valid values)")
+	flags.StringVar(&o.Title, "title", "", "New title")
+}
+
+func (o *incidentUpdateOpts) Validate() error {
+	if o.Severity == "" && o.Title == "" {
+		return errors.New("give at least one of --severity or --title")
+	}
+	return nil
+}
+
+func NewUpdateCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &incidentUpdateOpts{}
+	cmd := &cobra.Command{
+		Use:   "update <id>",
+		Short: "Update the severity or the title of an incident.",
+		Long: `Update the severity or the title of an incident.
+
+The severity is the display label, not the identifier. Run
+` + "`gcx irm incidents severities list`" + ` for the labels of your organization.
+
+The command emits the updated incident.`,
+		Example: `  # Raise the severity of an incident:
+  gcx irm incidents update 4 --severity Critical
+
+  # Correct the title:
+  gcx irm incidents update 4 --title "Checkout latency above the objective"`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := opts.IO.Validate(); err != nil {
+				return err
+			}
+			if err := opts.Validate(); err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			id := args[0]
+
+			restCfg, err := loader.LoadGrafanaConfig(ctx)
+			if err != nil {
+				return err
+			}
+
+			client, err := NewIncidentClient(restCfg)
+			if err != nil {
+				return err
+			}
+
+			// Validate guarantees at least one flag, so at least one call
+			// runs and inc is never nil below.
+			var inc *Incident
+			if opts.Title != "" {
+				if inc, err = client.UpdateTitle(ctx, id, opts.Title); err != nil {
+					return err
+				}
+			}
+			if opts.Severity != "" {
+				if inc, err = client.UpdateSeverity(ctx, id, opts.Severity); err != nil {
+					return err
+				}
+			}
+
+			res, err := ToResource(*inc, restCfg.Namespace)
+			if err != nil {
+				return fmt.Errorf("failed to convert incident to resource: %w", err)
+			}
+
+			obj := res.ToUnstructured()
+			return opts.IO.Encode(cmd.OutOrStdout(), &obj)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}

--- a/internal/providers/irm/incidents_update_command.go
+++ b/internal/providers/irm/incidents_update_command.go
@@ -23,13 +23,23 @@ func (o *incidentUpdateOpts) setup(flags *pflag.FlagSet) {
 	o.IO.DefaultFormat("yaml")
 	o.IO.BindFlags(flags)
 	flags.StringVar(&o.Severity, "severity", "",
-		"New severity label (run `gcx irm incidents severities list` for the valid values)")
+		"New severity label (run 'gcx irm incidents severities list' for the valid values)")
 	flags.StringVar(&o.Title, "title", "", "New title")
 }
 
-func (o *incidentUpdateOpts) Validate() error {
-	if o.Severity == "" && o.Title == "" {
+// Validate rejects an empty value on a flag the caller set. The Incident
+// schema marks the title as required, and an empty severity label matches no
+// entry in the severity list. Only flags.Changed separates an explicit empty
+// value from an omitted flag.
+func (o *incidentUpdateOpts) Validate(flags *pflag.FlagSet) error {
+	if !flags.Changed("severity") && !flags.Changed("title") {
 		return errors.New("give at least one of --severity or --title")
+	}
+	if flags.Changed("severity") && o.Severity == "" {
+		return errors.New("--severity must not be empty: run 'gcx irm incidents severities list' for the valid values")
+	}
+	if flags.Changed("title") && o.Title == "" {
+		return errors.New("--title must not be empty: the incident title is required")
 	}
 	return nil
 }
@@ -55,7 +65,7 @@ The command emits the updated incident.`,
 			if err := opts.IO.Validate(); err != nil {
 				return err
 			}
-			if err := opts.Validate(); err != nil {
+			if err := opts.Validate(cmd.Flags()); err != nil {
 				return err
 			}
 

--- a/internal/providers/irm/incidents_update_command.go
+++ b/internal/providers/irm/incidents_update_command.go
@@ -3,7 +3,10 @@ package irm
 import (
 	"errors"
 	"fmt"
+	"io"
+	"strings"
 
+	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -18,14 +21,34 @@ type incidentUpdateOpts struct {
 	IO       cmdio.Options
 	Severity string
 	Title    string
+
+	// id and changed carry the result of the update to the text codec: the
+	// success line names the incident and the fields that gcx changed.
+	id      string
+	changed []string
 }
 
 func (o *incidentUpdateOpts) setup(flags *pflag.FlagSet) {
-	o.IO.DefaultFormat("yaml")
+	// update is a mutation command, so the human default is one success line
+	// (docs/design/output.md § 11), the way `incidents close` prints one. The
+	// encoded document stays the incident manifest, so -o json and -o yaml
+	// emit what `gcx resources get` emits for the same incident.
+	o.IO.RegisterCustomCodec("text", &incidentUpdateTextCodec{render: o.report})
+	o.IO.DefaultFormat("text")
 	o.IO.BindFlags(flags)
 	flags.StringVar(&o.Severity, "severity", "",
 		"New severity label (run 'gcx irm incidents severities list' for the valid values)")
 	flags.StringVar(&o.Title, "title", "", "New title")
+}
+
+// report writes the success line. gcx reads the incident first and skips a
+// field that already matches, so a run can change nothing at all.
+func (o *incidentUpdateOpts) report(w io.Writer) {
+	if len(o.changed) == 0 {
+		cmdio.Info(w, "Incident %s already carries the requested values", o.id)
+		return
+	}
+	cmdio.Success(w, "Updated incident %s (%s)", o.id, strings.Join(o.changed, ", "))
 }
 
 // Validate rejects an empty value on a flag the caller set. The Incident
@@ -45,6 +68,25 @@ func (o *incidentUpdateOpts) Validate(flags *pflag.FlagSet) error {
 	return nil
 }
 
+// incidentUpdateTextCodec renders the human result of `incidents update`: one
+// line that names the incident and the fields that gcx changed. The value
+// that Encode receives is the incident manifest, which the json and the yaml
+// codec emit unchanged.
+type incidentUpdateTextCodec struct {
+	render func(w io.Writer)
+}
+
+func (c *incidentUpdateTextCodec) Format() format.Format { return "text" }
+
+func (c *incidentUpdateTextCodec) Decode(io.Reader, any) error {
+	return errors.New("text codec does not support decoding")
+}
+
+func (c *incidentUpdateTextCodec) Encode(w io.Writer, _ any) error {
+	c.render(w)
+	return nil
+}
+
 func NewUpdateCommand(loader GrafanaConfigLoader) *cobra.Command {
 	opts := &incidentUpdateOpts{}
 	cmd := &cobra.Command{
@@ -56,7 +98,8 @@ The severity is the display label, not the identifier. Run
 ` + "`gcx irm incidents severities list`" + ` for the labels of your organization.
 
 gcx reads the incident first, so a value that already matches causes no write.
-The command emits the incident.`,
+The command prints one line that names the fields it changed. Use -o json or
+-o yaml for the incident manifest.`,
 		Example: `  # Raise the severity of an incident:
   gcx irm incidents update 4 --severity Critical
 
@@ -72,7 +115,7 @@ The command emits the incident.`,
 			}
 
 			ctx := cmd.Context()
-			id := args[0]
+			opts.id = args[0]
 
 			restCfg, err := loader.LoadGrafanaConfig(ctx)
 			if err != nil {
@@ -87,10 +130,11 @@ The command emits the incident.`,
 			// Update skips an empty field and a field that already matches, so
 			// one call covers both flags. Validate rejects an explicit empty
 			// value, so an empty field here is an omitted flag.
-			inc, err := client.Update(ctx, id, &Incident{Title: opts.Title, Severity: opts.Severity})
+			inc, changed, err := client.Update(ctx, opts.id, &Incident{Title: opts.Title, Severity: opts.Severity})
 			if err != nil {
 				return err
 			}
+			opts.changed = changed
 
 			res, err := ToResource(*inc, restCfg.Namespace)
 			if err != nil {

--- a/internal/providers/irm/incidents_update_command.go
+++ b/internal/providers/irm/incidents_update_command.go
@@ -9,9 +9,10 @@ import (
 	"github.com/spf13/pflag"
 )
 
-// The IRM API has no single update method for an incident. Each mutable
-// field is its own operation, so this command applies one flag per call and
-// echoes the incident once, after the last call.
+// The IRM API has no single update method for an incident. Each mutable field
+// is its own operation. The command delegates to IncidentClient.Update, the
+// method the resources push path also reaches, so both paths share the read,
+// the skip of an unchanged field, and the not-found signal.
 
 type incidentUpdateOpts struct {
 	IO       cmdio.Options
@@ -54,7 +55,8 @@ func NewUpdateCommand(loader GrafanaConfigLoader) *cobra.Command {
 The severity is the display label, not the identifier. Run
 ` + "`gcx irm incidents severities list`" + ` for the labels of your organization.
 
-The command emits the updated incident.`,
+gcx reads the incident first, so a value that already matches causes no write.
+The command emits the incident.`,
 		Example: `  # Raise the severity of an incident:
   gcx irm incidents update 4 --severity Critical
 
@@ -82,18 +84,12 @@ The command emits the updated incident.`,
 				return err
 			}
 
-			// Validate guarantees at least one flag, so at least one call
-			// runs and inc is never nil below.
-			var inc *Incident
-			if opts.Title != "" {
-				if inc, err = client.UpdateTitle(ctx, id, opts.Title); err != nil {
-					return err
-				}
-			}
-			if opts.Severity != "" {
-				if inc, err = client.UpdateSeverity(ctx, id, opts.Severity); err != nil {
-					return err
-				}
+			// Update skips an empty field and a field that already matches, so
+			// one call covers both flags. Validate rejects an explicit empty
+			// value, so an empty field here is an omitted flag.
+			inc, err := client.Update(ctx, id, &Incident{Title: opts.Title, Severity: opts.Severity})
+			if err != nil {
+				return err
 			}
 
 			res, err := ToResource(*inc, restCfg.Namespace)

--- a/internal/providers/irm/incidents_update_command.go
+++ b/internal/providers/irm/incidents_update_command.go
@@ -2,12 +2,11 @@ package irm
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"strings"
 
-	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/resources/adapter"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
@@ -22,33 +21,28 @@ type incidentUpdateOpts struct {
 	Severity string
 	Title    string
 
-	// id and changed carry the result of the update to the text codec: the
-	// success line names the incident and the fields that gcx changed.
-	id      string
+	// changed carries the field names to the text codec. The structured
+	// mutation result reports whether the command changed the incident.
 	changed []string
 }
 
 func (o *incidentUpdateOpts) setup(flags *pflag.FlagSet) {
-	// update is a mutation command, so the human default is one success line
-	// (docs/design/output.md § 11), the way `incidents close` prints one. The
-	// encoded document stays the incident manifest, so -o json and -o yaml
-	// emit what `gcx resources get` emits for the same incident.
-	o.IO.RegisterCustomCodec("text", &incidentUpdateTextCodec{render: o.report})
+	// The result is a SingleMutation document. The human default is one line,
+	// and machine formats include the changed signal for idempotent updates.
+	o.IO.RegisterCustomCodec("text", &singleMutationTextCodec{
+		render: func(w io.Writer, m cmdio.SingleMutation) {
+			if m.Changed != nil && !*m.Changed {
+				cmdio.Info(w, "Incident %s already carries the requested values", m.Target.ID)
+				return
+			}
+			cmdio.Success(w, "Updated incident %s (%s)", m.Target.ID, strings.Join(o.changed, ", "))
+		},
+	})
 	o.IO.DefaultFormat("text")
 	o.IO.BindFlags(flags)
 	flags.StringVar(&o.Severity, "severity", "",
 		"New severity label (run 'gcx irm incidents severities list' for the valid values)")
 	flags.StringVar(&o.Title, "title", "", "New title")
-}
-
-// report writes the success line. gcx reads the incident first and skips a
-// field that already matches, so a run can change nothing at all.
-func (o *incidentUpdateOpts) report(w io.Writer) {
-	if len(o.changed) == 0 {
-		cmdio.Info(w, "Incident %s already carries the requested values", o.id)
-		return
-	}
-	cmdio.Success(w, "Updated incident %s (%s)", o.id, strings.Join(o.changed, ", "))
 }
 
 // Validate rejects an empty value on a flag the caller set. The Incident
@@ -68,25 +62,6 @@ func (o *incidentUpdateOpts) Validate(flags *pflag.FlagSet) error {
 	return nil
 }
 
-// incidentUpdateTextCodec renders the human result of `incidents update`: one
-// line that names the incident and the fields that gcx changed. The value
-// that Encode receives is the incident manifest, which the json and the yaml
-// codec emit unchanged.
-type incidentUpdateTextCodec struct {
-	render func(w io.Writer)
-}
-
-func (c *incidentUpdateTextCodec) Format() format.Format { return "text" }
-
-func (c *incidentUpdateTextCodec) Decode(io.Reader, any) error {
-	return errors.New("text codec does not support decoding")
-}
-
-func (c *incidentUpdateTextCodec) Encode(w io.Writer, _ any) error {
-	c.render(w)
-	return nil
-}
-
 func NewUpdateCommand(loader GrafanaConfigLoader) *cobra.Command {
 	opts := &incidentUpdateOpts{}
 	cmd := &cobra.Command{
@@ -99,7 +74,7 @@ The severity is the display label, not the identifier. Run
 
 gcx reads the incident first, so a value that already matches causes no write.
 The command prints one line that names the fields it changed. Use -o json or
--o yaml for the incident manifest.`,
+-o yaml for a structured update result.`,
 		Example: `  # Raise the severity of an incident:
   gcx irm incidents update 4 --severity Critical
 
@@ -115,14 +90,9 @@ The command prints one line that names the fields it changed. Use -o json or
 			}
 
 			ctx := cmd.Context()
-			opts.id = args[0]
+			id := args[0]
 
-			restCfg, err := loader.LoadGrafanaConfig(ctx)
-			if err != nil {
-				return err
-			}
-
-			client, err := NewIncidentClient(restCfg)
+			crud, _, err := NewTypedCRUD(ctx, loader, IncidentQuery{})
 			if err != nil {
 				return err
 			}
@@ -130,19 +100,24 @@ The command prints one line that names the fields it changed. Use -o json or
 			// Update skips an empty field and a field that already matches, so
 			// one call covers both flags. Validate rejects an explicit empty
 			// value, so an empty field here is an omitted flag.
-			inc, changed, err := client.Update(ctx, opts.id, &Incident{Title: opts.Title, Severity: opts.Severity})
+			updated, err := crud.Update(ctx, id, &adapter.TypedObject[Incident]{
+				Spec: Incident{Title: opts.Title, Severity: opts.Severity},
+			})
 			if err != nil {
 				return err
 			}
+			inc := &updated.Spec
+			changed := inc.updatedFields
 			opts.changed = changed
 
-			res, err := ToResource(*inc, restCfg.Namespace)
-			if err != nil {
-				return fmt.Errorf("failed to convert incident to resource: %w", err)
-			}
-
-			obj := res.ToUnstructured()
-			return opts.IO.Encode(cmd.OutOrStdout(), &obj)
+			result := cmdio.NewSingleMutation("updated", cmdio.MutationTarget{
+				Kind: "Incident",
+				ID:   id,
+				Name: inc.Title,
+			})
+			changedValue := len(changed) > 0
+			result.Changed = &changedValue
+			return opts.IO.Encode(cmd.OutOrStdout(), result)
 		},
 	}
 	opts.setup(cmd.Flags())

--- a/internal/providers/irm/incidents_update_command_test.go
+++ b/internal/providers/irm/incidents_update_command_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/grafana/gcx/internal/agent"
 	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/providers/irm"
-	"github.com/spf13/cobra"
 	"k8s.io/client-go/rest"
 )
 
@@ -179,21 +178,5 @@ func TestIncidentUpdateCommandOutputFormats(t *testing.T) {
 				t.Errorf("did not expect %q in the output, got %q", tt.notWant, out)
 			}
 		})
-	}
-}
-
-func TestIncidentUpdateCommandShape(t *testing.T) {
-	cmd := irm.NewUpdateCommand(fakeGrafanaConfigLoader{})
-	assertFlag(t, cmd, "severity")
-	assertFlag(t, cmd, "title")
-	if !strings.Contains(cmd.Use, "<id>") {
-		t.Errorf("update should take a positional <id>, got Use=%q", cmd.Use)
-	}
-}
-
-func assertFlag(t *testing.T, cmd *cobra.Command, name string) {
-	t.Helper()
-	if cmd.Flags().Lookup(name) == nil {
-		t.Errorf("incidents update is missing the --%s flag", name)
 	}
 }

--- a/internal/providers/irm/incidents_update_command_test.go
+++ b/internal/providers/irm/incidents_update_command_test.go
@@ -53,7 +53,7 @@ func TestIncidentUpdateCommand(t *testing.T) {
 				"IncidentsService.GetIncident",
 				"IncidentsService.UpdateSeverity",
 			},
-			wantOut: []string{"severity: Critical"},
+			wantOut: []string{"Updated incident 4 (severity)"},
 		},
 		{
 			name: "title only",
@@ -62,18 +62,18 @@ func TestIncidentUpdateCommand(t *testing.T) {
 				"IncidentsService.GetIncident",
 				"IncidentsService.UpdateTitle",
 			},
-			wantOut: []string{"Checkout latency above the objective"},
+			wantOut: []string{"Updated incident 4 (title)"},
 		},
 		{
 			name: "both fields",
 			args: []string{"4", "--title", "new title", "--severity", "Major"},
-			// The title runs first, so the echoed incident carries both.
+			// The title runs before the severity.
 			wantCalls: []string{
 				"IncidentsService.GetIncident",
 				"IncidentsService.UpdateTitle",
 				"IncidentsService.UpdateSeverity",
 			},
-			wantOut: []string{"new title", "severity: Major"},
+			wantOut: []string{"Updated incident 4 (title, severity)"},
 		},
 	}
 
@@ -137,6 +137,46 @@ func TestIncidentUpdateCommandRejectsBadFlags(t *testing.T) {
 			}
 			if len(srv.calls) != 0 {
 				t.Errorf("the command called the backend on a bad flag: %v", srv.calls)
+			}
+		})
+	}
+}
+
+// TestIncidentUpdateCommandOutputFormats covers the two output cases that
+// TestIncidentUpdateCommand does not reach: a run that changes nothing, and
+// the manifest that -o yaml emits.
+func TestIncidentUpdateCommandOutputFormats(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		want    string
+		notWant string
+	}{
+		{
+			name:    "a value that already matches changes nothing",
+			args:    []string{"4", "--title", "old title"},
+			want:    "Incident 4 already carries the requested values\n",
+			notWant: "Updated incident",
+		},
+		{
+			name: "-o yaml emits the manifest",
+			args: []string{"4", "--severity", "Critical", "-o", "yaml"},
+			want: "apiVersion: incident.ext.grafana.app/v1alpha1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := &severityServer{title: "old title"}
+			out, err := runIncidentUpdateCmd(t, srv, tt.args...)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(out, tt.want) {
+				t.Errorf("expected %q in the output, got %q", tt.want, out)
+			}
+			if tt.notWant != "" && strings.Contains(out, tt.notWant) {
+				t.Errorf("did not expect %q in the output, got %q", tt.notWant, out)
 			}
 		})
 	}

--- a/internal/providers/irm/incidents_update_command_test.go
+++ b/internal/providers/irm/incidents_update_command_test.go
@@ -44,24 +44,36 @@ func TestIncidentUpdateCommand(t *testing.T) {
 		wantCalls []string
 		wantOut   []string
 	}{
+		// The command reaches the backend through IncidentClient.Update, so
+		// every case starts with the read that method does.
 		{
-			name:      "severity only",
-			args:      []string{"4", "--severity", "Critical"},
-			wantCalls: []string{"IncidentsService.UpdateSeverity"},
-			wantOut:   []string{"severity: Critical"},
+			name: "severity only",
+			args: []string{"4", "--severity", "Critical"},
+			wantCalls: []string{
+				"IncidentsService.GetIncident",
+				"IncidentsService.UpdateSeverity",
+			},
+			wantOut: []string{"severity: Critical"},
 		},
 		{
-			name:      "title only",
-			args:      []string{"4", "--title", "Checkout latency above the objective"},
-			wantCalls: []string{"IncidentsService.UpdateTitle"},
-			wantOut:   []string{"Checkout latency above the objective"},
+			name: "title only",
+			args: []string{"4", "--title", "Checkout latency above the objective"},
+			wantCalls: []string{
+				"IncidentsService.GetIncident",
+				"IncidentsService.UpdateTitle",
+			},
+			wantOut: []string{"Checkout latency above the objective"},
 		},
 		{
 			name: "both fields",
 			args: []string{"4", "--title", "new title", "--severity", "Major"},
 			// The title runs first, so the echoed incident carries both.
-			wantCalls: []string{"IncidentsService.UpdateTitle", "IncidentsService.UpdateSeverity"},
-			wantOut:   []string{"new title", "severity: Major"},
+			wantCalls: []string{
+				"IncidentsService.GetIncident",
+				"IncidentsService.UpdateTitle",
+				"IncidentsService.UpdateSeverity",
+			},
+			wantOut: []string{"new title", "severity: Major"},
 		},
 	}
 

--- a/internal/providers/irm/incidents_update_command_test.go
+++ b/internal/providers/irm/incidents_update_command_test.go
@@ -1,0 +1,118 @@
+package irm_test
+
+import (
+	"bytes"
+	"context"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/internal/agent"
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/providers/irm"
+	"github.com/spf13/cobra"
+	"k8s.io/client-go/rest"
+)
+
+func runIncidentUpdateCmd(t *testing.T, srv *severityServer, args ...string) (string, error) {
+	t.Helper()
+	t.Setenv("GCX_AGENT_MODE", "false")
+	agent.ResetForTesting()
+	t.Cleanup(agent.ResetForTesting)
+
+	server := httptest.NewServer(srv.handler(t))
+	t.Cleanup(server.Close)
+
+	loader := fakeGrafanaConfigLoader{cfg: config.NamespacedRESTConfig{
+		Config:    rest.Config{Host: server.URL},
+		Namespace: "stack-123",
+	}}
+
+	cmd := irm.NewUpdateCommand(loader)
+	out := &bytes.Buffer{}
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs(args)
+	err := cmd.ExecuteContext(context.Background())
+	return out.String(), err
+}
+
+func TestIncidentUpdateCommand(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		wantCalls []string
+		wantOut   []string
+	}{
+		{
+			name:      "severity only",
+			args:      []string{"4", "--severity", "Critical"},
+			wantCalls: []string{"IncidentsService.UpdateSeverity"},
+			wantOut:   []string{"severity: Critical"},
+		},
+		{
+			name:      "title only",
+			args:      []string{"4", "--title", "Checkout latency above the objective"},
+			wantCalls: []string{"IncidentsService.UpdateTitle"},
+			wantOut:   []string{"Checkout latency above the objective"},
+		},
+		{
+			name: "both fields",
+			args: []string{"4", "--title", "new title", "--severity", "Major"},
+			// The title runs first, so the echoed incident carries both.
+			wantCalls: []string{"IncidentsService.UpdateTitle", "IncidentsService.UpdateSeverity"},
+			wantOut:   []string{"new title", "severity: Major"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := &severityServer{title: "old title"}
+			out, err := runIncidentUpdateCmd(t, srv, tt.args...)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if len(srv.calls) != len(tt.wantCalls) {
+				t.Fatalf("got calls %v, want %v", srv.calls, tt.wantCalls)
+			}
+			for i, want := range tt.wantCalls {
+				if srv.calls[i] != want {
+					t.Errorf("call %d: got %q, want %q", i, srv.calls[i], want)
+				}
+			}
+			for _, want := range tt.wantOut {
+				if !strings.Contains(out, want) {
+					t.Errorf("expected %q in the output, got %q", want, out)
+				}
+			}
+		})
+	}
+}
+
+func TestIncidentUpdateCommandRequiresAFlag(t *testing.T) {
+	srv := &severityServer{title: "old title"}
+	_, err := runIncidentUpdateCmd(t, srv, "4")
+	if err == nil || !strings.Contains(err.Error(), "at least one of --severity or --title") {
+		t.Errorf("expected a missing-flag error, got %v", err)
+	}
+	if len(srv.calls) != 0 {
+		t.Errorf("the command called the backend with no flag set: %v", srv.calls)
+	}
+}
+
+func TestIncidentUpdateCommandShape(t *testing.T) {
+	cmd := irm.NewUpdateCommand(fakeGrafanaConfigLoader{})
+	assertFlag(t, cmd, "severity")
+	assertFlag(t, cmd, "title")
+	if !strings.Contains(cmd.Use, "<id>") {
+		t.Errorf("update should take a positional <id>, got Use=%q", cmd.Use)
+	}
+}
+
+func assertFlag(t *testing.T, cmd *cobra.Command, name string) {
+	t.Helper()
+	if cmd.Flags().Lookup(name) == nil {
+		t.Errorf("incidents update is missing the --%s flag", name)
+	}
+}

--- a/internal/providers/irm/incidents_update_command_test.go
+++ b/internal/providers/irm/incidents_update_command_test.go
@@ -13,9 +13,9 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-func runIncidentUpdateCmd(t *testing.T, srv *severityServer, args ...string) (string, error) {
+func runIncidentUpdateCmdWithMode(t *testing.T, srv *severityServer, agentMode string, args ...string) (string, error) {
 	t.Helper()
-	t.Setenv("GCX_AGENT_MODE", "false")
+	t.Setenv("GCX_AGENT_MODE", agentMode)
 	agent.ResetForTesting()
 	t.Cleanup(agent.ResetForTesting)
 
@@ -36,6 +36,11 @@ func runIncidentUpdateCmd(t *testing.T, srv *severityServer, args ...string) (st
 	return out.String(), err
 }
 
+func runIncidentUpdateCmd(t *testing.T, srv *severityServer, args ...string) (string, error) {
+	t.Helper()
+	return runIncidentUpdateCmdWithMode(t, srv, "false", args...)
+}
+
 func TestIncidentUpdateCommand(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -50,6 +55,7 @@ func TestIncidentUpdateCommand(t *testing.T) {
 			args: []string{"4", "--severity", "Critical"},
 			wantCalls: []string{
 				"IncidentsService.GetIncident",
+				"SeveritiesService.GetOrgSeverities",
 				"IncidentsService.UpdateSeverity",
 			},
 			wantOut: []string{"Updated incident 4 (severity)"},
@@ -69,6 +75,7 @@ func TestIncidentUpdateCommand(t *testing.T) {
 			// The title runs before the severity.
 			wantCalls: []string{
 				"IncidentsService.GetIncident",
+				"SeveritiesService.GetOrgSeverities",
 				"IncidentsService.UpdateTitle",
 				"IncidentsService.UpdateSeverity",
 			},
@@ -90,6 +97,9 @@ func TestIncidentUpdateCommand(t *testing.T) {
 			for i, want := range tt.wantCalls {
 				if srv.calls[i] != want {
 					t.Errorf("call %d: got %q, want %q", i, srv.calls[i], want)
+				}
+				if strings.HasPrefix(srv.calls[i], "IncidentsService.") && srv.bodies[i]["incidentID"] != "4" {
+					t.Errorf("call %d sent incidentID %v, want 4", i, srv.bodies[i]["incidentID"])
 				}
 			}
 			for _, want := range tt.wantOut {
@@ -141,26 +151,30 @@ func TestIncidentUpdateCommandRejectsBadFlags(t *testing.T) {
 	}
 }
 
-// TestIncidentUpdateCommandOutputFormats covers the two output cases that
-// TestIncidentUpdateCommand does not reach: a run that changes nothing, and
-// the manifest that -o yaml emits.
+// TestIncidentUpdateCommandOutputFormats covers a run that changes nothing
+// and the structured mutation result in the explicit machine formats.
 func TestIncidentUpdateCommandOutputFormats(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    []string
-		want    string
+		want    []string
 		notWant string
 	}{
 		{
 			name:    "a value that already matches changes nothing",
 			args:    []string{"4", "--title", "old title"},
-			want:    "Incident 4 already carries the requested values\n",
+			want:    []string{"Incident 4 already carries the requested values\n"},
 			notWant: "Updated incident",
 		},
 		{
-			name: "-o yaml emits the manifest",
+			name: "-o yaml emits a changed mutation result",
 			args: []string{"4", "--severity", "Critical", "-o", "yaml"},
-			want: "apiVersion: incident.ext.grafana.app/v1alpha1",
+			want: []string{"type: gcx.mutation", "action: updated", "id: \"4\"", "changed: true"},
+		},
+		{
+			name: "-o json emits an unchanged mutation result",
+			args: []string{"4", "--title", "old title", "-o", "json"},
+			want: []string{`"type": "gcx.mutation"`, `"action": "updated"`, `"id": "4"`, `"changed": false`},
 		},
 	}
 
@@ -171,12 +185,27 @@ func TestIncidentUpdateCommandOutputFormats(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if !strings.Contains(out, tt.want) {
-				t.Errorf("expected %q in the output, got %q", tt.want, out)
+			for _, want := range tt.want {
+				if !strings.Contains(out, want) {
+					t.Errorf("expected %q in the output, got %q", want, out)
+				}
 			}
 			if tt.notWant != "" && strings.Contains(out, tt.notWant) {
 				t.Errorf("did not expect %q in the output, got %q", tt.notWant, out)
 			}
 		})
+	}
+}
+
+func TestIncidentUpdateCommandAgentOutputReportsNoChange(t *testing.T) {
+	srv := &severityServer{title: "old title"}
+	out, err := runIncidentUpdateCmdWithMode(t, srv, "true", "4", "--title", "old title")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{`"type":"gcx.mutation"`, `"id":"4"`, `"changed":false`} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in the agent output, got %q", want, out)
+		}
 	}
 }

--- a/internal/providers/irm/incidents_update_command_test.go
+++ b/internal/providers/irm/incidents_update_command_test.go
@@ -90,14 +90,43 @@ func TestIncidentUpdateCommand(t *testing.T) {
 	}
 }
 
-func TestIncidentUpdateCommandRequiresAFlag(t *testing.T) {
-	srv := &severityServer{title: "old title"}
-	_, err := runIncidentUpdateCmd(t, srv, "4")
-	if err == nil || !strings.Contains(err.Error(), "at least one of --severity or --title") {
-		t.Errorf("expected a missing-flag error, got %v", err)
+// TestIncidentUpdateCommandRejectsBadFlags covers the omitted flag and the
+// explicit empty value. An unset shell variable produces the second one, and
+// silence there loses the request of the caller.
+func TestIncidentUpdateCommandRejectsBadFlags(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "no flag at all",
+			args:    []string{"4"},
+			wantErr: "at least one of --severity or --title",
+		},
+		{
+			name:    "an empty title next to a severity",
+			args:    []string{"4", "--severity", "Critical", "--title", ""},
+			wantErr: "--title must not be empty",
+		},
+		{
+			name:    "an empty severity",
+			args:    []string{"4", "--severity", ""},
+			wantErr: "--severity must not be empty",
+		},
 	}
-	if len(srv.calls) != 0 {
-		t.Errorf("the command called the backend with no flag set: %v", srv.calls)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := &severityServer{title: "old title"}
+			_, err := runIncidentUpdateCmd(t, srv, tt.args...)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("expected %q, got %v", tt.wantErr, err)
+			}
+			if len(srv.calls) != 0 {
+				t.Errorf("the command called the backend on a bad flag: %v", srv.calls)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

Item 4 of #1186, and the highest-severity item in it: **`gcx irm incidents create` silently dropped the severity.** Every incident was created at the default severity, whichever severity the manifest set. `gcx resources list-types` advertised both `spec.severity` and `spec.severityID`, which made the silence worse. No command could change the severity afterwards.

```console
$ gcx irm incidents create -f inc.json    # spec.severity: Critical
✔ Created incident probe (id=1)
$ gcx irm incidents get 1
severity: Pending
```

## Changes

```bash
# create now applies the severity
gcx irm incidents create -f incident.yaml    # spec.severity: Critical

# and it can be changed afterwards
gcx irm incidents update <id> --severity Critical
gcx irm incidents update <id> --title "Checkout latency above the objective"
```

| File | Change |
| --- | --- |
| `internal/providers/irm/incidents_client.go` | Adds the title and severity update operations; validates severity labels and IDs before writes; adds consistent versioned/unversioned fallback |
| `internal/providers/irm/incidents_types.go` | Adds the update request bodies and internal mutation metadata |
| `internal/providers/irm/incidents_update_command.go` | Adds `incidents update` through the shared `TypedCRUD` path and emits a structured mutation result |
| `internal/providers/irm/incidents_resource_adapter.go` | Applies status, title, and severity; uses one shared read-field strip list |
| `internal/providers/irm/incidents_commands.go` | Wires `update` onto the incidents noun |
| `internal/agent/command_annotations.go`, `cmd/gcx/root/testdata/output_classes.json` | Adds agent metadata and the output class |
| `docs/reference/cli/`, `docs/architecture/architecture.md` | Regenerates and updates the documentation |

## Compatibility note

Incident reads no longer emit `spec.severityID`. The field is write-only: a hand-written manifest can still use it, but `get`, `list`, and `pull` return `spec.severity` only. This prevents an organization-specific identifier from overriding an edited severity label or breaking a cross-stack push. Existing callers that read `.spec.severityID` must use `.spec.severity` instead.

The new `incidents update` command emits a `gcx.mutation` result for JSON, YAML, and agent output. Its `changed` field distinguishes a write from an idempotent no-op. Text output remains one status line.

## Design notes

**Why `Create` makes a second write.** `IncidentsService.CreateIncident` ignores the severity in the request body. `UpdateSeverity` is the only route. `Create` validates the requested label or identifier against the organization severity list before it creates the incident, and then applies the severity when the created incident does not already carry it. A manifest with no severity still costs one call. A manifest with a severity also reads the severity list before it writes.

**Why the fix lives in the shared CRUD path.** The provider command and the `resources push` pipeline both reach the same `TypedCRUD` update function. The create and update fixes therefore apply to both access paths.

**How severity input resolves.** `UpdateSeverity` takes the display label, not the identifier. Both `spec.severity` and `spec.severityID` resolve through `SeveritiesService.GetOrgSeverities` before any write. An unknown value is an error that names `gcx irm incidents severities list`.

**What `Update` changes.** `resources push` previously applied the status and dropped the title and severity. `Update` now applies all three and skips fields that already match. The IRM API has no update operation for the other incident fields.

**How the fallback works.** `GetIncident` and the field update operations try the versioned path first and the unversioned path after a 404. If both update paths return 404, `GetIncident` distinguishes a missing incident from an unavailable update operation.

## Compliance

| Level | Result |
| --- | --- |
| CONSTITUTION | Pass. The provider update command uses `TypedCRUD`; both access paths share the same update logic and serialized resource shape. |
| VISION | Pass. IRM Incidents is an existing product surface. |
| DESIGN | Pass. Positional subject, flag modifiers, `finite` output class, text status output, and a structured mutation result for machine formats. |
| ARCHITECTURE | Pass. The new file sits inside the existing IRM provider; the architecture file table records it. |

## Test plan

- [x] `GCX_AGENT_MODE=false mise run all` passes
- [x] Tests cover label and identifier validation before writes
- [x] Tests cover versioned/unversioned fallback and missing-operation classification
- [x] Tests cover all changed and unchanged fields on the shared update path
- [x] Tests cover request ID binding and text, JSON, YAML, and agent output
- [x] Reference documentation regenerated

Refs #1186 (item 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
