### PR TITLE
fix: include otlp_url and otlp_username in instrumentation cluster configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- instrumentation: app and service writes (`clusters apps configure`/`remove`, `services include`/`exclude`/`clear`) no longer fail with `otlp_url is required`.
+
 ## v1.0.0 (2026-07-28)
 
 ### Features

--- a/cmd/gcx/instrumentation/services/clear_test.go
+++ b/cmd/gcx/instrumentation/services/clear_test.go
@@ -32,7 +32,7 @@ func TestRunClear_RemovesOverride(t *testing.T) {
 	client := makeIncludeClient(t, srv.URL)
 
 	var out bytes.Buffer
-	err := services.RunClear(context.Background(), services.NewMutationTestIO(t), client, "c1", "grotshop", "frontend", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+	err := services.RunClear(context.Background(), services.NewMutationTestIO(t), client, "c1", "grotshop", "frontend", testBackendURLs, instrumentation.PromHeaders{}, &out)
 	require.NoError(t, err, "clear must succeed")
 	assert.Equal(t, int64(1), ts.setAppCalled.Load(), "Set must be called once to remove the override")
 }
@@ -53,7 +53,7 @@ func TestRunClear_NoOp_NoOverride(t *testing.T) {
 	client := makeIncludeClient(t, srv.URL)
 
 	var out bytes.Buffer
-	err := services.RunClear(context.Background(), services.NewMutationTestIO(t), client, "c1", "grotshop", "frontend", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+	err := services.RunClear(context.Background(), services.NewMutationTestIO(t), client, "c1", "grotshop", "frontend", testBackendURLs, instrumentation.PromHeaders{}, &out)
 	require.NoError(t, err, "clear with no override must be a no-op (exit 0)")
 	assert.Equal(t, int64(0), ts.setAppCalled.Load(), "no Set call when no override exists")
 }
@@ -72,7 +72,7 @@ func TestRunClear_NoOp_NamespaceNotFound(t *testing.T) {
 	srv := ts.start(t)
 	client := makeIncludeClient(t, srv.URL)
 
-	err := services.RunClear(context.Background(), services.NewMutationTestIO(t), client, "c1", "missing-ns", "svc", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &bytes.Buffer{})
+	err := services.RunClear(context.Background(), services.NewMutationTestIO(t), client, "c1", "missing-ns", "svc", testBackendURLs, instrumentation.PromHeaders{}, &bytes.Buffer{})
 	require.NoError(t, err, "clear on missing namespace must be a no-op")
 	assert.Equal(t, int64(0), ts.setAppCalled.Load(), "no Set call for missing namespace")
 }
@@ -119,12 +119,12 @@ func TestRunClear_Idempotent_TwoCalls(t *testing.T) {
 	client := makeIncludeClient(t, srv.URL)
 
 	// First clear: removes the INCLUDED override.
-	err1 := services.RunClear(context.Background(), services.NewMutationTestIO(t), client, "c1", "grotshop", "frontend", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &bytes.Buffer{})
+	err1 := services.RunClear(context.Background(), services.NewMutationTestIO(t), client, "c1", "grotshop", "frontend", testBackendURLs, instrumentation.PromHeaders{}, &bytes.Buffer{})
 	require.NoError(t, err1, "first clear must succeed")
 	assert.Equal(t, int64(1), ts.setAppCalled.Load(), "first clear must call Set once")
 
 	// Second clear: no override → no-op.
-	err2 := services.RunClear(context.Background(), services.NewMutationTestIO(t), client, "c1", "grotshop", "frontend", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &bytes.Buffer{})
+	err2 := services.RunClear(context.Background(), services.NewMutationTestIO(t), client, "c1", "grotshop", "frontend", testBackendURLs, instrumentation.PromHeaders{}, &bytes.Buffer{})
 	require.NoError(t, err2, "second clear must succeed (exit 0)")
 	assert.Equal(t, int64(1), ts.setAppCalled.Load(), "second clear must be a no-op (no additional Set)")
 }
@@ -154,7 +154,7 @@ func TestRunClear_WorkloadNotFound(t *testing.T) {
 
 	var out bytes.Buffer
 	err := services.RunClear(context.Background(), services.NewMutationTestIO(t), client, "prod-eu", "checkout", "nonexistent-svc",
-		instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+		testBackendURLs, instrumentation.PromHeaders{}, &out)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Resource not found")
 	// Verify GetAppInstrumentation was NOT called (pre-flight short-circuited).

--- a/cmd/gcx/instrumentation/services/clear_test.go
+++ b/cmd/gcx/instrumentation/services/clear_test.go
@@ -32,7 +32,7 @@ func TestRunClear_RemovesOverride(t *testing.T) {
 	client := makeIncludeClient(t, srv.URL)
 
 	var out bytes.Buffer
-	err := services.RunClear(context.Background(), services.NewMutationTestIO(t), client, "c1", "grotshop", "frontend", testBackendURLs, instrumentation.PromHeaders{}, &out)
+	err := services.RunClear(context.Background(), services.NewMutationTestIO(t), client, "c1", "grotshop", "frontend", instrumentation.BackendURLs{OTLPURL: "https://otlp-gateway.example/otlp"}, instrumentation.PromHeaders{}, &out)
 	require.NoError(t, err, "clear must succeed")
 	assert.Equal(t, int64(1), ts.setAppCalled.Load(), "Set must be called once to remove the override")
 }
@@ -53,7 +53,7 @@ func TestRunClear_NoOp_NoOverride(t *testing.T) {
 	client := makeIncludeClient(t, srv.URL)
 
 	var out bytes.Buffer
-	err := services.RunClear(context.Background(), services.NewMutationTestIO(t), client, "c1", "grotshop", "frontend", testBackendURLs, instrumentation.PromHeaders{}, &out)
+	err := services.RunClear(context.Background(), services.NewMutationTestIO(t), client, "c1", "grotshop", "frontend", instrumentation.BackendURLs{OTLPURL: "https://otlp-gateway.example/otlp"}, instrumentation.PromHeaders{}, &out)
 	require.NoError(t, err, "clear with no override must be a no-op (exit 0)")
 	assert.Equal(t, int64(0), ts.setAppCalled.Load(), "no Set call when no override exists")
 }
@@ -72,7 +72,7 @@ func TestRunClear_NoOp_NamespaceNotFound(t *testing.T) {
 	srv := ts.start(t)
 	client := makeIncludeClient(t, srv.URL)
 
-	err := services.RunClear(context.Background(), services.NewMutationTestIO(t), client, "c1", "missing-ns", "svc", testBackendURLs, instrumentation.PromHeaders{}, &bytes.Buffer{})
+	err := services.RunClear(context.Background(), services.NewMutationTestIO(t), client, "c1", "missing-ns", "svc", instrumentation.BackendURLs{OTLPURL: "https://otlp-gateway.example/otlp"}, instrumentation.PromHeaders{}, &bytes.Buffer{})
 	require.NoError(t, err, "clear on missing namespace must be a no-op")
 	assert.Equal(t, int64(0), ts.setAppCalled.Load(), "no Set call for missing namespace")
 }
@@ -119,12 +119,12 @@ func TestRunClear_Idempotent_TwoCalls(t *testing.T) {
 	client := makeIncludeClient(t, srv.URL)
 
 	// First clear: removes the INCLUDED override.
-	err1 := services.RunClear(context.Background(), services.NewMutationTestIO(t), client, "c1", "grotshop", "frontend", testBackendURLs, instrumentation.PromHeaders{}, &bytes.Buffer{})
+	err1 := services.RunClear(context.Background(), services.NewMutationTestIO(t), client, "c1", "grotshop", "frontend", instrumentation.BackendURLs{OTLPURL: "https://otlp-gateway.example/otlp"}, instrumentation.PromHeaders{}, &bytes.Buffer{})
 	require.NoError(t, err1, "first clear must succeed")
 	assert.Equal(t, int64(1), ts.setAppCalled.Load(), "first clear must call Set once")
 
 	// Second clear: no override → no-op.
-	err2 := services.RunClear(context.Background(), services.NewMutationTestIO(t), client, "c1", "grotshop", "frontend", testBackendURLs, instrumentation.PromHeaders{}, &bytes.Buffer{})
+	err2 := services.RunClear(context.Background(), services.NewMutationTestIO(t), client, "c1", "grotshop", "frontend", instrumentation.BackendURLs{OTLPURL: "https://otlp-gateway.example/otlp"}, instrumentation.PromHeaders{}, &bytes.Buffer{})
 	require.NoError(t, err2, "second clear must succeed (exit 0)")
 	assert.Equal(t, int64(1), ts.setAppCalled.Load(), "second clear must be a no-op (no additional Set)")
 }
@@ -154,7 +154,7 @@ func TestRunClear_WorkloadNotFound(t *testing.T) {
 
 	var out bytes.Buffer
 	err := services.RunClear(context.Background(), services.NewMutationTestIO(t), client, "prod-eu", "checkout", "nonexistent-svc",
-		testBackendURLs, instrumentation.PromHeaders{}, &out)
+		instrumentation.BackendURLs{OTLPURL: "https://otlp-gateway.example/otlp"}, instrumentation.PromHeaders{}, &out)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Resource not found")
 	// Verify GetAppInstrumentation was NOT called (pre-flight short-circuited).

--- a/cmd/gcx/instrumentation/services/exclude_test.go
+++ b/cmd/gcx/instrumentation/services/exclude_test.go
@@ -30,7 +30,7 @@ func TestRunExclude_AutoinstrumentTrue_AddsExcluded(t *testing.T) {
 	client := makeIncludeClient(t, srv.URL)
 
 	var out bytes.Buffer
-	err := services.RunExclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "ns", "svc", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+	err := services.RunExclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "ns", "svc", testBackendURLs, instrumentation.PromHeaders{}, &out)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), ts.setAppCalled.Load(), "Set must be called once to add EXCLUDED override when autoinstrument=true")
 }
@@ -51,7 +51,7 @@ func TestRunExclude_AutoinstrumentFalse_NoOp(t *testing.T) {
 	client := makeIncludeClient(t, srv.URL)
 
 	var out bytes.Buffer
-	err := services.RunExclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "ns", "svc", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+	err := services.RunExclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "ns", "svc", testBackendURLs, instrumentation.PromHeaders{}, &out)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), ts.setAppCalled.Load(), "no Set call when autoinstrument=false (namespace default is already off)")
 }
@@ -71,7 +71,7 @@ func TestRunExclude_NilAutoinstrument_NoOp(t *testing.T) {
 	client := makeIncludeClient(t, srv.URL)
 
 	var out bytes.Buffer
-	err := services.RunExclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "ns", "svc", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+	err := services.RunExclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "ns", "svc", testBackendURLs, instrumentation.PromHeaders{}, &out)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), ts.setAppCalled.Load(), "no Set call when autoinstrument=nil")
 }
@@ -94,7 +94,7 @@ func TestRunExclude_RemovesIncludedOverride(t *testing.T) {
 	client := makeIncludeClient(t, srv.URL)
 
 	var out bytes.Buffer
-	err := services.RunExclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "ns", "svc", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+	err := services.RunExclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "ns", "svc", testBackendURLs, instrumentation.PromHeaders{}, &out)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), ts.setAppCalled.Load(), "Set must be called once to replace INCLUDED with EXCLUDED")
 }
@@ -113,7 +113,7 @@ func TestRunExclude_NamespaceNotFound(t *testing.T) {
 	srv := ts.start(t)
 	client := makeIncludeClient(t, srv.URL)
 
-	err := services.RunExclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "missing-ns", "svc", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &bytes.Buffer{})
+	err := services.RunExclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "missing-ns", "svc", testBackendURLs, instrumentation.PromHeaders{}, &bytes.Buffer{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "services exclude")
 	assert.Contains(t, err.Error(), "missing-ns")
@@ -165,14 +165,14 @@ func TestRunExclude_Idempotent(t *testing.T) {
 
 	// First invocation: should call SetApp once.
 	var out1 bytes.Buffer
-	err1 := services.RunExclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "ns", "svc", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out1)
+	err1 := services.RunExclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "ns", "svc", testBackendURLs, instrumentation.PromHeaders{}, &out1)
 	require.NoError(t, err1, "first exclude must succeed")
 	firstCallCount := ts.setAppCalled.Load()
 	assert.Equal(t, int64(1), firstCallCount, "first exclude must call SetApp once")
 
 	// Second invocation: reads post-write state (EXCLUDED already present) → no-op.
 	var out2 bytes.Buffer
-	err2 := services.RunExclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "ns", "svc", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out2)
+	err2 := services.RunExclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "ns", "svc", testBackendURLs, instrumentation.PromHeaders{}, &out2)
 	require.NoError(t, err2, "second exclude must succeed (exit 0)")
 	secondCallCount := ts.setAppCalled.Load()
 	assert.Equal(t, firstCallCount, secondCallCount, "second exclude must be a no-op: no additional Set calls")
@@ -203,7 +203,7 @@ func TestRunExclude_WorkloadNotFound(t *testing.T) {
 
 	var out bytes.Buffer
 	err := services.RunExclude(context.Background(), services.NewMutationTestIO(t), client, "prod-eu", "checkout", "nonexistent-svc",
-		instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+		testBackendURLs, instrumentation.PromHeaders{}, &out)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Resource not found")
 	// Verify GetAppInstrumentation was NOT called (pre-flight short-circuited).

--- a/cmd/gcx/instrumentation/services/exclude_test.go
+++ b/cmd/gcx/instrumentation/services/exclude_test.go
@@ -30,7 +30,7 @@ func TestRunExclude_AutoinstrumentTrue_AddsExcluded(t *testing.T) {
 	client := makeIncludeClient(t, srv.URL)
 
 	var out bytes.Buffer
-	err := services.RunExclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "ns", "svc", testBackendURLs, instrumentation.PromHeaders{}, &out)
+	err := services.RunExclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "ns", "svc", instrumentation.BackendURLs{OTLPURL: "https://otlp-gateway.example/otlp"}, instrumentation.PromHeaders{}, &out)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), ts.setAppCalled.Load(), "Set must be called once to add EXCLUDED override when autoinstrument=true")
 }
@@ -51,7 +51,7 @@ func TestRunExclude_AutoinstrumentFalse_NoOp(t *testing.T) {
 	client := makeIncludeClient(t, srv.URL)
 
 	var out bytes.Buffer
-	err := services.RunExclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "ns", "svc", testBackendURLs, instrumentation.PromHeaders{}, &out)
+	err := services.RunExclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "ns", "svc", instrumentation.BackendURLs{OTLPURL: "https://otlp-gateway.example/otlp"}, instrumentation.PromHeaders{}, &out)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), ts.setAppCalled.Load(), "no Set call when autoinstrument=false (namespace default is already off)")
 }
@@ -71,7 +71,7 @@ func TestRunExclude_NilAutoinstrument_NoOp(t *testing.T) {
 	client := makeIncludeClient(t, srv.URL)
 
 	var out bytes.Buffer
-	err := services.RunExclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "ns", "svc", testBackendURLs, instrumentation.PromHeaders{}, &out)
+	err := services.RunExclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "ns", "svc", instrumentation.BackendURLs{OTLPURL: "https://otlp-gateway.example/otlp"}, instrumentation.PromHeaders{}, &out)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), ts.setAppCalled.Load(), "no Set call when autoinstrument=nil")
 }
@@ -94,7 +94,7 @@ func TestRunExclude_RemovesIncludedOverride(t *testing.T) {
 	client := makeIncludeClient(t, srv.URL)
 
 	var out bytes.Buffer
-	err := services.RunExclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "ns", "svc", testBackendURLs, instrumentation.PromHeaders{}, &out)
+	err := services.RunExclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "ns", "svc", instrumentation.BackendURLs{OTLPURL: "https://otlp-gateway.example/otlp"}, instrumentation.PromHeaders{}, &out)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), ts.setAppCalled.Load(), "Set must be called once to replace INCLUDED with EXCLUDED")
 }
@@ -113,7 +113,7 @@ func TestRunExclude_NamespaceNotFound(t *testing.T) {
 	srv := ts.start(t)
 	client := makeIncludeClient(t, srv.URL)
 
-	err := services.RunExclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "missing-ns", "svc", testBackendURLs, instrumentation.PromHeaders{}, &bytes.Buffer{})
+	err := services.RunExclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "missing-ns", "svc", instrumentation.BackendURLs{OTLPURL: "https://otlp-gateway.example/otlp"}, instrumentation.PromHeaders{}, &bytes.Buffer{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "services exclude")
 	assert.Contains(t, err.Error(), "missing-ns")
@@ -165,14 +165,14 @@ func TestRunExclude_Idempotent(t *testing.T) {
 
 	// First invocation: should call SetApp once.
 	var out1 bytes.Buffer
-	err1 := services.RunExclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "ns", "svc", testBackendURLs, instrumentation.PromHeaders{}, &out1)
+	err1 := services.RunExclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "ns", "svc", instrumentation.BackendURLs{OTLPURL: "https://otlp-gateway.example/otlp"}, instrumentation.PromHeaders{}, &out1)
 	require.NoError(t, err1, "first exclude must succeed")
 	firstCallCount := ts.setAppCalled.Load()
 	assert.Equal(t, int64(1), firstCallCount, "first exclude must call SetApp once")
 
 	// Second invocation: reads post-write state (EXCLUDED already present) → no-op.
 	var out2 bytes.Buffer
-	err2 := services.RunExclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "ns", "svc", testBackendURLs, instrumentation.PromHeaders{}, &out2)
+	err2 := services.RunExclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "ns", "svc", instrumentation.BackendURLs{OTLPURL: "https://otlp-gateway.example/otlp"}, instrumentation.PromHeaders{}, &out2)
 	require.NoError(t, err2, "second exclude must succeed (exit 0)")
 	secondCallCount := ts.setAppCalled.Load()
 	assert.Equal(t, firstCallCount, secondCallCount, "second exclude must be a no-op: no additional Set calls")
@@ -203,7 +203,7 @@ func TestRunExclude_WorkloadNotFound(t *testing.T) {
 
 	var out bytes.Buffer
 	err := services.RunExclude(context.Background(), services.NewMutationTestIO(t), client, "prod-eu", "checkout", "nonexistent-svc",
-		testBackendURLs, instrumentation.PromHeaders{}, &out)
+		instrumentation.BackendURLs{OTLPURL: "https://otlp-gateway.example/otlp"}, instrumentation.PromHeaders{}, &out)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Resource not found")
 	// Verify GetAppInstrumentation was NOT called (pre-flight short-circuited).

--- a/cmd/gcx/instrumentation/services/include_test.go
+++ b/cmd/gcx/instrumentation/services/include_test.go
@@ -71,10 +71,6 @@ func makeIncludeClient(t *testing.T, serverURL string) *instrumentation.Client {
 	return instrumentation.NewClient(f)
 }
 
-// testBackendURLs stands in for what BackendURLsFromStack resolves in
-// production; a set OTLPURL clears the SetAppInstrumentation precondition.
-var testBackendURLs = instrumentation.BackendURLs{OTLPURL: "https://otlp-gateway.example/otlp"}
-
 // buildGetAppResp builds a JSON GetAppInstrumentation response with one namespace.
 //
 //nolint:unparam // clusterName is designed to be flexible; current tests all use "c1" by convention.
@@ -145,14 +141,14 @@ func TestRunInclude_Idempotent_AutoinstrumentDefault(t *testing.T) {
 
 	// First invocation: should call SetApp once.
 	var out1 bytes.Buffer
-	err1 := services.RunInclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "grotshop", "frontend", testBackendURLs, instrumentation.PromHeaders{}, &out1)
+	err1 := services.RunInclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "grotshop", "frontend", instrumentation.BackendURLs{OTLPURL: "https://otlp-gateway.example/otlp"}, instrumentation.PromHeaders{}, &out1)
 	require.NoError(t, err1, "first include must succeed (exit 0)")
 	firstCallCount := ts.setAppCalled.Load()
 	assert.Equal(t, int64(1), firstCallCount, "first include must call SetApp once")
 
 	// Second invocation: reads post-write state (INCLUDED already present) → no-op.
 	var out2 bytes.Buffer
-	err2 := services.RunInclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "grotshop", "frontend", testBackendURLs, instrumentation.PromHeaders{}, &out2)
+	err2 := services.RunInclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "grotshop", "frontend", instrumentation.BackendURLs{OTLPURL: "https://otlp-gateway.example/otlp"}, instrumentation.PromHeaders{}, &out2)
 	require.NoError(t, err2, "second include must succeed (exit 0)")
 	secondCallCount := ts.setAppCalled.Load()
 	assert.Equal(t, firstCallCount, secondCallCount,
@@ -175,7 +171,7 @@ func TestRunInclude_AutoinstrumentTrue_NoOverrideAdded(t *testing.T) {
 	client := makeIncludeClient(t, srv.URL)
 
 	var out bytes.Buffer
-	err := services.RunInclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "ns", "svc", testBackendURLs, instrumentation.PromHeaders{}, &out)
+	err := services.RunInclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "ns", "svc", instrumentation.BackendURLs{OTLPURL: "https://otlp-gateway.example/otlp"}, instrumentation.PromHeaders{}, &out)
 	require.NoError(t, err)
 	// autoinstrument=true: namespace default is on, no override needed → no-op.
 	assert.Equal(t, int64(0), ts.setAppCalled.Load(), "no Set call when autoinstrument=true and service is not excluded")
@@ -199,7 +195,7 @@ func TestRunInclude_RemovesExcludedOverride(t *testing.T) {
 	client := makeIncludeClient(t, srv.URL)
 
 	var out bytes.Buffer
-	err := services.RunInclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "ns", "svc", testBackendURLs, instrumentation.PromHeaders{}, &out)
+	err := services.RunInclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "ns", "svc", instrumentation.BackendURLs{OTLPURL: "https://otlp-gateway.example/otlp"}, instrumentation.PromHeaders{}, &out)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), ts.setAppCalled.Load(), "Set must be called once to remove EXCLUDED override")
 }
@@ -219,7 +215,7 @@ func TestRunInclude_NamespaceNotFound(t *testing.T) {
 	srv := ts.start(t)
 	client := makeIncludeClient(t, srv.URL)
 
-	err := services.RunInclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "missing-ns", "svc", testBackendURLs, instrumentation.PromHeaders{}, &bytes.Buffer{})
+	err := services.RunInclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "missing-ns", "svc", instrumentation.BackendURLs{OTLPURL: "https://otlp-gateway.example/otlp"}, instrumentation.PromHeaders{}, &bytes.Buffer{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "services include")
 	assert.Contains(t, err.Error(), "missing-ns")
@@ -250,7 +246,7 @@ func TestRunInclude_WorkloadNotFound(t *testing.T) {
 
 	var out bytes.Buffer
 	err := services.RunInclude(context.Background(), services.NewMutationTestIO(t), client, "prod-eu", "checkout", "nonexistent-svc",
-		testBackendURLs, instrumentation.PromHeaders{}, &out)
+		instrumentation.BackendURLs{OTLPURL: "https://otlp-gateway.example/otlp"}, instrumentation.PromHeaders{}, &out)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Resource not found")
 	// Verify GetAppInstrumentation was NOT called (pre-flight short-circuited).
@@ -279,7 +275,7 @@ func TestRunInclude_WorkloadNotFound_ExitCode1(t *testing.T) {
 
 	var out bytes.Buffer
 	err := services.RunInclude(context.Background(), services.NewMutationTestIO(t), client, "prod-eu", "checkout", "nonexistent-svc",
-		testBackendURLs, instrumentation.PromHeaders{}, &out)
+		instrumentation.BackendURLs{OTLPURL: "https://otlp-gateway.example/otlp"}, instrumentation.PromHeaders{}, &out)
 	require.Error(t, err)
 
 	var de *gcxerrors.DetailedError

--- a/cmd/gcx/instrumentation/services/include_test.go
+++ b/cmd/gcx/instrumentation/services/include_test.go
@@ -71,6 +71,10 @@ func makeIncludeClient(t *testing.T, serverURL string) *instrumentation.Client {
 	return instrumentation.NewClient(f)
 }
 
+// testBackendURLs stands in for what BackendURLsFromStack resolves in
+// production; a set OTLPURL clears the SetAppInstrumentation precondition.
+var testBackendURLs = instrumentation.BackendURLs{OTLPURL: "https://otlp-gateway.example/otlp"}
+
 // buildGetAppResp builds a JSON GetAppInstrumentation response with one namespace.
 //
 //nolint:unparam // clusterName is designed to be flexible; current tests all use "c1" by convention.
@@ -141,14 +145,14 @@ func TestRunInclude_Idempotent_AutoinstrumentDefault(t *testing.T) {
 
 	// First invocation: should call SetApp once.
 	var out1 bytes.Buffer
-	err1 := services.RunInclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "grotshop", "frontend", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out1)
+	err1 := services.RunInclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "grotshop", "frontend", testBackendURLs, instrumentation.PromHeaders{}, &out1)
 	require.NoError(t, err1, "first include must succeed (exit 0)")
 	firstCallCount := ts.setAppCalled.Load()
 	assert.Equal(t, int64(1), firstCallCount, "first include must call SetApp once")
 
 	// Second invocation: reads post-write state (INCLUDED already present) → no-op.
 	var out2 bytes.Buffer
-	err2 := services.RunInclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "grotshop", "frontend", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out2)
+	err2 := services.RunInclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "grotshop", "frontend", testBackendURLs, instrumentation.PromHeaders{}, &out2)
 	require.NoError(t, err2, "second include must succeed (exit 0)")
 	secondCallCount := ts.setAppCalled.Load()
 	assert.Equal(t, firstCallCount, secondCallCount,
@@ -171,7 +175,7 @@ func TestRunInclude_AutoinstrumentTrue_NoOverrideAdded(t *testing.T) {
 	client := makeIncludeClient(t, srv.URL)
 
 	var out bytes.Buffer
-	err := services.RunInclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "ns", "svc", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+	err := services.RunInclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "ns", "svc", testBackendURLs, instrumentation.PromHeaders{}, &out)
 	require.NoError(t, err)
 	// autoinstrument=true: namespace default is on, no override needed → no-op.
 	assert.Equal(t, int64(0), ts.setAppCalled.Load(), "no Set call when autoinstrument=true and service is not excluded")
@@ -195,7 +199,7 @@ func TestRunInclude_RemovesExcludedOverride(t *testing.T) {
 	client := makeIncludeClient(t, srv.URL)
 
 	var out bytes.Buffer
-	err := services.RunInclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "ns", "svc", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+	err := services.RunInclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "ns", "svc", testBackendURLs, instrumentation.PromHeaders{}, &out)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), ts.setAppCalled.Load(), "Set must be called once to remove EXCLUDED override")
 }
@@ -215,7 +219,7 @@ func TestRunInclude_NamespaceNotFound(t *testing.T) {
 	srv := ts.start(t)
 	client := makeIncludeClient(t, srv.URL)
 
-	err := services.RunInclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "missing-ns", "svc", instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &bytes.Buffer{})
+	err := services.RunInclude(context.Background(), services.NewMutationTestIO(t), client, "c1", "missing-ns", "svc", testBackendURLs, instrumentation.PromHeaders{}, &bytes.Buffer{})
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "services include")
 	assert.Contains(t, err.Error(), "missing-ns")
@@ -246,7 +250,7 @@ func TestRunInclude_WorkloadNotFound(t *testing.T) {
 
 	var out bytes.Buffer
 	err := services.RunInclude(context.Background(), services.NewMutationTestIO(t), client, "prod-eu", "checkout", "nonexistent-svc",
-		instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+		testBackendURLs, instrumentation.PromHeaders{}, &out)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Resource not found")
 	// Verify GetAppInstrumentation was NOT called (pre-flight short-circuited).
@@ -275,7 +279,7 @@ func TestRunInclude_WorkloadNotFound_ExitCode1(t *testing.T) {
 
 	var out bytes.Buffer
 	err := services.RunInclude(context.Background(), services.NewMutationTestIO(t), client, "prod-eu", "checkout", "nonexistent-svc",
-		instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+		testBackendURLs, instrumentation.PromHeaders{}, &out)
 	require.Error(t, err)
 
 	var de *gcxerrors.DetailedError

--- a/cmd/gcx/instrumentation/services/mutation_contract_test.go
+++ b/cmd/gcx/instrumentation/services/mutation_contract_test.go
@@ -48,19 +48,18 @@ func runServiceMutation(t *testing.T, verb string, outOpts *cmdio.Options) (stri
 	ts := srv.start(t)
 	client := makeIncludeClient(t, ts.URL)
 
-	urls := instrumentation.BackendURLs{OTLPURL: "https://otlp-gateway.example/otlp"}
 	var out bytes.Buffer
 	var err error
 	switch verb {
 	case "include":
 		err = services.RunInclude(context.Background(), outOpts, client, "c1", "grotshop", "frontend",
-			urls, instrumentation.PromHeaders{}, &out)
+			testBackendURLs, instrumentation.PromHeaders{}, &out)
 	case "exclude":
 		err = services.RunExclude(context.Background(), outOpts, client, "c1", "grotshop", "frontend",
-			urls, instrumentation.PromHeaders{}, &out)
+			testBackendURLs, instrumentation.PromHeaders{}, &out)
 	case "clear":
 		err = services.RunClear(context.Background(), outOpts, client, "c1", "grotshop", "frontend",
-			urls, instrumentation.PromHeaders{}, &out)
+			testBackendURLs, instrumentation.PromHeaders{}, &out)
 	default:
 		t.Fatalf("unknown verb %q", verb)
 	}

--- a/cmd/gcx/instrumentation/services/mutation_contract_test.go
+++ b/cmd/gcx/instrumentation/services/mutation_contract_test.go
@@ -48,18 +48,19 @@ func runServiceMutation(t *testing.T, verb string, outOpts *cmdio.Options) (stri
 	ts := srv.start(t)
 	client := makeIncludeClient(t, ts.URL)
 
+	urls := instrumentation.BackendURLs{OTLPURL: "https://otlp-gateway.example/otlp"}
 	var out bytes.Buffer
 	var err error
 	switch verb {
 	case "include":
 		err = services.RunInclude(context.Background(), outOpts, client, "c1", "grotshop", "frontend",
-			instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+			urls, instrumentation.PromHeaders{}, &out)
 	case "exclude":
 		err = services.RunExclude(context.Background(), outOpts, client, "c1", "grotshop", "frontend",
-			instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+			urls, instrumentation.PromHeaders{}, &out)
 	case "clear":
 		err = services.RunClear(context.Background(), outOpts, client, "c1", "grotshop", "frontend",
-			instrumentation.BackendURLs{}, instrumentation.PromHeaders{}, &out)
+			urls, instrumentation.PromHeaders{}, &out)
 	default:
 		t.Fatalf("unknown verb %q", verb)
 	}

--- a/cmd/gcx/instrumentation/services/mutation_contract_test.go
+++ b/cmd/gcx/instrumentation/services/mutation_contract_test.go
@@ -53,13 +53,13 @@ func runServiceMutation(t *testing.T, verb string, outOpts *cmdio.Options) (stri
 	switch verb {
 	case "include":
 		err = services.RunInclude(context.Background(), outOpts, client, "c1", "grotshop", "frontend",
-			testBackendURLs, instrumentation.PromHeaders{}, &out)
+			instrumentation.BackendURLs{OTLPURL: "https://otlp-gateway.example/otlp"}, instrumentation.PromHeaders{}, &out)
 	case "exclude":
 		err = services.RunExclude(context.Background(), outOpts, client, "c1", "grotshop", "frontend",
-			testBackendURLs, instrumentation.PromHeaders{}, &out)
+			instrumentation.BackendURLs{OTLPURL: "https://otlp-gateway.example/otlp"}, instrumentation.PromHeaders{}, &out)
 	case "clear":
 		err = services.RunClear(context.Background(), outOpts, client, "c1", "grotshop", "frontend",
-			testBackendURLs, instrumentation.PromHeaders{}, &out)
+			instrumentation.BackendURLs{OTLPURL: "https://otlp-gateway.example/otlp"}, instrumentation.PromHeaders{}, &out)
 	default:
 		t.Fatalf("unknown verb %q", verb)
 	}

--- a/internal/providers/instrumentation/client.go
+++ b/internal/providers/instrumentation/client.go
@@ -3,6 +3,7 @@ package instrumentation
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -50,6 +51,8 @@ type BackendURLs struct {
 	TempoUsername     string `json:"tempo_username"`
 	PyroscopeURL      string `json:"pyroscope_url"`
 	PyroscopeUsername string `json:"pyroscope_username"`
+	OTLPURL           string `json:"otlp_url,omitempty"`
+	OTLPUsername      string `json:"otlp_username,omitempty"`
 }
 
 // BackendURLsFromStack resolves datasource write endpoints from the Grafana
@@ -65,7 +68,41 @@ func BackendURLsFromStack(stack cloud.StackInfo) BackendURLs {
 		TempoUsername:     strconv.Itoa(stack.HTInstanceID),
 		PyroscopeURL:      appendPath(stack.HPInstanceURL, "/ingest"),
 		PyroscopeUsername: strconv.Itoa(stack.HPInstanceID),
+		OTLPURL:           otlpGatewayURL(stack),
+		OTLPUsername:      strconv.Itoa(stack.ID),
 	}
+}
+
+// otlpGatewayURL derives the OTLP gateway endpoint, which GCOM does not return.
+func otlpGatewayURL(stack cloud.StackInfo) string {
+	if stack.RegionSlug == "" {
+		return ""
+	}
+	domain := grafanaCloudDomain(
+		stack.HMInstancePromURL, stack.HLInstanceURL, stack.HTInstanceURL, stack.HPInstanceURL)
+	if domain == "" {
+		return ""
+	}
+	return "https://otlp-gateway-" + stack.RegionSlug + "." + domain + "/otlp"
+}
+
+// grafanaCloudDomain returns the base domain (host minus its first DNS label) of
+// the first usable ingest URL, e.g. "grafana.net" from a "prometheus-...grafana.net" host.
+func grafanaCloudDomain(ingestURLs ...string) string {
+	for _, raw := range ingestURLs {
+		if raw == "" {
+			continue
+		}
+		u, err := url.Parse(raw)
+		if err != nil {
+			continue
+		}
+		host := u.Hostname()
+		if i := strings.Index(host, "."); i >= 0 && i < len(host)-1 {
+			return host[i+1:]
+		}
+	}
+	return ""
 }
 
 // FleetManagement holds the fleet management connection parameters used by the
@@ -317,6 +354,10 @@ func (c *Client) GetAppInstrumentation(ctx context.Context, clusterName string) 
 // SetAppInstrumentation sets app instrumentation configuration for the given cluster.
 // The namespaces slice is a whole-list replacement of the cluster's app config.
 func (c *Client) SetAppInstrumentation(ctx context.Context, clusterName string, namespaces []App, urls BackendURLs) error {
+	if urls.OTLPURL == "" {
+		return errors.New("SetAppInstrumentation: could not resolve the OTLP gateway URL for this stack (region slug or ingest URLs missing from stack info)")
+	}
+
 	wireNS := make([]wireAppNamespace, 0, len(namespaces))
 	for _, ns := range namespaces {
 		apps := make([]wireAppOverride, 0, len(ns.Apps))

--- a/internal/providers/instrumentation/client.go
+++ b/internal/providers/instrumentation/client.go
@@ -51,8 +51,8 @@ type BackendURLs struct {
 	TempoUsername     string `json:"tempo_username"`
 	PyroscopeURL      string `json:"pyroscope_url"`
 	PyroscopeUsername string `json:"pyroscope_username"`
-	OTLPURL           string `json:"otlp_url,omitempty"`
-	OTLPUsername      string `json:"otlp_username,omitempty"`
+	OTLPURL           string `json:"otlp_url"`
+	OTLPUsername      string `json:"otlp_username"`
 }
 
 // BackendURLsFromStack resolves datasource write endpoints from the Grafana

--- a/internal/providers/instrumentation/client_test.go
+++ b/internal/providers/instrumentation/client_test.go
@@ -330,12 +330,17 @@ func TestClient_SetK8SInstrumentation(t *testing.T) {
 			defer srv.Close()
 
 			client := newTestClient(srv.URL)
-			err := client.SetK8SInstrumentation(context.Background(), tt.clusterName, tt.k8s, instrumentation.BackendURLs{})
+			urls := instrumentation.BackendURLs{
+				OTLPURL:      "https://otlp-gateway.example/otlp",
+				OTLPUsername: "1075384",
+			}
+			err := client.SetK8SInstrumentation(context.Background(), tt.clusterName, tt.k8s, urls)
 
 			assertConnectRequest(t, cr, "/instrumentation.v1.InstrumentationService/SetK8SInstrumentation")
 			assert.Contains(t, cr.Body, tt.clusterName)
-			assert.NotContains(t, cr.Body, "otlp_url")
-			assert.NotContains(t, cr.Body, "otlp_username")
+			// BackendURLs is shared, so the K8s endpoint receives OTLP too (it ignores it).
+			assert.Contains(t, cr.Body, `"otlp_url":"https://otlp-gateway.example/otlp"`)
+			assert.Contains(t, cr.Body, `"otlp_username":"1075384"`)
 
 			if tt.wantErr {
 				require.Error(t, err)

--- a/internal/providers/instrumentation/client_test.go
+++ b/internal/providers/instrumentation/client_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/grafana/gcx/internal/cloud"
 	"github.com/grafana/gcx/internal/fleet"
 	"github.com/grafana/gcx/internal/providers/instrumentation"
 	"github.com/stretchr/testify/assert"
@@ -168,7 +169,8 @@ func TestClient_SetAppInstrumentation(t *testing.T) {
 			defer srv.Close()
 
 			client := newTestClient(srv.URL)
-			err := client.SetAppInstrumentation(context.Background(), tt.clusterName, tt.namespaces, instrumentation.BackendURLs{})
+			urls := instrumentation.BackendURLs{OTLPURL: "https://otlp-gateway.example/otlp"}
+			err := client.SetAppInstrumentation(context.Background(), tt.clusterName, tt.namespaces, urls)
 
 			assertConnectRequest(t, cr, "/instrumentation.v1.InstrumentationService/SetAppInstrumentation")
 			assert.Contains(t, cr.Body, tt.clusterName)
@@ -180,6 +182,70 @@ func TestClient_SetAppInstrumentation(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+// SetAppInstrumentation rejects empty otlp_url/otlp_username with HTTP 400, so
+// BackendURLs must reach the wire.
+func TestClient_SetAppInstrumentation_SendsBackendURLs(t *testing.T) {
+	handler, cr := captureHandler(t, http.StatusOK, `{}`)
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	urls := instrumentation.BackendURLs{
+		MimirURL:     "https://prometheus.example/api/prom/push",
+		OTLPURL:      "https://otlp-gateway.example/otlp",
+		OTLPUsername: "1075384",
+	}
+	err := newTestClient(srv.URL).SetAppInstrumentation(
+		context.Background(), "prod-1",
+		[]instrumentation.App{{Name: "default"}}, urls)
+	require.NoError(t, err)
+
+	assert.Contains(t, cr.Body, `"otlp_url":"https://otlp-gateway.example/otlp"`)
+	assert.Contains(t, cr.Body, `"otlp_username":"1075384"`)
+	assert.Contains(t, cr.Body, `"mimir_url":"https://prometheus.example/api/prom/push"`)
+}
+
+// An unresolved OTLP URL is rejected before any request is sent, so the caller
+// gets an actionable error instead of the server's opaque HTTP 400.
+func TestClient_SetAppInstrumentation_EmptyOTLPURLFailsFast(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		t.Error("server must not be called when the OTLP URL is unresolved")
+	}))
+	defer srv.Close()
+
+	err := newTestClient(srv.URL).SetAppInstrumentation(
+		context.Background(), "prod-1",
+		[]instrumentation.App{{Name: "default"}}, instrumentation.BackendURLs{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "OTLP gateway URL")
+}
+
+func TestBackendURLsFromStack_OTLP(t *testing.T) {
+	got := instrumentation.BackendURLsFromStack(cloud.StackInfo{
+		ID:                1075384,
+		RegionSlug:        "prod-us-east-0",
+		HMInstancePromURL: "https://prometheus-prod-13-prod-us-east-0.grafana.net",
+	})
+	assert.Equal(t, "https://otlp-gateway-prod-us-east-0.grafana.net/otlp", got.OTLPURL)
+	assert.Equal(t, "1075384", got.OTLPUsername)
+
+	// Domain follows the environment rather than defaulting to prod.
+	got = instrumentation.BackendURLsFromStack(cloud.StackInfo{
+		RegionSlug:        "dev-us-central-0",
+		HMInstancePromURL: "https://prometheus-dev-01-dev-us-central-0.grafana-dev.net",
+	})
+	assert.Equal(t, "https://otlp-gateway-dev-us-central-0.grafana-dev.net/otlp", got.OTLPURL)
+
+	// Domain sourced from a non-metrics ingest URL when the prom URL is absent.
+	got = instrumentation.BackendURLsFromStack(cloud.StackInfo{
+		RegionSlug:    "prod-us-east-0",
+		HLInstanceURL: "https://logs-prod-006.grafana.net",
+	})
+	assert.Equal(t, "https://otlp-gateway-prod-us-east-0.grafana.net/otlp", got.OTLPURL)
+
+	assert.Empty(t, instrumentation.BackendURLsFromStack(cloud.StackInfo{}).OTLPURL)
+	assert.Empty(t, instrumentation.BackendURLsFromStack(cloud.StackInfo{RegionSlug: "prod-us-east-0"}).OTLPURL)
 }
 
 func TestClient_GetK8SInstrumentation(t *testing.T) {
@@ -268,6 +334,8 @@ func TestClient_SetK8SInstrumentation(t *testing.T) {
 
 			assertConnectRequest(t, cr, "/instrumentation.v1.InstrumentationService/SetK8SInstrumentation")
 			assert.Contains(t, cr.Body, tt.clusterName)
+			assert.NotContains(t, cr.Body, "otlp_url")
+			assert.NotContains(t, cr.Body, "otlp_username")
 
 			if tt.wantErr {
 				require.Error(t, err)


### PR DESCRIPTION
Fixes a bug in `gcx instrumentation` where any command using `SetAppInstrumentation` were unusable due to missing required `otlp_url` and`otlp_username` fields. For example, `gcx instrumentation clusters apps configure` always fails on the latest version.