### PR TITLE
feat(dbo11y): add Database Observability provider

### DIFF
--- a/cmd/gcx/root/command.go
+++ b/cmd/gcx/root/command.go
@@ -38,6 +38,7 @@ import (
 	_ "github.com/grafana/gcx/internal/providers/assistant"       // Provider registrations — blank imports trigger init() self-registration.
 	_ "github.com/grafana/gcx/internal/providers/dashboards"      // Provider registrations — blank imports trigger init() self-registration.
 	_ "github.com/grafana/gcx/internal/providers/datasources"     // Provider registrations — blank imports trigger init() self-registration.
+	_ "github.com/grafana/gcx/internal/providers/dbo11y"          // Provider registrations — blank imports trigger init() self-registration.
 	_ "github.com/grafana/gcx/internal/providers/faro"            // Provider registrations — blank imports trigger init() self-registration.
 	_ "github.com/grafana/gcx/internal/providers/fleet"           // Provider registrations — blank imports trigger init() self-registration.
 	_ "github.com/grafana/gcx/internal/providers/instrumentation" // Provider registrations — blank imports trigger init() self-registration.

--- a/cmd/gcx/root/testdata/output_classes.json
+++ b/cmd/gcx/root/testdata/output_classes.json
@@ -212,6 +212,8 @@
  "gcx datasources tempo metrics": "finite",
  "gcx datasources tempo query": "finite",
  "gcx datasources update": "finite",
+ "gcx dbo11y instances get": "finite",
+ "gcx dbo11y instances list": "finite",
  "gcx dev generate": "finite",
  "gcx dev import": "finite",
  "gcx dev lint list-rules": "finite",

--- a/docs/architecture/project-structure.md
+++ b/docs/architecture/project-structure.md
@@ -63,6 +63,8 @@ gcx/
 │   │   ├── appo11y/          # App Observability provider (singleton config resources)
 │   │   │   ├── overrides/    # MetricsGeneratorConfig with ETag concurrency
 │   │   │   └── settings/     # PluginSettings
+│   │   ├── dbo11y/           # Database Observability provider (query/discovery views, no CRUD resources)
+│   │   │   └── instances/    # Instance inventory + health/query-performance snapshot from postgres_exporter + pg_stat_statements
 │   │   ├── alert/            # Alert provider (rules and groups)
 │   │   ├── assistant/        # Assistant provider — lift-and-shift of the `gcx assistant` command tree; TypedRegistrations() registers the MCPServer adapter (internal/assistant/mcpserver/)
 │   │   ├── dashboards/       # Dashboards provider (CRUD, search, version history, snapshot) — CLI: `gcx dashboards`

--- a/docs/reference/cli/gcx.md
+++ b/docs/reference/cli/gcx.md
@@ -34,6 +34,7 @@ Run 'gcx agent skills list' to see bundled Agent Skills with task-specific guida
 * [gcx config](gcx_config.md)	 - View or manipulate configuration settings
 * [gcx dashboards](gcx_dashboards.md)	 - Manage Grafana dashboards
 * [gcx datasources](gcx_datasources.md)	 - Manage and query Grafana datasources
+* [gcx dbo11y](gcx_dbo11y.md)	 - Inspect Grafana Database Observability instances and query performance
 * [gcx dev](gcx_dev.md)	 - Manage Grafana resources as code
 * [gcx fleet](gcx_fleet.md)	 - Manage Grafana Fleet Management pipelines and collectors
 * [gcx frontend](gcx_frontend.md)	 - Manage Grafana Frontend Observability resources

--- a/docs/reference/cli/gcx_dbo11y.md
+++ b/docs/reference/cli/gcx_dbo11y.md
@@ -1,0 +1,27 @@
+## gcx dbo11y
+
+Inspect Grafana Database Observability instances and query performance
+
+### Options
+
+```
+      --config string   Path to the configuration file to use
+  -h, --help            help for dbo11y
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx](gcx.md)	 - Control plane for Grafana Cloud operations
+* [gcx dbo11y instances](gcx_dbo11y_instances.md)	 - Inspect Database Observability instances discovered from telemetry
+

--- a/docs/reference/cli/gcx_dbo11y_instances.md
+++ b/docs/reference/cli/gcx_dbo11y_instances.md
@@ -1,0 +1,28 @@
+## gcx dbo11y instances
+
+Inspect Database Observability instances discovered from telemetry
+
+### Options
+
+```
+  -h, --help   help for instances
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx dbo11y](gcx_dbo11y.md)	 - Inspect Grafana Database Observability instances and query performance
+* [gcx dbo11y instances get](gcx_dbo11y_instances_get.md)	 - Inspect a single Database Observability instance: health, connections, wait events, and top queries.
+* [gcx dbo11y instances list](gcx_dbo11y_instances_list.md)	 - List Database Observability instances discovered from telemetry.
+

--- a/docs/reference/cli/gcx_dbo11y_instances_get.md
+++ b/docs/reference/cli/gcx_dbo11y_instances_get.md
@@ -1,0 +1,64 @@
+## gcx dbo11y instances get
+
+Inspect a single Database Observability instance: health, connections, wait events, and top queries.
+
+### Synopsis
+
+Show exporter health and a query-performance snapshot for one database instance.
+
+The argument is the instance's service_name (the identifier "gcx dbo11y
+instances list" reports as NAME). Health comes from pg_up and the exporter's
+own scrape metrics; connections and wait events come from pg_stat_activity;
+top queries are ranked by time share (seconds of database time spent per
+second) from pg_stat_statements over --window (default 5m).
+
+```
+gcx dbo11y instances get <name> [flags]
+```
+
+### Examples
+
+```
+
+  # Health, connections, wait events, and top queries for one instance
+  gcx dbo11y instances get quickpizza-db
+
+  # Widen the query window and show more top queries
+  gcx dbo11y instances get quickpizza-db --window 1h --top 20
+
+  # Scope to a single database on a multi-database instance
+  gcx dbo11y instances get quickpizza-db --filter datname=payments
+
+  # JSON for scripting
+  gcx dbo11y instances get quickpizza-db -o json
+```
+
+### Options
+
+```
+  -d, --datasource string    Prometheus datasource UID (defaults to datasources.prometheus in config or auto-discovery)
+      --filter stringArray   Scope the snapshot to series matching a label matcher, e.g. --filter datname=payments (repeatable)
+  -h, --help                 help for get
+      --jq string            jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string        Output format. One of: agents, json, table, wide, yaml (default "table")
+      --top int              Limit the number of top queries returned, ranked by time share (0 = unlimited) (default 10)
+      --window string        Rate window applied to pg_stat_statements (e.g. 1m, 5m, 1h) — PromQL duration syntax (default "5m")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx dbo11y instances](gcx_dbo11y_instances.md)	 - Inspect Database Observability instances discovered from telemetry
+

--- a/docs/reference/cli/gcx_dbo11y_instances_get.md
+++ b/docs/reference/cli/gcx_dbo11y_instances_get.md
@@ -10,7 +10,12 @@ The argument is the instance's service_name (the identifier "gcx dbo11y
 instances list" reports as NAME). Health comes from pg_up and the exporter's
 own scrape metrics; connections and wait events come from pg_stat_activity;
 top queries are ranked by time share (seconds of database time spent per
-second) from pg_stat_statements over --window (default 5m).
+second) from pg_stat_statements over --since (default 5m).
+
+--filter only scopes the pg_stat_activity/pg_stat_statements queries
+(connections, wait events, longest transaction, top queries) — health and
+inventory metadata (pg_up, exporter scrape stats, instance metadata) don't
+carry a datname label and are unaffected.
 
 ```
 gcx dbo11y instances get <name> [flags]
@@ -24,9 +29,9 @@ gcx dbo11y instances get <name> [flags]
   gcx dbo11y instances get quickpizza-db
 
   # Widen the query window and show more top queries
-  gcx dbo11y instances get quickpizza-db --window 1h --top 20
+  gcx dbo11y instances get quickpizza-db --since 1h --top 20
 
-  # Scope to a single database on a multi-database instance
+  # Scope connections/queries to a single database on a multi-database instance
   gcx dbo11y instances get quickpizza-db --filter datname=payments
 
   # JSON for scripting
@@ -37,13 +42,13 @@ gcx dbo11y instances get <name> [flags]
 
 ```
   -d, --datasource string    Prometheus datasource UID (defaults to datasources.prometheus in config or auto-discovery)
-      --filter stringArray   Scope the snapshot to series matching a label matcher, e.g. --filter datname=payments (repeatable)
+      --filter stringArray   Scope the pg_stat_activity/pg_stat_statements queries (connections, wait events, longest transaction, top queries) to series matching a label matcher, e.g. --filter datname=payments (repeatable). Does not affect health/inventory metrics (pg_up, exporter scrape stats, instance metadata), which don't carry a datname label
   -h, --help                 help for get
       --jq string            jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
   -o, --output string        Output format. One of: agents, json, table, wide, yaml (default "table")
+      --since string         Rate window applied to pg_stat_statements (e.g. 1m, 5m, 1h) — PromQL duration syntax (default "5m")
       --top int              Limit the number of top queries returned, ranked by time share (0 = unlimited) (default 10)
-      --window string        Rate window applied to pg_stat_statements (e.g. 1m, 5m, 1h) — PromQL duration syntax (default "5m")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_dbo11y_instances_get.md
+++ b/docs/reference/cli/gcx_dbo11y_instances_get.md
@@ -7,15 +7,30 @@ Inspect a single Database Observability instance: health, connections, wait even
 Show exporter health and a query-performance snapshot for one database instance.
 
 The argument is the instance's service_name (the identifier "gcx dbo11y
-instances list" reports as NAME). Health comes from pg_up and the exporter's
-own scrape metrics; connections and wait events come from pg_stat_activity;
-top queries are ranked by time share (seconds of database time spent per
-second) from pg_stat_statements over --since (default 5m).
+instances list" reports as NAME). What's available depends on the instance's
+engine (from "gcx dbo11y instances list"):
 
---filter only scopes the pg_stat_activity/pg_stat_statements queries
-(connections, wait events, longest transaction, top queries) — health and
-inventory metadata (pg_up, exporter scrape stats, instance metadata) don't
-carry a datname label and are unaffected.
+  - Health (up/down) is engine-agnostic, from the standard Prometheus scrape
+    target gauge.
+  - Postgres additionally reports exporter self-scrape health, per-state
+    connection counts, active wait events, and the longest running
+    transaction, all from postgres_exporter's pg_stat_activity collector.
+  - MySQL reports a single current-connections count
+    (mysql_global_status_threads_connected); wait events and exporter
+    self-scrape health have no confirmed live metric for MySQL and are
+    omitted rather than guessed.
+  - Top queries (both engines) are ranked by time share (seconds of database
+    time spent per second) over --since (default 5m): pg_stat_statements for
+    Postgres, mysqld_exporter's Performance Schema eventsstatements collector
+    for MySQL.
+
+--filter only scopes the connections/query-performance queries — health and
+inventory metadata don't carry a datname/schema label and are unaffected.
+
+When no telemetry is found for the instance, this command checks whether
+Database Observability has been activated for the stack and, if not, exits
+non-zero with a hint to activate it in Grafana Cloud instead of a generic
+"no telemetry" message.
 
 ```
 gcx dbo11y instances get <name> [flags]
@@ -25,7 +40,7 @@ gcx dbo11y instances get <name> [flags]
 
 ```
 
-  # Health, connections, wait events, and top queries for one instance
+  # Health, connections, and top queries for one instance (Postgres or MySQL)
   gcx dbo11y instances get quickpizza-db
 
   # Widen the query window and show more top queries
@@ -42,7 +57,7 @@ gcx dbo11y instances get <name> [flags]
 
 ```
   -d, --datasource string    Prometheus datasource UID (defaults to datasources.prometheus in config or auto-discovery)
-      --filter stringArray   Scope the pg_stat_activity/pg_stat_statements queries (connections, wait events, longest transaction, top queries) to series matching a label matcher, e.g. --filter datname=payments (repeatable). Does not affect health/inventory metrics (pg_up, exporter scrape stats, instance metadata), which don't carry a datname label
+      --filter stringArray   Scope the connections/query-performance queries to series matching a label matcher, e.g. --filter datname=payments for Postgres or --filter schema=payments for MySQL (repeatable). Does not affect health/inventory metrics, which don't carry that label
   -h, --help                 help for get
       --jq string            jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields

--- a/docs/reference/cli/gcx_dbo11y_instances_list.md
+++ b/docs/reference/cli/gcx_dbo11y_instances_list.md
@@ -14,6 +14,11 @@ and cloud-provider metadata.
 Related: "gcx dbo11y instances get <name>" drills into one instance's health,
 connections, wait events, and top queries by time share.
 
+When no instances are found, this command checks whether Database
+Observability has been activated for the stack and, if not, exits non-zero
+with a hint to activate it in Grafana Cloud instead of a generic empty
+result.
+
 ```
 gcx dbo11y instances list [flags]
 ```

--- a/docs/reference/cli/gcx_dbo11y_instances_list.md
+++ b/docs/reference/cli/gcx_dbo11y_instances_list.md
@@ -1,0 +1,62 @@
+## gcx dbo11y instances list
+
+List Database Observability instances discovered from telemetry.
+
+### Synopsis
+
+List the database instances Grafana Cloud Database Observability has discovered.
+
+Discovery uses the database_observability_connection_info inventory metric
+emitted by the database_observability.postgres Alloy component (job
+"integrations/db-o11y"): one row per monitored database instance, with engine
+and cloud-provider metadata.
+
+Related: "gcx dbo11y instances get <name>" drills into one instance's health,
+connections, wait events, and top queries by time share.
+
+```
+gcx dbo11y instances list [flags]
+```
+
+### Examples
+
+```
+
+  # List all database instances in the current stack
+  gcx dbo11y instances list
+
+  # Filter to Postgres instances
+  gcx dbo11y instances list --filter engine=postgres
+
+  # Pin a datasource and output JSON
+  gcx dbo11y instances list -d grafanacloud-prom -o json
+```
+
+### Options
+
+```
+  -d, --datasource string    Prometheus datasource UID (defaults to datasources.prometheus in config or auto-discovery)
+      --filter stringArray   Restrict to instances matching a label matcher, e.g. --filter engine=postgres (repeatable)
+  -h, --help                 help for list
+      --jq string            jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string          Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int            Limit the number of instances returned (0 = unlimited) (default 50)
+  -o, --output string        Output format. One of: agents, json, table, wide, yaml (default "table")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx dbo11y instances](gcx_dbo11y_instances.md)	 - Inspect Database Observability instances discovered from telemetry
+

--- a/internal/providers/dbo11y/instances/activation.go
+++ b/internal/providers/dbo11y/instances/activation.go
@@ -1,0 +1,84 @@
+package instances
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	internalconfig "github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/providers"
+	k8srest "k8s.io/client-go/rest"
+)
+
+// Database Observability gates its own UI behind a per-stack "activation"
+// resource — DbO11yConfig under the shared productactivation.ext.grafana.com
+// API group other Grafana Cloud o11y products (App O11y, Host O11y, K8s O11y)
+// also use. Confirmed from the grafana-dbo11y-app v2.30.0 production bundle
+// (module.js chunk 993): the plugin's own ActivationService does
+//
+//	GET /apis/productactivation.ext.grafana.com/v1alpha1/namespaces/<ns>/dbo11yconfigs/global
+//
+// and treats a 404 (config never created) or `spec.enabled == false` as "not
+// activated". There is no dedicated activation-status endpoint separate from
+// this resource — the plugin's own onboarding flow POSTs the same resource
+// (spec: {enabled: true}) to activate.
+const (
+	productActivationAPIGroup = "productactivation.ext.grafana.com/v1alpha1"
+	dbo11yConfigResource      = "dbo11yconfigs"
+	dbo11yConfigName          = "global"
+)
+
+// dbo11yActivationDocsURL is Grafana's own get-started doc, referenced in the
+// not-activated hint below.
+const dbo11yActivationDocsURL = "https://grafana.com/docs/grafana-cloud/monitor-applications/database-observability/get-started/"
+
+// checkActivation reports whether Database Observability is activated for
+// the stack cfg targets. The second return value is an unexpected-failure
+// error (transport failure, non-404 non-2xx status, malformed body) — callers
+// should treat that as inconclusive (log it, don't block on it) rather than
+// as "not activated", since the activation resource is a best-effort
+// diagnostic enrichment, not a hard dependency of the metrics-based commands.
+func checkActivation(ctx context.Context, cfg internalconfig.NamespacedRESTConfig) (bool, error) {
+	hc, err := k8srest.HTTPClientFor(&cfg.Config)
+	if err != nil {
+		return false, fmt.Errorf("failed to create HTTP client for activation check: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/apis/%s/namespaces/%s/%s/%s", cfg.Host, productActivationAPIGroup, cfg.Namespace, dbo11yConfigResource, dbo11yConfigName)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return false, fmt.Errorf("failed to build activation check request: %w", err)
+	}
+	resp, err := hc.Do(req)
+	if err != nil {
+		return false, fmt.Errorf("activation check request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return false, nil
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return false, providers.HandleErrorResponse(resp)
+	}
+
+	var body struct {
+		Spec struct {
+			Enabled bool `json:"enabled"`
+		} `json:"spec"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return false, fmt.Errorf("failed to decode activation config response: %w", err)
+	}
+	return body.Spec.Enabled, nil
+}
+
+// notActivatedError is the error surfaced in place of a generic "no data"
+// message once checkActivation has positively confirmed the product isn't
+// enabled for this stack.
+func notActivatedError() error {
+	return errors.New("Database Observability is not activated for this stack — activate it in Grafana Cloud " + //nolint:staticcheck // "Grafana" is a proper noun, capitalization is intentional
+		"(Connections > Add new connection > Database Observability), or see " + dbo11yActivationDocsURL)
+}

--- a/internal/providers/dbo11y/instances/activation_test.go
+++ b/internal/providers/dbo11y/instances/activation_test.go
@@ -1,0 +1,82 @@
+package instances //nolint:testpackage // Tests cover unexported activation-check logic.
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	internalconfig "github.com/grafana/gcx/internal/config"
+	"k8s.io/client-go/rest"
+)
+
+func testRESTConfig(t *testing.T, handler http.HandlerFunc) internalconfig.NamespacedRESTConfig {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	return internalconfig.NamespacedRESTConfig{
+		Config:    rest.Config{Host: srv.URL},
+		Namespace: "stacks-12345",
+	}
+}
+
+func TestCheckActivation_Enabled(t *testing.T) {
+	// Real shape confirmed against Grafana's own "ops" stack via `gcx api`:
+	// GET .../dbo11yconfigs/global -> 200 {"spec": {"enabled": true}}.
+	cfg := testRESTConfig(t, func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/apis/productactivation.ext.grafana.com/v1alpha1/namespaces/stacks-12345/dbo11yconfigs/global"; got != want {
+			t.Errorf("path = %q, want %q", got, want)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"spec":{"enabled":true}}`)) //nolint:errcheck // test helper
+	})
+
+	activated, err := checkActivation(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if !activated {
+		t.Error("expected activated = true")
+	}
+}
+
+func TestCheckActivation_EnabledFalse(t *testing.T) {
+	cfg := testRESTConfig(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"spec":{"enabled":false}}`)) //nolint:errcheck // test helper
+	})
+
+	activated, err := checkActivation(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if activated {
+		t.Error("expected activated = false")
+	}
+}
+
+func TestCheckActivation_NotFound(t *testing.T) {
+	// Real shape confirmed against a stack that never went through Database
+	// Observability's onboarding flow: 404, config resource never created.
+	cfg := testRESTConfig(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	activated, err := checkActivation(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("expected 404 to resolve to (false, nil), got err = %v", err)
+	}
+	if activated {
+		t.Error("expected activated = false")
+	}
+}
+
+func TestCheckActivation_UnexpectedError(t *testing.T) {
+	cfg := testRESTConfig(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	if _, err := checkActivation(context.Background(), cfg); err == nil {
+		t.Fatal("expected an error for a non-404 non-2xx status")
+	}
+}

--- a/internal/providers/dbo11y/instances/commands.go
+++ b/internal/providers/dbo11y/instances/commands.go
@@ -1,0 +1,19 @@
+package instances
+
+import (
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/spf13/cobra"
+)
+
+// Commands returns the `instances` command group, rooted under `gcx dbo11y`.
+// The loader carries the --config flag bound on the dbo11y command; every
+// subcommand loads config through it so an explicit --config is honored.
+func Commands(loader *providers.ConfigLoader) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "instances",
+		Short: "Inspect Database Observability instances discovered from telemetry",
+	}
+	cmd.AddCommand(newListCommand(loader))
+	cmd.AddCommand(newGetCommand(loader))
+	return cmd
+}

--- a/internal/providers/dbo11y/instances/get.go
+++ b/internal/providers/dbo11y/instances/get.go
@@ -49,7 +49,7 @@ func (o *getOpts) setup(flags *pflag.FlagSet) {
 	flags.StringVarP(&o.Datasource, "datasource", "d", "", "Prometheus datasource UID (defaults to datasources.prometheus in config or auto-discovery)")
 	flags.StringVar(&o.Since, "since", defaultQueryWindow, "Rate window applied to pg_stat_statements (e.g. 1m, 5m, 1h) — PromQL duration syntax")
 	flags.IntVar(&o.Top, "top", defaultTopQueriesLimit, "Limit the number of top queries returned, ranked by time share (0 = unlimited)")
-	flags.StringArrayVar(&o.Filters, "filter", nil, "Scope the pg_stat_activity/pg_stat_statements queries (connections, wait events, longest transaction, top queries) to series matching a label matcher, e.g. --filter datname=payments (repeatable). Does not affect health/inventory metrics (pg_up, exporter scrape stats, instance metadata), which don't carry a datname label")
+	flags.StringArrayVar(&o.Filters, "filter", nil, "Scope the connections/query-performance queries to series matching a label matcher, e.g. --filter datname=payments for Postgres or --filter schema=payments for MySQL (repeatable). Does not affect health/inventory metrics, which don't carry that label")
 }
 
 func (o *getOpts) Validate(cmd *cobra.Command) error {
@@ -76,17 +76,32 @@ func newGetCommand(loader *providers.ConfigLoader) *cobra.Command {
 		Long: `Show exporter health and a query-performance snapshot for one database instance.
 
 The argument is the instance's service_name (the identifier "gcx dbo11y
-instances list" reports as NAME). Health comes from pg_up and the exporter's
-own scrape metrics; connections and wait events come from pg_stat_activity;
-top queries are ranked by time share (seconds of database time spent per
-second) from pg_stat_statements over --since (default 5m).
+instances list" reports as NAME). What's available depends on the instance's
+engine (from "gcx dbo11y instances list"):
 
---filter only scopes the pg_stat_activity/pg_stat_statements queries
-(connections, wait events, longest transaction, top queries) — health and
-inventory metadata (pg_up, exporter scrape stats, instance metadata) don't
-carry a datname label and are unaffected.`,
+  - Health (up/down) is engine-agnostic, from the standard Prometheus scrape
+    target gauge.
+  - Postgres additionally reports exporter self-scrape health, per-state
+    connection counts, active wait events, and the longest running
+    transaction, all from postgres_exporter's pg_stat_activity collector.
+  - MySQL reports a single current-connections count
+    (mysql_global_status_threads_connected); wait events and exporter
+    self-scrape health have no confirmed live metric for MySQL and are
+    omitted rather than guessed.
+  - Top queries (both engines) are ranked by time share (seconds of database
+    time spent per second) over --since (default 5m): pg_stat_statements for
+    Postgres, mysqld_exporter's Performance Schema eventsstatements collector
+    for MySQL.
+
+--filter only scopes the connections/query-performance queries — health and
+inventory metadata don't carry a datname/schema label and are unaffected.
+
+When no telemetry is found for the instance, this command checks whether
+Database Observability has been activated for the stack and, if not, exits
+non-zero with a hint to activate it in Grafana Cloud instead of a generic
+"no telemetry" message.`,
 		Example: `
-  # Health, connections, wait events, and top queries for one instance
+  # Health, connections, and top queries for one instance (Postgres or MySQL)
   gcx dbo11y instances get quickpizza-db
 
   # Widen the query window and show more top queries
@@ -101,7 +116,7 @@ carry a datname label and are unaffected.`,
 		RunE: runGet(loader, opts),
 		Annotations: map[string]string{
 			agent.AnnotationTokenCost: "small",
-			agent.AnnotationLLMHint:   `Per-instance Database Observability snapshot: pg_up/scrape health, connection counts by state, active wait events (wait_event_type/wait_event), longest running transaction, and top queries by time share from pg_stat_statements over --since (default 5m). Pairs with 'gcx dbo11y instances list' to find instance names. Use --filter <label><op><value> (repeatable) to scope the pg_stat_activity/pg_stat_statements queries to one database on a multi-database instance, e.g. --filter datname=payments — health/inventory metrics don't carry that label and are unaffected. Examples: gcx dbo11y instances get <name> -o json; gcx dbo11y instances get <name> --since 1h --top 20 -o json`,
+			agent.AnnotationLLMHint:   `Per-instance Database Observability snapshot. Health (up/down) is engine-agnostic. Postgres also reports connection counts by state, active wait events (wait_event_type/wait_event), and longest running transaction, from pg_stat_activity. MySQL reports a single current-connections count only (mysql_global_status_threads_connected); wait events aren't available as a live metric for MySQL. Top queries (both engines) are ranked by time share from pg_stat_statements (Postgres) or mysql_perf_schema_events_statements_* (MySQL) over --since (default 5m). Pairs with 'gcx dbo11y instances list' to find instance names and engines. Use --filter <label><op><value> (repeatable) to scope the connections/query-performance queries to one database on a multi-database instance, e.g. --filter datname=payments (Postgres) or --filter schema=payments (MySQL) — health/inventory metrics don't carry that label. On no telemetry this command also checks the stack's Database Observability activation status and, if not activated, exits 1 with a specific "not activated" hint instead of the generic no-telemetry message. Examples: gcx dbo11y instances get <name> -o json; gcx dbo11y instances get <name> --since 1h --top 20 -o json`,
 		},
 	}
 	opts.setup(cmd.Flags())
@@ -145,7 +160,20 @@ func runGet(loader *providers.ConfigLoader, opts *getOpts) func(*cobra.Command, 
 		}
 
 		notFound := !detail.Health.HasUp && len(detail.Connections) == 0 && len(detail.TopQueries) == 0
+		// checkActivation is a best-effort diagnostic enrichment: it can only
+		// make the not-found case more specific, never less — an inconclusive
+		// check (activated=false, err!=nil) falls through to the generic
+		// no-telemetry message below rather than blocking.
+		var notActivated bool
 		if notFound {
+			if activated, actErr := checkActivation(ctx, cfg); actErr == nil && !activated {
+				notActivated = true
+			}
+		}
+		switch {
+		case notActivated:
+			cmdio.EmitWarn(cmd.ErrOrStderr(), notActivatedError().Error())
+		case notFound:
 			cmdio.EmitHint(cmd.ErrOrStderr(),
 				fmt.Sprintf("no telemetry found for %q in the requested window", name),
 				"gcx dbo11y instances list")
@@ -158,6 +186,9 @@ func runGet(loader *providers.ConfigLoader, opts *getOpts) func(*cobra.Command, 
 		if err := opts.IO.Encode(cmd.OutOrStdout(), detail); err != nil {
 			return err
 		}
+		if notActivated {
+			return gcxerrors.NewEmittedError(gcxerrors.ExitGeneralError, notActivatedError())
+		}
 		if notFound {
 			cmdio.EmitWarn(cmd.ErrOrStderr(), fmt.Sprintf("instance %q has no telemetry in the requested window", name))
 			return gcxerrors.NewEmittedError(gcxerrors.ExitGeneralError, errors.New("instance not found"))
@@ -166,55 +197,22 @@ func runGet(loader *providers.ConfigLoader, opts *getOpts) func(*cobra.Command, 
 	}
 }
 
-// fetchInstanceDetail runs the metadata, health, connections, wait-events,
-// longest-tx, and top-queries queries in parallel and folds the responses
-// into one InstanceDetail. matchers only scope the pg_stat_activity/
-// pg_stat_statements queries (connections, wait events, longest tx, top
-// queries) — metadata and health/exporter metrics don't carry labels like
-// datname, so applying arbitrary matchers there would silently zero them out.
+// fetchInstanceDetail runs the metadata lookup first (to learn the engine),
+// then the health/connections/wait-events/longest-tx/top-queries queries in
+// parallel, scoped to whichever metric family that engine actually has —
+// see metricsForEngine. matchers only scope the per-engine activity/
+// statements queries (connections, wait events, longest tx, top queries) —
+// metadata and health metrics don't carry labels like datname/schema, so
+// applying arbitrary matchers there would silently zero them out.
 func fetchInstanceDetail(ctx context.Context, client *prometheus.Client, datasourceUID, name, window string, top int, matchers []Matcher) (*InstanceDetail, bool, error) {
-	var (
-		metadataResp                                   *prometheus.QueryResponse
-		upResp, scrapeErrResp, scrapeDurResp           *prometheus.QueryResponse
-		connectionsResp, waitEventsResp, longestTxResp *prometheus.QueryResponse
-		callsResp, secondsResp, rowsResp               *prometheus.QueryResponse
-	)
-
-	eg, egCtx := errgroup.WithContext(ctx)
-	eg.Go(queryInto(egCtx, client, datasourceUID, func() (string, error) {
-		return buildConnectionInfoQuery([]Matcher{{Label: serviceNameLabel, Op: "=", Value: name}})
-	}, &metadataResp))
-	eg.Go(queryInto(egCtx, client, datasourceUID, func() (string, error) {
-		return buildUpQuery(pgUpMetric, name, nil)
-	}, &upResp))
-	eg.Go(queryInto(egCtx, client, datasourceUID, func() (string, error) {
-		return buildUpQuery(pgScrapeErrorMetric, name, nil)
-	}, &scrapeErrResp))
-	eg.Go(queryInto(egCtx, client, datasourceUID, func() (string, error) {
-		return buildUpQuery(pgScrapeDurationMetric, name, nil)
-	}, &scrapeDurResp))
-	eg.Go(queryInto(egCtx, client, datasourceUID, func() (string, error) {
-		return buildConnectionsByStateQuery(name, matchers)
-	}, &connectionsResp))
-	eg.Go(queryInto(egCtx, client, datasourceUID, func() (string, error) {
-		return buildWaitEventsQuery(name, matchers)
-	}, &waitEventsResp))
-	eg.Go(queryInto(egCtx, client, datasourceUID, func() (string, error) {
-		return buildLongestTxQuery(name, matchers)
-	}, &longestTxResp))
-	eg.Go(queryInto(egCtx, client, datasourceUID, func() (string, error) {
-		return buildTopQueriesRateQuery(pgStatStatementsCalls, name, window, matchers)
-	}, &callsResp))
-	eg.Go(queryInto(egCtx, client, datasourceUID, func() (string, error) {
-		return buildTopQueriesRateQuery(pgStatStatementsSeconds, name, window, matchers)
-	}, &secondsResp))
-	eg.Go(queryInto(egCtx, client, datasourceUID, func() (string, error) {
-		return buildTopQueriesRateQuery(pgStatStatementsRows, name, window, matchers)
-	}, &rowsResp))
-	if err := eg.Wait(); err != nil {
-		return nil, false, err
+	metadataExpr, err := buildConnectionInfoQuery([]Matcher{{Label: serviceNameLabel, Op: "=", Value: name}})
+	if err != nil {
+		return nil, false, fmt.Errorf("failed to build metadata query: %w", err)
 	}
-
+	metadataResp, err := client.Query(ctx, datasourceUID, prometheus.QueryRequest{Query: metadataExpr})
+	if err != nil {
+		return nil, false, fmt.Errorf("metadata query failed: %w", err)
+	}
 	metadata, err := parseInstancesResponse(metadataResp)
 	if err != nil {
 		return nil, false, fmt.Errorf("failed to parse instance metadata: %w", err)
@@ -223,15 +221,80 @@ func fetchInstanceDetail(ctx context.Context, client *prometheus.Client, datasou
 	if len(metadata) > 0 {
 		inst = metadata[0]
 	}
+	metrics := metricsForEngine(inst.Engine)
+
+	var (
+		upResp, scrapeErrResp, scrapeDurResp *prometheus.QueryResponse
+		connectionsResp, connectedResp       *prometheus.QueryResponse
+		waitEventsResp, longestTxResp        *prometheus.QueryResponse
+		callsResp, secondsResp, rowsResp     *prometheus.QueryResponse
+	)
+
+	eg, egCtx := errgroup.WithContext(ctx)
+	eg.Go(queryInto(egCtx, client, datasourceUID, func() (string, error) {
+		return buildScrapeUpQuery(name)
+	}, &upResp))
+	if metrics.scrapeErrorMetric != "" {
+		eg.Go(queryInto(egCtx, client, datasourceUID, func() (string, error) {
+			return buildUpQuery(metrics.scrapeErrorMetric, name, nil)
+		}, &scrapeErrResp))
+	}
+	if metrics.scrapeDurationMetric != "" {
+		eg.Go(queryInto(egCtx, client, datasourceUID, func() (string, error) {
+			return buildUpQuery(metrics.scrapeDurationMetric, name, nil)
+		}, &scrapeDurResp))
+	}
+	if metrics.activityMetric != "" {
+		eg.Go(queryInto(egCtx, client, datasourceUID, func() (string, error) {
+			return buildConnectionsByStateQuery(name, matchers)
+		}, &connectionsResp))
+		eg.Go(queryInto(egCtx, client, datasourceUID, func() (string, error) {
+			return buildWaitEventsQuery(name, matchers)
+		}, &waitEventsResp))
+	}
+	if metrics.connectedMetric != "" {
+		eg.Go(queryInto(egCtx, client, datasourceUID, func() (string, error) {
+			return buildUpQuery(metrics.connectedMetric, name, matchers)
+		}, &connectedResp))
+	}
+	if metrics.maxTxMetric != "" {
+		eg.Go(queryInto(egCtx, client, datasourceUID, func() (string, error) {
+			return buildLongestTxQuery(name, matchers)
+		}, &longestTxResp))
+	}
+	eg.Go(queryInto(egCtx, client, datasourceUID, func() (string, error) {
+		return buildTopQueriesRateQuery(metrics.statementsCalls, name, window, matchers, metrics.queryIDLabel, metrics.datnameLabel)
+	}, &callsResp))
+	eg.Go(queryInto(egCtx, client, datasourceUID, func() (string, error) {
+		return buildTopQueriesRateQuery(metrics.statementsSeconds, name, window, matchers, metrics.queryIDLabel, metrics.datnameLabel)
+	}, &secondsResp))
+	if metrics.statementsRows != "" {
+		eg.Go(queryInto(egCtx, client, datasourceUID, func() (string, error) {
+			return buildTopQueriesRateQuery(metrics.statementsRows, name, window, matchers, metrics.queryIDLabel, metrics.datnameLabel)
+		}, &rowsResp))
+	}
+	if err := eg.Wait(); err != nil {
+		return nil, false, err
+	}
 
 	up, hasUp := instantScalar(upResp)
 	scrapeErr, hasScrapeErr := instantScalar(scrapeErrResp)
 	scrapeDur, hasScrapeDur := instantScalar(scrapeDurResp)
 	longestTx, hasLongestTx := instantScalar(longestTxResp)
 
-	calls := bucketByQueryKey(callsResp)
-	seconds := bucketByQueryKey(secondsResp)
-	rows := bucketByQueryKey(rowsResp)
+	var connections []ConnectionState
+	switch {
+	case metrics.activityMetric != "":
+		connections = parseConnectionsByState(connectionsResp)
+	case metrics.connectedMetric != "":
+		if v, ok := instantScalar(connectedResp); ok {
+			connections = []ConnectionState{{State: "connected", Count: v}}
+		}
+	}
+
+	calls := bucketByQueryKey(callsResp, metrics.queryIDLabel, metrics.datnameLabel)
+	seconds := bucketByQueryKey(secondsResp, metrics.queryIDLabel, metrics.datnameLabel)
+	rows := bucketByQueryKey(rowsResp, metrics.queryIDLabel, metrics.datnameLabel)
 	topQueries, truncated := mergeTopQueries(calls, seconds, rows, top)
 
 	return &InstanceDetail{
@@ -247,7 +310,7 @@ func fetchInstanceDetail(ctx context.Context, client *prometheus.Client, datasou
 		},
 		LongestTxSeconds: longestTx,
 		HasLongestTx:     hasLongestTx,
-		Connections:      parseConnectionsByState(connectionsResp),
+		Connections:      connections,
 		WaitEvents:       parseWaitEvents(waitEventsResp),
 		TopQueries:       topQueries,
 	}, truncated, nil

--- a/internal/providers/dbo11y/instances/get.go
+++ b/internal/providers/dbo11y/instances/get.go
@@ -1,0 +1,393 @@
+package instances
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+
+	"github.com/grafana/gcx/cmd/gcx/fail"
+	"github.com/grafana/gcx/internal/agent"
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+	"github.com/grafana/gcx/internal/format"
+	"github.com/grafana/gcx/internal/gcxerrors"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/query/prometheus"
+	"github.com/grafana/gcx/internal/style"
+	"github.com/prometheus/common/model"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"golang.org/x/sync/errgroup"
+)
+
+// defaultQueryWindow is the rate window for pg_stat_statements when --window
+// isn't set. 5m mirrors appo11y's defaultRedWindow.
+const defaultQueryWindow = "5m"
+
+// defaultTopQueriesLimit caps the number of pg_stat_statements rows shown by
+// default; --top 0 removes the cap.
+const defaultTopQueriesLimit = 10
+
+type getOpts struct {
+	IO         cmdio.Options
+	Datasource string
+	Window     string
+	Top        int
+	Filters    []string
+}
+
+func (o *getOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &instanceDetailCodec{})
+	o.IO.RegisterCustomCodec("wide", &instanceDetailCodec{Wide: true})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+
+	flags.StringVarP(&o.Datasource, "datasource", "d", "", "Prometheus datasource UID (defaults to datasources.prometheus in config or auto-discovery)")
+	flags.StringVar(&o.Window, "window", defaultQueryWindow, "Rate window applied to pg_stat_statements (e.g. 1m, 5m, 1h) — PromQL duration syntax")
+	flags.IntVar(&o.Top, "top", defaultTopQueriesLimit, "Limit the number of top queries returned, ranked by time share (0 = unlimited)")
+	flags.StringArrayVar(&o.Filters, "filter", nil, "Scope the snapshot to series matching a label matcher, e.g. --filter datname=payments (repeatable)")
+}
+
+func (o *getOpts) Validate(cmd *cobra.Command) error {
+	if err := o.IO.Validate(); err != nil {
+		return err
+	}
+	if strings.TrimSpace(o.Window) == "" {
+		return fail.NewCommandUsageError(cmd, "--window must not be empty", nil)
+	}
+	if _, err := model.ParseDuration(o.Window); err != nil {
+		return fail.NewCommandUsageError(cmd, fmt.Sprintf("--window %q is not a valid PromQL duration", o.Window), err)
+	}
+	if o.Top < 0 {
+		return fail.NewCommandUsageError(cmd, "--top must be zero or positive", nil)
+	}
+	return nil
+}
+
+func newGetCommand(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &getOpts{}
+	cmd := &cobra.Command{
+		Use:   "get <name>",
+		Short: "Inspect a single Database Observability instance: health, connections, wait events, and top queries.",
+		Long: `Show exporter health and a query-performance snapshot for one database instance.
+
+The argument is the instance's service_name (the identifier "gcx dbo11y
+instances list" reports as NAME). Health comes from pg_up and the exporter's
+own scrape metrics; connections and wait events come from pg_stat_activity;
+top queries are ranked by time share (seconds of database time spent per
+second) from pg_stat_statements over --window (default 5m).`,
+		Example: `
+  # Health, connections, wait events, and top queries for one instance
+  gcx dbo11y instances get quickpizza-db
+
+  # Widen the query window and show more top queries
+  gcx dbo11y instances get quickpizza-db --window 1h --top 20
+
+  # Scope to a single database on a multi-database instance
+  gcx dbo11y instances get quickpizza-db --filter datname=payments
+
+  # JSON for scripting
+  gcx dbo11y instances get quickpizza-db -o json`,
+		Args: cobra.ExactArgs(1),
+		RunE: runGet(loader, opts),
+		Annotations: map[string]string{
+			agent.AnnotationTokenCost: "small",
+			agent.AnnotationLLMHint:   `Per-instance Database Observability snapshot: pg_up/scrape health, connection counts by state, active wait events (wait_event_type/wait_event), longest running transaction, and top queries by time share from pg_stat_statements over --window (default 5m). Pairs with 'gcx dbo11y instances list' to find instance names. Use --filter <label><op><value> (repeatable) to scope to one database on a multi-database instance, e.g. --filter datname=payments. Examples: gcx dbo11y instances get <name> -o json; gcx dbo11y instances get <name> --window 1h --top 20 -o json`,
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+func runGet(loader *providers.ConfigLoader, opts *getOpts) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, args []string) error {
+		if err := opts.Validate(cmd); err != nil {
+			return err
+		}
+		name := strings.TrimSpace(args[0])
+		if name == "" {
+			return fail.NewCommandUsageError(cmd, "instance name is required", nil)
+		}
+		matchers, err := parseFilters(opts.Filters)
+		if err != nil {
+			return fail.NewCommandUsageError(cmd, "", err)
+		}
+
+		ctx := cmd.Context()
+
+		cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
+		if err != nil {
+			return err
+		}
+
+		datasourceUID, err := dsquery.ResolveAndSaveDatasource(ctx, loader, opts.Datasource, cfgCtx, cfg, "prometheus")
+		if err != nil {
+			return err
+		}
+
+		client, err := prometheus.NewClient(cfg)
+		if err != nil {
+			return fmt.Errorf("failed to create prometheus client: %w", err)
+		}
+
+		detail, err := fetchInstanceDetail(ctx, client, datasourceUID, name, opts.Window, opts.Top, matchers)
+		if err != nil {
+			return err
+		}
+
+		notFound := !detail.Health.HasUp && len(detail.Connections) == 0 && len(detail.TopQueries) == 0
+		if notFound {
+			cmdio.EmitHint(cmd.ErrOrStderr(),
+				fmt.Sprintf("no telemetry found for %q in the requested window", name),
+				"gcx dbo11y instances list")
+		}
+		if err := opts.IO.Encode(cmd.OutOrStdout(), detail); err != nil {
+			return err
+		}
+		if notFound {
+			cmdio.EmitWarn(cmd.ErrOrStderr(), fmt.Sprintf("instance %q has no telemetry in the requested window", name))
+			return gcxerrors.NewEmittedError(gcxerrors.ExitGeneralError, errors.New("instance not found"))
+		}
+		return nil
+	}
+}
+
+// fetchInstanceDetail runs the metadata, health, connections, wait-events,
+// longest-tx, and top-queries queries in parallel and folds the responses
+// into one InstanceDetail.
+func fetchInstanceDetail(ctx context.Context, client *prometheus.Client, datasourceUID, name, window string, top int, matchers []Matcher) (*InstanceDetail, error) {
+	var (
+		metadataResp                                   *prometheus.QueryResponse
+		upResp, scrapeErrResp, scrapeDurResp           *prometheus.QueryResponse
+		connectionsResp, waitEventsResp, longestTxResp *prometheus.QueryResponse
+		callsResp, secondsResp, rowsResp               *prometheus.QueryResponse
+	)
+
+	eg, egCtx := errgroup.WithContext(ctx)
+	eg.Go(queryInto(egCtx, client, datasourceUID, func() (string, error) {
+		return buildConnectionInfoQuery(append([]Matcher{{Label: serviceNameLabel, Op: "=", Value: name}}, matchers...))
+	}, &metadataResp))
+	eg.Go(queryInto(egCtx, client, datasourceUID, func() (string, error) {
+		return buildUpQuery(pgUpMetric, name, matchers)
+	}, &upResp))
+	eg.Go(queryInto(egCtx, client, datasourceUID, func() (string, error) {
+		return buildUpQuery(pgScrapeErrorMetric, name, matchers)
+	}, &scrapeErrResp))
+	eg.Go(queryInto(egCtx, client, datasourceUID, func() (string, error) {
+		return buildUpQuery(pgScrapeDurationMetric, name, matchers)
+	}, &scrapeDurResp))
+	eg.Go(queryInto(egCtx, client, datasourceUID, func() (string, error) {
+		return buildConnectionsByStateQuery(name, matchers)
+	}, &connectionsResp))
+	eg.Go(queryInto(egCtx, client, datasourceUID, func() (string, error) {
+		return buildWaitEventsQuery(name, matchers)
+	}, &waitEventsResp))
+	eg.Go(queryInto(egCtx, client, datasourceUID, func() (string, error) {
+		return buildLongestTxQuery(name, matchers)
+	}, &longestTxResp))
+	eg.Go(queryInto(egCtx, client, datasourceUID, func() (string, error) {
+		return buildTopQueriesRateQuery(pgStatStatementsCalls, name, window, matchers)
+	}, &callsResp))
+	eg.Go(queryInto(egCtx, client, datasourceUID, func() (string, error) {
+		return buildTopQueriesRateQuery(pgStatStatementsSeconds, name, window, matchers)
+	}, &secondsResp))
+	eg.Go(queryInto(egCtx, client, datasourceUID, func() (string, error) {
+		return buildTopQueriesRateQuery(pgStatStatementsRows, name, window, matchers)
+	}, &rowsResp))
+	if err := eg.Wait(); err != nil {
+		return nil, err
+	}
+
+	metadata, err := parseInstancesResponse(metadataResp)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse instance metadata: %w", err)
+	}
+	inst := Instance{Name: name}
+	if len(metadata) > 0 {
+		inst = metadata[0]
+	}
+
+	up, hasUp := instantScalar(upResp)
+	scrapeErr, hasScrapeErr := instantScalar(scrapeErrResp)
+	scrapeDur, hasScrapeDur := instantScalar(scrapeDurResp)
+	longestTx, hasLongestTx := instantScalar(longestTxResp)
+
+	calls := bucketByQueryKey(callsResp)
+	seconds := bucketByQueryKey(secondsResp)
+	rows := bucketByQueryKey(rowsResp)
+
+	return &InstanceDetail{
+		Instance: inst,
+		Window:   window,
+		Health: InstanceHealth{
+			Up:                    up > 0,
+			HasUp:                 hasUp,
+			ScrapeError:           scrapeErr > 0,
+			HasScrapeError:        hasScrapeErr,
+			ScrapeDurationSeconds: scrapeDur,
+			HasScrapeDuration:     hasScrapeDur,
+		},
+		LongestTxSeconds: longestTx,
+		HasLongestTx:     hasLongestTx,
+		Connections:      parseConnectionsByState(connectionsResp),
+		WaitEvents:       parseWaitEvents(waitEventsResp),
+		TopQueries:       mergeTopQueries(calls, seconds, rows, top),
+	}, nil
+}
+
+// queryInto returns an errgroup task that builds a PromQL expression via
+// build, executes it, and stores the response in sink.
+func queryInto(ctx context.Context, client *prometheus.Client, datasourceUID string, build func() (string, error), sink **prometheus.QueryResponse) func() error {
+	return func() error {
+		expr, err := build()
+		if err != nil {
+			return fmt.Errorf("failed to build query: %w", err)
+		}
+		resp, err := client.Query(ctx, datasourceUID, prometheus.QueryRequest{Query: expr})
+		if err != nil {
+			return fmt.Errorf("query failed: %w", err)
+		}
+		*sink = resp
+		return nil
+	}
+}
+
+// instanceDetailCodec renders an InstanceDetail as a kubectl-describe-style
+// key:value block followed by connections/wait-events/top-queries tables.
+type instanceDetailCodec struct {
+	Wide bool
+}
+
+func (c *instanceDetailCodec) Format() format.Format {
+	if c.Wide {
+		return "wide"
+	}
+	return "table"
+}
+
+func (c *instanceDetailCodec) Decode(io.Reader, any) error {
+	return errors.New("instances get table codec does not support decoding")
+}
+
+func (c *instanceDetailCodec) Encode(w io.Writer, v any) error {
+	detail, ok := v.(*InstanceDetail)
+	if !ok {
+		return fmt.Errorf("invalid data type for instances get table codec: %T", v)
+	}
+
+	tw := tabwriter.NewWriter(w, 0, 4, 2, ' ', 0)
+	writeRow := func(label, value string) {
+		fmt.Fprintf(tw, "%s:\t%s\n", label, value)
+	}
+
+	inst := &detail.Instance
+	writeRow("Name", orDash(inst.Name))
+	writeRow("Engine", orDash(inst.Engine))
+	writeRow("Version", orDash(inst.EngineVersion))
+	writeRow("Environment", orDash(inst.Environment))
+	writeRow("Provider", orDash(inst.ProviderName))
+	if c.Wide {
+		writeRow("Namespace", orDash(inst.Namespace))
+		writeRow("Host", orDash(inst.Host))
+		writeRow("Identifier", orDash(inst.InstanceIdentifier))
+		writeRow("Region", orDash(inst.ProviderRegion))
+	}
+	fmt.Fprintln(tw)
+
+	h := &detail.Health
+	writeRow("Up", formatBoolMaybe(h.Up, h.HasUp))
+	writeRow("Scrape error", formatBoolMaybe(h.ScrapeError, h.HasScrapeError))
+	writeRow("Scrape duration", formatSeconds(h.ScrapeDurationSeconds, h.HasScrapeDuration))
+	writeRow("Longest transaction", formatSeconds(detail.LongestTxSeconds, detail.HasLongestTx))
+	fmt.Fprintln(tw)
+	if err := tw.Flush(); err != nil {
+		return err
+	}
+
+	if len(detail.Connections) > 0 {
+		fmt.Fprintln(w, "Connections by state:")
+		t := style.NewTable("STATE", "COUNT")
+		for _, c := range detail.Connections {
+			t.Row(c.State, strconv.FormatFloat(c.Count, 'f', 0, 64))
+		}
+		if err := t.Render(w); err != nil {
+			return err
+		}
+		fmt.Fprintln(w)
+	}
+
+	if len(detail.WaitEvents) > 0 {
+		fmt.Fprintln(w, "Active wait events:")
+		t := style.NewTable("TYPE", "EVENT", "COUNT")
+		for _, we := range detail.WaitEvents {
+			t.Row(orDash(we.Type), orDash(we.Event), strconv.FormatFloat(we.Count, 'f', 0, 64))
+		}
+		if err := t.Render(w); err != nil {
+			return err
+		}
+		fmt.Fprintln(w)
+	}
+
+	fmt.Fprintf(w, "Top queries by time share (window %s):\n", detail.Window)
+	if len(detail.TopQueries) == 0 {
+		_, err := fmt.Fprintln(w, "No pg_stat_statements activity in the requested window.")
+		return err
+	}
+	headers := []string{"QUERYID", "DATNAME", "CALLS/S", "TIME/S", "MEAN LATENCY"}
+	if c.Wide {
+		headers = append(headers, "ROWS/CALL")
+	}
+	t := style.NewTable(headers...)
+	for _, q := range detail.TopQueries {
+		row := []string{
+			q.QueryID,
+			orDash(q.Datname),
+			fmt.Sprintf("%.3f", q.CallsPerSecond),
+			fmt.Sprintf("%.6f", q.TimePerSecond),
+			formatSeconds(q.MeanLatencySeconds, q.HasMeanLatency),
+		}
+		if c.Wide {
+			row = append(row, formatRowsPerCall(q.RowsPerCall, q.HasRowsPerCall))
+		}
+		t.Row(row...)
+	}
+	return t.Render(w)
+}
+
+func formatBoolMaybe(v, has bool) string {
+	if !has {
+		return "-"
+	}
+	if v {
+		return "true"
+	}
+	return "false"
+}
+
+// formatSeconds prints a duration with units that scale to the magnitude —
+// sub-millisecond stays in µs, sub-second stays in ms, anything larger is
+// shown in seconds. Mirrors appo11y/services.formatDuration.
+func formatSeconds(seconds float64, has bool) string {
+	if !has {
+		return "-"
+	}
+	switch {
+	case seconds < 0.001:
+		return fmt.Sprintf("%.0fµs", seconds*1_000_000)
+	case seconds < 1:
+		return fmt.Sprintf("%.2fms", seconds*1000)
+	default:
+		return fmt.Sprintf("%.3fs", seconds)
+	}
+}
+
+func formatRowsPerCall(v float64, has bool) string {
+	if !has {
+		return "-"
+	}
+	return fmt.Sprintf("%.2f", v)
+}

--- a/internal/providers/dbo11y/instances/get.go
+++ b/internal/providers/dbo11y/instances/get.go
@@ -24,7 +24,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// defaultQueryWindow is the rate window for pg_stat_statements when --window
+// defaultQueryWindow is the rate window for pg_stat_statements when --since
 // isn't set. 5m mirrors appo11y's defaultRedWindow.
 const defaultQueryWindow = "5m"
 
@@ -35,7 +35,7 @@ const defaultTopQueriesLimit = 10
 type getOpts struct {
 	IO         cmdio.Options
 	Datasource string
-	Window     string
+	Since      string
 	Top        int
 	Filters    []string
 }
@@ -47,20 +47,20 @@ func (o *getOpts) setup(flags *pflag.FlagSet) {
 	o.IO.BindFlags(flags)
 
 	flags.StringVarP(&o.Datasource, "datasource", "d", "", "Prometheus datasource UID (defaults to datasources.prometheus in config or auto-discovery)")
-	flags.StringVar(&o.Window, "window", defaultQueryWindow, "Rate window applied to pg_stat_statements (e.g. 1m, 5m, 1h) — PromQL duration syntax")
+	flags.StringVar(&o.Since, "since", defaultQueryWindow, "Rate window applied to pg_stat_statements (e.g. 1m, 5m, 1h) — PromQL duration syntax")
 	flags.IntVar(&o.Top, "top", defaultTopQueriesLimit, "Limit the number of top queries returned, ranked by time share (0 = unlimited)")
-	flags.StringArrayVar(&o.Filters, "filter", nil, "Scope the snapshot to series matching a label matcher, e.g. --filter datname=payments (repeatable)")
+	flags.StringArrayVar(&o.Filters, "filter", nil, "Scope the pg_stat_activity/pg_stat_statements queries (connections, wait events, longest transaction, top queries) to series matching a label matcher, e.g. --filter datname=payments (repeatable). Does not affect health/inventory metrics (pg_up, exporter scrape stats, instance metadata), which don't carry a datname label")
 }
 
 func (o *getOpts) Validate(cmd *cobra.Command) error {
 	if err := o.IO.Validate(); err != nil {
 		return err
 	}
-	if strings.TrimSpace(o.Window) == "" {
-		return fail.NewCommandUsageError(cmd, "--window must not be empty", nil)
+	if strings.TrimSpace(o.Since) == "" {
+		return fail.NewCommandUsageError(cmd, "--since must not be empty", nil)
 	}
-	if _, err := model.ParseDuration(o.Window); err != nil {
-		return fail.NewCommandUsageError(cmd, fmt.Sprintf("--window %q is not a valid PromQL duration", o.Window), err)
+	if _, err := model.ParseDuration(o.Since); err != nil {
+		return fail.NewCommandUsageError(cmd, fmt.Sprintf("--since %q is not a valid PromQL duration", o.Since), err)
 	}
 	if o.Top < 0 {
 		return fail.NewCommandUsageError(cmd, "--top must be zero or positive", nil)
@@ -79,15 +79,20 @@ The argument is the instance's service_name (the identifier "gcx dbo11y
 instances list" reports as NAME). Health comes from pg_up and the exporter's
 own scrape metrics; connections and wait events come from pg_stat_activity;
 top queries are ranked by time share (seconds of database time spent per
-second) from pg_stat_statements over --window (default 5m).`,
+second) from pg_stat_statements over --since (default 5m).
+
+--filter only scopes the pg_stat_activity/pg_stat_statements queries
+(connections, wait events, longest transaction, top queries) — health and
+inventory metadata (pg_up, exporter scrape stats, instance metadata) don't
+carry a datname label and are unaffected.`,
 		Example: `
   # Health, connections, wait events, and top queries for one instance
   gcx dbo11y instances get quickpizza-db
 
   # Widen the query window and show more top queries
-  gcx dbo11y instances get quickpizza-db --window 1h --top 20
+  gcx dbo11y instances get quickpizza-db --since 1h --top 20
 
-  # Scope to a single database on a multi-database instance
+  # Scope connections/queries to a single database on a multi-database instance
   gcx dbo11y instances get quickpizza-db --filter datname=payments
 
   # JSON for scripting
@@ -96,7 +101,7 @@ second) from pg_stat_statements over --window (default 5m).`,
 		RunE: runGet(loader, opts),
 		Annotations: map[string]string{
 			agent.AnnotationTokenCost: "small",
-			agent.AnnotationLLMHint:   `Per-instance Database Observability snapshot: pg_up/scrape health, connection counts by state, active wait events (wait_event_type/wait_event), longest running transaction, and top queries by time share from pg_stat_statements over --window (default 5m). Pairs with 'gcx dbo11y instances list' to find instance names. Use --filter <label><op><value> (repeatable) to scope to one database on a multi-database instance, e.g. --filter datname=payments. Examples: gcx dbo11y instances get <name> -o json; gcx dbo11y instances get <name> --window 1h --top 20 -o json`,
+			agent.AnnotationLLMHint:   `Per-instance Database Observability snapshot: pg_up/scrape health, connection counts by state, active wait events (wait_event_type/wait_event), longest running transaction, and top queries by time share from pg_stat_statements over --since (default 5m). Pairs with 'gcx dbo11y instances list' to find instance names. Use --filter <label><op><value> (repeatable) to scope the pg_stat_activity/pg_stat_statements queries to one database on a multi-database instance, e.g. --filter datname=payments — health/inventory metrics don't carry that label and are unaffected. Examples: gcx dbo11y instances get <name> -o json; gcx dbo11y instances get <name> --since 1h --top 20 -o json`,
 		},
 	}
 	opts.setup(cmd.Flags())
@@ -134,7 +139,7 @@ func runGet(loader *providers.ConfigLoader, opts *getOpts) func(*cobra.Command, 
 			return fmt.Errorf("failed to create prometheus client: %w", err)
 		}
 
-		detail, err := fetchInstanceDetail(ctx, client, datasourceUID, name, opts.Window, opts.Top, matchers)
+		detail, truncated, err := fetchInstanceDetail(ctx, client, datasourceUID, name, opts.Since, opts.Top, matchers)
 		if err != nil {
 			return err
 		}
@@ -144,6 +149,11 @@ func runGet(loader *providers.ConfigLoader, opts *getOpts) func(*cobra.Command, 
 			cmdio.EmitHint(cmd.ErrOrStderr(),
 				fmt.Sprintf("no telemetry found for %q in the requested window", name),
 				"gcx dbo11y instances list")
+		}
+		if truncated {
+			cmdio.EmitHint(cmd.ErrOrStderr(),
+				fmt.Sprintf("showing top %d queries by time share", opts.Top),
+				fmt.Sprintf("gcx dbo11y instances get %s --top %d", name, opts.Top*2))
 		}
 		if err := opts.IO.Encode(cmd.OutOrStdout(), detail); err != nil {
 			return err
@@ -158,8 +168,11 @@ func runGet(loader *providers.ConfigLoader, opts *getOpts) func(*cobra.Command, 
 
 // fetchInstanceDetail runs the metadata, health, connections, wait-events,
 // longest-tx, and top-queries queries in parallel and folds the responses
-// into one InstanceDetail.
-func fetchInstanceDetail(ctx context.Context, client *prometheus.Client, datasourceUID, name, window string, top int, matchers []Matcher) (*InstanceDetail, error) {
+// into one InstanceDetail. matchers only scope the pg_stat_activity/
+// pg_stat_statements queries (connections, wait events, longest tx, top
+// queries) — metadata and health/exporter metrics don't carry labels like
+// datname, so applying arbitrary matchers there would silently zero them out.
+func fetchInstanceDetail(ctx context.Context, client *prometheus.Client, datasourceUID, name, window string, top int, matchers []Matcher) (*InstanceDetail, bool, error) {
 	var (
 		metadataResp                                   *prometheus.QueryResponse
 		upResp, scrapeErrResp, scrapeDurResp           *prometheus.QueryResponse
@@ -169,16 +182,16 @@ func fetchInstanceDetail(ctx context.Context, client *prometheus.Client, datasou
 
 	eg, egCtx := errgroup.WithContext(ctx)
 	eg.Go(queryInto(egCtx, client, datasourceUID, func() (string, error) {
-		return buildConnectionInfoQuery(append([]Matcher{{Label: serviceNameLabel, Op: "=", Value: name}}, matchers...))
+		return buildConnectionInfoQuery([]Matcher{{Label: serviceNameLabel, Op: "=", Value: name}})
 	}, &metadataResp))
 	eg.Go(queryInto(egCtx, client, datasourceUID, func() (string, error) {
-		return buildUpQuery(pgUpMetric, name, matchers)
+		return buildUpQuery(pgUpMetric, name, nil)
 	}, &upResp))
 	eg.Go(queryInto(egCtx, client, datasourceUID, func() (string, error) {
-		return buildUpQuery(pgScrapeErrorMetric, name, matchers)
+		return buildUpQuery(pgScrapeErrorMetric, name, nil)
 	}, &scrapeErrResp))
 	eg.Go(queryInto(egCtx, client, datasourceUID, func() (string, error) {
-		return buildUpQuery(pgScrapeDurationMetric, name, matchers)
+		return buildUpQuery(pgScrapeDurationMetric, name, nil)
 	}, &scrapeDurResp))
 	eg.Go(queryInto(egCtx, client, datasourceUID, func() (string, error) {
 		return buildConnectionsByStateQuery(name, matchers)
@@ -199,12 +212,12 @@ func fetchInstanceDetail(ctx context.Context, client *prometheus.Client, datasou
 		return buildTopQueriesRateQuery(pgStatStatementsRows, name, window, matchers)
 	}, &rowsResp))
 	if err := eg.Wait(); err != nil {
-		return nil, err
+		return nil, false, err
 	}
 
 	metadata, err := parseInstancesResponse(metadataResp)
 	if err != nil {
-		return nil, fmt.Errorf("failed to parse instance metadata: %w", err)
+		return nil, false, fmt.Errorf("failed to parse instance metadata: %w", err)
 	}
 	inst := Instance{Name: name}
 	if len(metadata) > 0 {
@@ -219,6 +232,7 @@ func fetchInstanceDetail(ctx context.Context, client *prometheus.Client, datasou
 	calls := bucketByQueryKey(callsResp)
 	seconds := bucketByQueryKey(secondsResp)
 	rows := bucketByQueryKey(rowsResp)
+	topQueries, truncated := mergeTopQueries(calls, seconds, rows, top)
 
 	return &InstanceDetail{
 		Instance: inst,
@@ -235,8 +249,8 @@ func fetchInstanceDetail(ctx context.Context, client *prometheus.Client, datasou
 		HasLongestTx:     hasLongestTx,
 		Connections:      parseConnectionsByState(connectionsResp),
 		WaitEvents:       parseWaitEvents(waitEventsResp),
-		TopQueries:       mergeTopQueries(calls, seconds, rows, top),
-	}, nil
+		TopQueries:       topQueries,
+	}, truncated, nil
 }
 
 // queryInto returns an errgroup task that builds a PromQL expression via

--- a/internal/providers/dbo11y/instances/list.go
+++ b/internal/providers/dbo11y/instances/list.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/grafana/gcx/cmd/gcx/fail"
 	"github.com/grafana/gcx/internal/agent"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	"github.com/grafana/gcx/internal/format"
@@ -38,12 +39,12 @@ func (o *listOpts) setup(flags *pflag.FlagSet) {
 	flags.IntVar(&o.Limit, "limit", instancesListDefaultLimit, "Limit the number of instances returned (0 = unlimited)")
 }
 
-func (o *listOpts) Validate() error {
+func (o *listOpts) Validate(cmd *cobra.Command) error {
 	if err := o.IO.Validate(); err != nil {
 		return err
 	}
 	if o.Limit < 0 {
-		return errors.New("--limit must be zero or positive")
+		return fail.NewCommandUsageError(cmd, "--limit must be zero or positive", nil)
 	}
 	return nil
 }
@@ -84,8 +85,12 @@ connections, wait events, and top queries by time share.`,
 
 func runList(loader *providers.ConfigLoader, opts *listOpts) func(*cobra.Command, []string) error {
 	return func(cmd *cobra.Command, _ []string) error {
-		if err := opts.Validate(); err != nil {
+		if err := opts.Validate(cmd); err != nil {
 			return err
+		}
+		matchers, err := parseFilters(opts.Filters)
+		if err != nil {
+			return fail.NewCommandUsageError(cmd, "", err)
 		}
 
 		ctx := cmd.Context()
@@ -96,11 +101,6 @@ func runList(loader *providers.ConfigLoader, opts *listOpts) func(*cobra.Command
 		}
 
 		datasourceUID, err := dsquery.ResolveAndSaveDatasource(ctx, loader, opts.Datasource, cfgCtx, cfg, "prometheus")
-		if err != nil {
-			return err
-		}
-
-		matchers, err := parseFilters(opts.Filters)
 		if err != nil {
 			return err
 		}

--- a/internal/providers/dbo11y/instances/list.go
+++ b/internal/providers/dbo11y/instances/list.go
@@ -1,0 +1,200 @@
+package instances
+
+import (
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/grafana/gcx/internal/agent"
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+	"github.com/grafana/gcx/internal/format"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/query/prometheus"
+	"github.com/grafana/gcx/internal/style"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// instancesListDefaultLimit caps the row count of the default `instances list`
+// view. Mirrors appo11y services list.
+const instancesListDefaultLimit = 50
+
+type listOpts struct {
+	IO         cmdio.Options
+	Datasource string
+	Filters    []string
+	Limit      int
+}
+
+func (o *listOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &instancesTableCodec{})
+	o.IO.RegisterCustomCodec("wide", &instancesTableCodec{Wide: true})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+
+	flags.StringVarP(&o.Datasource, "datasource", "d", "", "Prometheus datasource UID (defaults to datasources.prometheus in config or auto-discovery)")
+	flags.StringArrayVar(&o.Filters, "filter", nil, "Restrict to instances matching a label matcher, e.g. --filter engine=postgres (repeatable)")
+	flags.IntVar(&o.Limit, "limit", instancesListDefaultLimit, "Limit the number of instances returned (0 = unlimited)")
+}
+
+func (o *listOpts) Validate() error {
+	if err := o.IO.Validate(); err != nil {
+		return err
+	}
+	if o.Limit < 0 {
+		return errors.New("--limit must be zero or positive")
+	}
+	return nil
+}
+
+func newListCommand(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &listOpts{}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List Database Observability instances discovered from telemetry.",
+		Long: `List the database instances Grafana Cloud Database Observability has discovered.
+
+Discovery uses the database_observability_connection_info inventory metric
+emitted by the database_observability.postgres Alloy component (job
+"integrations/db-o11y"): one row per monitored database instance, with engine
+and cloud-provider metadata.
+
+Related: "gcx dbo11y instances get <name>" drills into one instance's health,
+connections, wait events, and top queries by time share.`,
+		Example: `
+  # List all database instances in the current stack
+  gcx dbo11y instances list
+
+  # Filter to Postgres instances
+  gcx dbo11y instances list --filter engine=postgres
+
+  # Pin a datasource and output JSON
+  gcx dbo11y instances list -d grafanacloud-prom -o json`,
+		Args: cobra.NoArgs,
+		RunE: runList(loader, opts),
+		Annotations: map[string]string{
+			agent.AnnotationTokenCost: "small",
+			agent.AnnotationLLMHint:   `Database Observability instance inventory from database_observability_connection_info: one row per monitored database (engine, version, cloud provider metadata). Pairs with 'gcx dbo11y instances get <name>' for health/connections/wait-events/top-queries. Examples: gcx dbo11y instances list -o json; gcx dbo11y instances list --filter engine=postgres -o json`,
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+func runList(loader *providers.ConfigLoader, opts *listOpts) func(*cobra.Command, []string) error {
+	return func(cmd *cobra.Command, _ []string) error {
+		if err := opts.Validate(); err != nil {
+			return err
+		}
+
+		ctx := cmd.Context()
+
+		cfgCtx, cfg, err := dsquery.LoadContextAndConfig(ctx, loader)
+		if err != nil {
+			return err
+		}
+
+		datasourceUID, err := dsquery.ResolveAndSaveDatasource(ctx, loader, opts.Datasource, cfgCtx, cfg, "prometheus")
+		if err != nil {
+			return err
+		}
+
+		matchers, err := parseFilters(opts.Filters)
+		if err != nil {
+			return err
+		}
+
+		client, err := prometheus.NewClient(cfg)
+		if err != nil {
+			return fmt.Errorf("failed to create prometheus client: %w", err)
+		}
+
+		expr, err := buildConnectionInfoQuery(matchers)
+		if err != nil {
+			return fmt.Errorf("failed to build instances query: %w", err)
+		}
+		resp, err := client.Query(ctx, datasourceUID, prometheus.QueryRequest{Query: expr})
+		if err != nil {
+			return fmt.Errorf("instances query failed: %w", err)
+		}
+
+		items, err := parseInstancesResponse(resp)
+		if err != nil {
+			return fmt.Errorf("failed to parse instances response: %w", err)
+		}
+
+		truncated := false
+		if opts.Limit > 0 && len(items) > opts.Limit {
+			items = items[:opts.Limit]
+			truncated = true
+		}
+		if truncated {
+			cmdio.EmitHint(cmd.ErrOrStderr(),
+				fmt.Sprintf("showing first %d instances", opts.Limit),
+				fmt.Sprintf("gcx dbo11y instances list --limit %d", opts.Limit*2))
+		}
+
+		return opts.IO.Encode(cmd.OutOrStdout(), &InstancesResponse{Items: items})
+	}
+}
+
+// instancesTableCodec renders the instances inventory as a tabular view.
+type instancesTableCodec struct {
+	Wide bool
+}
+
+func (c *instancesTableCodec) Format() format.Format {
+	if c.Wide {
+		return "wide"
+	}
+	return "table"
+}
+
+func (c *instancesTableCodec) Decode(io.Reader, any) error {
+	return errors.New("instances table codec does not support decoding")
+}
+
+func (c *instancesTableCodec) Encode(w io.Writer, v any) error {
+	resp, ok := v.(*InstancesResponse)
+	if !ok {
+		return fmt.Errorf("invalid data type for instances table codec: %T", v)
+	}
+	if len(resp.Items) == 0 {
+		_, err := fmt.Fprintln(w, "No database instances discovered. Verify Database Observability is configured for this stack.")
+		return err
+	}
+
+	headers := []string{"NAME", "ENGINE", "VERSION", "ENVIRONMENT", "PROVIDER"}
+	if c.Wide {
+		headers = append(headers, "NAMESPACE", "HOST", "IDENTIFIER", "REGION")
+	}
+
+	t := style.NewTable(headers...)
+	for _, inst := range resp.Items {
+		row := []string{
+			inst.Name,
+			orDash(inst.Engine),
+			orDash(inst.EngineVersion),
+			orDash(inst.Environment),
+			orDash(inst.ProviderName),
+		}
+		if c.Wide {
+			row = append(row,
+				orDash(inst.Namespace),
+				orDash(inst.Host),
+				orDash(inst.InstanceIdentifier),
+				orDash(inst.ProviderRegion),
+			)
+		}
+		t.Row(row...)
+	}
+	return t.Render(w)
+}
+
+func orDash(v string) string {
+	if v == "" {
+		return "-"
+	}
+	return v
+}

--- a/internal/providers/dbo11y/instances/list.go
+++ b/internal/providers/dbo11y/instances/list.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/gcx/internal/agent"
 	dsquery "github.com/grafana/gcx/internal/datasources/query"
 	"github.com/grafana/gcx/internal/format"
+	"github.com/grafana/gcx/internal/gcxerrors"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/prometheus"
@@ -62,7 +63,12 @@ emitted by the database_observability.postgres Alloy component (job
 and cloud-provider metadata.
 
 Related: "gcx dbo11y instances get <name>" drills into one instance's health,
-connections, wait events, and top queries by time share.`,
+connections, wait events, and top queries by time share.
+
+When no instances are found, this command checks whether Database
+Observability has been activated for the stack and, if not, exits non-zero
+with a hint to activate it in Grafana Cloud instead of a generic empty
+result.`,
 		Example: `
   # List all database instances in the current stack
   gcx dbo11y instances list
@@ -76,7 +82,7 @@ connections, wait events, and top queries by time share.`,
 		RunE: runList(loader, opts),
 		Annotations: map[string]string{
 			agent.AnnotationTokenCost: "small",
-			agent.AnnotationLLMHint:   `Database Observability instance inventory from database_observability_connection_info: one row per monitored database (engine, version, cloud provider metadata). Pairs with 'gcx dbo11y instances get <name>' for health/connections/wait-events/top-queries. Examples: gcx dbo11y instances list -o json; gcx dbo11y instances list --filter engine=postgres -o json`,
+			agent.AnnotationLLMHint:   `Database Observability instance inventory from database_observability_connection_info: one row per monitored database (engine, version, cloud provider metadata). Pairs with 'gcx dbo11y instances get <name>' for health/connections/wait-events/top-queries. On an empty result this command also checks the stack's Database Observability activation status and, if not activated, exits 1 with a specific "not activated" hint instead of the generic empty-result message. Examples: gcx dbo11y instances list -o json; gcx dbo11y instances list --filter engine=postgres -o json`,
 		},
 	}
 	opts.setup(cmd.Flags())
@@ -122,6 +128,20 @@ func runList(loader *providers.ConfigLoader, opts *listOpts) func(*cobra.Command
 		items, err := parseInstancesResponse(resp)
 		if err != nil {
 			return fmt.Errorf("failed to parse instances response: %w", err)
+		}
+
+		if len(items) == 0 {
+			// checkActivation is a best-effort diagnostic enrichment: it can
+			// only make the "no instances" case more specific, never less —
+			// an inconclusive check (activated=false, err!=nil) falls through
+			// to the generic table message below rather than blocking.
+			if activated, actErr := checkActivation(ctx, cfg); actErr == nil && !activated {
+				cmdio.EmitWarn(cmd.ErrOrStderr(), notActivatedError().Error())
+				if err := opts.IO.Encode(cmd.OutOrStdout(), &InstancesResponse{Items: items}); err != nil {
+					return err
+				}
+				return gcxerrors.NewEmittedError(gcxerrors.ExitGeneralError, notActivatedError())
+			}
 		}
 
 		truncated := false

--- a/internal/providers/dbo11y/instances/query.go
+++ b/internal/providers/dbo11y/instances/query.go
@@ -1,0 +1,484 @@
+// Package instances implements the `gcx dbo11y instances` command group.
+//
+// Discovery and health data come from the postgres_exporter + pg_stat_statements
+// metrics emitted by the `database_observability.postgres` Alloy component
+// (job="integrations/db-o11y" by convention). `database_observability_connection_info`
+// is the inventory metric — one series per database instance, carrying engine
+// and cloud-provider metadata — mirroring how appo11y services list treats
+// `target_info` as the service inventory.
+package instances
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/grafana/gcx/internal/query/prometheus"
+	"github.com/grafana/promql-builder/go/promql"
+)
+
+// connectionInfoMetric is the Database Observability inventory metric: one
+// gauge series per monitored database instance, carrying engine/provider
+// metadata as labels.
+const connectionInfoMetric = "database_observability_connection_info"
+
+// Health metrics from postgres_exporter, scoped by the shared service_name label.
+const (
+	pgUpMetric              = "pg_up"
+	pgScrapeErrorMetric     = "pg_exporter_last_scrape_error"
+	pgScrapeDurationMetric  = "pg_exporter_last_scrape_duration_seconds"
+	pgActivityCountMetric   = "pg_stat_activity_count"
+	pgActivityMaxTxMetric   = "pg_stat_activity_max_tx_duration"
+	pgStatStatementsCalls   = "pg_stat_statements_calls_total"
+	pgStatStatementsSeconds = "pg_stat_statements_seconds_total"
+	pgStatStatementsRows    = "pg_stat_statements_rows_total"
+)
+
+// serviceNameLabel is the label every Database Observability metric family
+// shares (inventory, exporter health, and pg_stat_statements alike), so it's
+// the identifier `instances get <name>` scopes queries by.
+const serviceNameLabel = "service_name"
+
+// escapePromqlValue escapes a raw user-supplied value for safe embedding as
+// the value side of a PromQL label matcher. Mirrors appo11y/services'
+// escapePromqlValue: backslashes doubled before quotes are escaped.
+func escapePromqlValue(v string) string {
+	v = strings.ReplaceAll(v, `\`, `\\`)
+	v = strings.ReplaceAll(v, `"`, `\"`)
+	return v
+}
+
+// Instance is a single row in the database inventory, sourced from
+// database_observability_connection_info.
+type Instance struct {
+	Name               string            `json:"name" yaml:"name"`
+	Namespace          string            `json:"namespace,omitempty" yaml:"namespace,omitempty"`
+	Engine             string            `json:"engine,omitempty" yaml:"engine,omitempty"`
+	EngineVersion      string            `json:"engine_version,omitempty" yaml:"engine_version,omitempty"`
+	Environment        string            `json:"environment,omitempty" yaml:"environment,omitempty"`
+	Host               string            `json:"host,omitempty" yaml:"host,omitempty"`
+	InstanceIdentifier string            `json:"instance_identifier,omitempty" yaml:"instance_identifier,omitempty"`
+	ProviderName       string            `json:"provider_name,omitempty" yaml:"provider_name,omitempty"`
+	ProviderAccount    string            `json:"provider_account,omitempty" yaml:"provider_account,omitempty"`
+	ProviderRegion     string            `json:"provider_region,omitempty" yaml:"provider_region,omitempty"`
+	Labels             map[string]string `json:"labels,omitempty" yaml:"labels,omitempty"`
+}
+
+// InstancesResponse is the top-level shape returned by `instances list`.
+type InstancesResponse struct {
+	Items []Instance `json:"items" yaml:"items"`
+}
+
+// unknownProviderValue is what the Alloy component emits for provider_* labels
+// when a database isn't linked to a recognized cloud provider (self-hosted).
+const unknownProviderValue = "unknown"
+
+// orEmpty maps the exporter's "unknown" sentinel to an empty string so table
+// rendering can fall back to "-" uniformly instead of printing "unknown".
+func orEmpty(v string) string {
+	if v == unknownProviderValue {
+		return ""
+	}
+	return v
+}
+
+// buildConnectionInfoQuery returns the PromQL expression for the instance
+// inventory. No aggregation is needed — the metric already carries one series
+// per instance with every label the inventory view needs.
+func buildConnectionInfoQuery(matchers []Matcher) (string, error) {
+	v := promql.Vector(connectionInfoMetric)
+	for _, m := range matchers {
+		v = m.apply(v)
+	}
+	expr, err := v.Build()
+	if err != nil {
+		return "", err
+	}
+	return expr.String(), nil
+}
+
+// Matcher is a parsed `--filter` triple, identical in shape to appo11y/services.Matcher.
+type Matcher struct {
+	Label string
+	Op    string // "=", "!=", "=~", "!~"
+	Value string
+}
+
+func (m Matcher) apply(v *promql.VectorExprBuilder) *promql.VectorExprBuilder {
+	val := escapePromqlValue(m.Value)
+	switch m.Op {
+	case "!=":
+		return v.LabelNeq(m.Label, val)
+	case "=~":
+		return v.LabelMatchRegexp(m.Label, val)
+	case "!~":
+		return v.LabelNotMatchRegexp(m.Label, val)
+	default: // "="
+		return v.Label(m.Label, val)
+	}
+}
+
+// matcherPattern accepts <label><op><value> where op is one of = != =~ !~.
+var matcherPattern = regexp.MustCompile(`^([a-zA-Z_][a-zA-Z0-9_]*)(=~|!~|!=|=)(.*)$`)
+
+// parseFilter validates a single `label<op>value` filter into a Matcher.
+func parseFilter(raw string) (Matcher, error) {
+	m := matcherPattern.FindStringSubmatch(raw)
+	if m == nil {
+		return Matcher{}, fmt.Errorf("invalid --filter %q: expected <label><op><value> where op is = != =~ !~", raw)
+	}
+	label, op, val := m[1], m[2], m[3]
+	if len(val) >= 2 && val[0] == '"' && val[len(val)-1] == '"' {
+		val = val[1 : len(val)-1]
+	}
+	return Matcher{Label: label, Op: op, Value: val}, nil
+}
+
+// parseFilters validates a slice of raw `--filter` strings into Matchers.
+func parseFilters(raw []string) ([]Matcher, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	out := make([]Matcher, 0, len(raw))
+	for _, f := range raw {
+		parsed, err := parseFilter(f)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, parsed)
+	}
+	return out, nil
+}
+
+// parseInstancesResponse converts a database_observability_connection_info
+// instant-query result into a sorted slice of Instance.
+func parseInstancesResponse(resp *prometheus.QueryResponse) ([]Instance, error) {
+	if resp == nil {
+		return nil, errors.New("nil query response")
+	}
+	out := make([]Instance, 0, len(resp.Data.Result))
+	for _, sample := range resp.Data.Result {
+		name := sample.Metric[serviceNameLabel]
+		if name == "" {
+			continue
+		}
+		labels := map[string]string{}
+		for k, v := range sample.Metric {
+			if k == "__name__" || k == serviceNameLabel || v == "" {
+				continue
+			}
+			labels[k] = v
+		}
+		out = append(out, Instance{
+			Name:               name,
+			Namespace:          sample.Metric["service_namespace"],
+			Engine:             sample.Metric["engine"],
+			EngineVersion:      sample.Metric["engine_version"],
+			Environment:        sample.Metric["deployment_environment"],
+			Host:               sample.Metric["instance"],
+			InstanceIdentifier: orEmpty(sample.Metric["db_instance_identifier"]),
+			ProviderName:       orEmpty(sample.Metric["provider_name"]),
+			ProviderAccount:    orEmpty(sample.Metric["provider_account"]),
+			ProviderRegion:     orEmpty(sample.Metric["provider_region"]),
+			Labels:             labels,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Namespace != out[j].Namespace {
+			return out[i].Namespace < out[j].Namespace
+		}
+		return out[i].Name < out[j].Name
+	})
+	return out, nil
+}
+
+// scopedByServiceName returns a vector selector for `metric` filtered to a
+// single instance via the shared service_name label, plus any caller-supplied
+// matchers.
+func scopedByServiceName(metric, name string, matchers []Matcher) *promql.VectorExprBuilder {
+	v := promql.Vector(metric).Label(serviceNameLabel, escapePromqlValue(name))
+	for _, m := range matchers {
+		v = m.apply(v)
+	}
+	return v
+}
+
+// buildUpQuery returns the PromQL for an instant pg_up/scrape-health metric
+// scoped to one instance.
+func buildUpQuery(metric, name string, matchers []Matcher) (string, error) {
+	if name == "" {
+		return "", errors.New("instance name is required")
+	}
+	expr, err := scopedByServiceName(metric, name, matchers).Build()
+	if err != nil {
+		return "", err
+	}
+	return expr.String(), nil
+}
+
+// buildConnectionsByStateQuery returns `sum by (state) (pg_stat_activity_count{...})`
+// for one instance.
+func buildConnectionsByStateQuery(name string, matchers []Matcher) (string, error) {
+	if name == "" {
+		return "", errors.New("instance name is required")
+	}
+	v := scopedByServiceName(pgActivityCountMetric, name, matchers)
+	expr, err := promql.Sum(v).By([]string{"state"}).Build()
+	if err != nil {
+		return "", err
+	}
+	return expr.String(), nil
+}
+
+// buildWaitEventsQuery returns `sum by (wait_event_type, wait_event)
+// (pg_stat_activity_count{..., wait_event!=""})` for one instance — the
+// sessions currently blocked on something, broken out by what they're
+// waiting on.
+func buildWaitEventsQuery(name string, matchers []Matcher) (string, error) {
+	if name == "" {
+		return "", errors.New("instance name is required")
+	}
+	v := scopedByServiceName(pgActivityCountMetric, name, matchers).LabelNeq("wait_event", "")
+	expr, err := promql.Sum(v).By([]string{"wait_event_type", "wait_event"}).Build()
+	if err != nil {
+		return "", err
+	}
+	return expr.String(), nil
+}
+
+// buildLongestTxQuery returns `max(pg_stat_activity_max_tx_duration{...})`
+// for one instance.
+func buildLongestTxQuery(name string, matchers []Matcher) (string, error) {
+	if name == "" {
+		return "", errors.New("instance name is required")
+	}
+	v := scopedByServiceName(pgActivityMaxTxMetric, name, matchers)
+	expr, err := promql.Max(v).Build()
+	if err != nil {
+		return "", err
+	}
+	return expr.String(), nil
+}
+
+// buildTopQueriesRateQuery returns `sum by (queryid, datname) (rate(<metric>{...}[<window>]))`,
+// used for the calls/seconds/rows rates that make up the top-queries view.
+func buildTopQueriesRateQuery(metric, name, window string, matchers []Matcher) (string, error) {
+	if name == "" {
+		return "", errors.New("instance name is required")
+	}
+	v := scopedByServiceName(metric, name, matchers).Range(window)
+	expr, err := promql.Sum(promql.Rate(v)).By([]string{"queryid", "datname"}).Build()
+	if err != nil {
+		return "", err
+	}
+	return expr.String(), nil
+}
+
+// InstanceHealth is the exporter-reported liveness of one database instance.
+type InstanceHealth struct {
+	Up                    bool    `json:"up" yaml:"up"`
+	HasUp                 bool    `json:"has_up" yaml:"has_up"`
+	ScrapeError           bool    `json:"scrape_error" yaml:"scrape_error"`
+	HasScrapeError        bool    `json:"has_scrape_error" yaml:"has_scrape_error"`
+	ScrapeDurationSeconds float64 `json:"scrape_duration_seconds" yaml:"scrape_duration_seconds"`
+	HasScrapeDuration     bool    `json:"has_scrape_duration" yaml:"has_scrape_duration"`
+}
+
+// ConnectionState is one row of the connections-by-state breakdown.
+type ConnectionState struct {
+	State string  `json:"state" yaml:"state"`
+	Count float64 `json:"count" yaml:"count"`
+}
+
+// WaitEvent is one row of the active wait-event breakdown.
+type WaitEvent struct {
+	Type  string  `json:"type" yaml:"type"`
+	Event string  `json:"event" yaml:"event"`
+	Count float64 `json:"count" yaml:"count"`
+}
+
+// TopQuery is one row of the top-queries-by-time-share view, computed from
+// pg_stat_statements over the requested window.
+type TopQuery struct {
+	QueryID            string  `json:"query_id" yaml:"query_id"`
+	Datname            string  `json:"datname" yaml:"datname"`
+	CallsPerSecond     float64 `json:"calls_per_second" yaml:"calls_per_second"`
+	TimePerSecond      float64 `json:"time_per_second" yaml:"time_per_second"`
+	MeanLatencySeconds float64 `json:"mean_latency_seconds" yaml:"mean_latency_seconds"`
+	HasMeanLatency     bool    `json:"has_mean_latency" yaml:"has_mean_latency"`
+	RowsPerCall        float64 `json:"rows_per_call" yaml:"rows_per_call"`
+	HasRowsPerCall     bool    `json:"has_rows_per_call" yaml:"has_rows_per_call"`
+}
+
+// InstanceDetail is the `instances get` response: inventory metadata, exporter
+// health, connection/wait-event breakdowns, and the top queries by time share.
+type InstanceDetail struct {
+	Instance         Instance          `json:"instance" yaml:"instance"`
+	Window           string            `json:"window" yaml:"window"`
+	Health           InstanceHealth    `json:"health" yaml:"health"`
+	LongestTxSeconds float64           `json:"longest_tx_seconds" yaml:"longest_tx_seconds"`
+	HasLongestTx     bool              `json:"has_longest_tx" yaml:"has_longest_tx"`
+	Connections      []ConnectionState `json:"connections,omitempty" yaml:"connections,omitempty"`
+	WaitEvents       []WaitEvent       `json:"wait_events,omitempty" yaml:"wait_events,omitempty"`
+	TopQueries       []TopQuery        `json:"top_queries,omitempty" yaml:"top_queries,omitempty"`
+}
+
+// instantScalar pulls the first sample's value out of a Prometheus instant
+// response and parses it as float64. false means "no data" (no series,
+// unparseable, or NaN/Inf) rather than a misleading zero.
+func instantScalar(resp *prometheus.QueryResponse) (float64, bool) {
+	if resp == nil || len(resp.Data.Result) == 0 {
+		return 0, false
+	}
+	return sampleScalar(resp.Data.Result[0])
+}
+
+func sampleScalar(sample prometheus.Sample) (float64, bool) {
+	if len(sample.Value) < 2 {
+		return 0, false
+	}
+	str, ok := sample.Value[1].(string)
+	if !ok {
+		return 0, false
+	}
+	f, err := strconv.ParseFloat(str, 64)
+	if err != nil {
+		return 0, false
+	}
+	return f, true
+}
+
+// parseConnectionsByState converts a `sum by (state)` response into sorted
+// ConnectionState rows (count desc, then state asc).
+func parseConnectionsByState(resp *prometheus.QueryResponse) []ConnectionState {
+	if resp == nil {
+		return nil
+	}
+	out := make([]ConnectionState, 0, len(resp.Data.Result))
+	for _, sample := range resp.Data.Result {
+		v, ok := sampleScalar(sample)
+		if !ok {
+			continue
+		}
+		out = append(out, ConnectionState{State: sample.Metric["state"], Count: v})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Count != out[j].Count {
+			return out[i].Count > out[j].Count
+		}
+		return out[i].State < out[j].State
+	})
+	return out
+}
+
+// parseWaitEvents converts a `sum by (wait_event_type, wait_event)` response
+// into sorted WaitEvent rows (count desc).
+func parseWaitEvents(resp *prometheus.QueryResponse) []WaitEvent {
+	if resp == nil {
+		return nil
+	}
+	out := make([]WaitEvent, 0, len(resp.Data.Result))
+	for _, sample := range resp.Data.Result {
+		v, ok := sampleScalar(sample)
+		if !ok {
+			continue
+		}
+		out = append(out, WaitEvent{
+			Type:  sample.Metric["wait_event_type"],
+			Event: sample.Metric["wait_event"],
+			Count: v,
+		})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Count != out[j].Count {
+			return out[i].Count > out[j].Count
+		}
+		if out[i].Type != out[j].Type {
+			return out[i].Type < out[j].Type
+		}
+		return out[i].Event < out[j].Event
+	})
+	return out
+}
+
+// queryKey identifies one pg_stat_statements row for joining the calls/time/rows
+// rates together before ranking.
+type queryKey struct {
+	queryID string
+	datname string
+}
+
+// bucketByQueryKey folds a rate-query response into a map keyed by (queryid, datname).
+func bucketByQueryKey(resp *prometheus.QueryResponse) map[queryKey]float64 {
+	out := make(map[queryKey]float64)
+	if resp == nil {
+		return out
+	}
+	for _, sample := range resp.Data.Result {
+		v, ok := sampleScalar(sample)
+		if !ok {
+			continue
+		}
+		k := queryKey{queryID: sample.Metric["queryid"], datname: sample.Metric["datname"]}
+		out[k] = v
+	}
+	return out
+}
+
+// mergeTopQueries joins the calls/time/rows rate buckets into TopQuery rows
+// and sorts by time share (seconds of DB time spent per second) descending —
+// the same "where is the time going" ranking appo11y's operations view uses,
+// applied to SQL statements instead of RPC operations. limit caps the
+// returned rows to the busiest N; 0 means unlimited.
+func mergeTopQueries(calls, seconds, rows map[queryKey]float64, limit int) []TopQuery {
+	keys := make(map[queryKey]struct{}, len(calls)+len(seconds)+len(rows))
+	for k := range calls {
+		keys[k] = struct{}{}
+	}
+	for k := range seconds {
+		keys[k] = struct{}{}
+	}
+	for k := range rows {
+		keys[k] = struct{}{}
+	}
+
+	out := make([]TopQuery, 0, len(keys))
+	for k := range keys {
+		callRate, hasCalls := calls[k]
+		secRate, hasSeconds := seconds[k]
+		rowRate, hasRows := rows[k]
+
+		tq := TopQuery{
+			QueryID:        k.queryID,
+			Datname:        k.datname,
+			CallsPerSecond: callRate,
+			TimePerSecond:  secRate,
+		}
+		if hasCalls && callRate > 0 && hasSeconds {
+			tq.MeanLatencySeconds = secRate / callRate
+			tq.HasMeanLatency = true
+		}
+		if hasCalls && callRate > 0 && hasRows {
+			tq.RowsPerCall = rowRate / callRate
+			tq.HasRowsPerCall = true
+		}
+		out = append(out, tq)
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].TimePerSecond != out[j].TimePerSecond {
+			return out[i].TimePerSecond > out[j].TimePerSecond
+		}
+		if out[i].QueryID != out[j].QueryID {
+			return out[i].QueryID < out[j].QueryID
+		}
+		return out[i].Datname < out[j].Datname
+	})
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return out
+}

--- a/internal/providers/dbo11y/instances/query.go
+++ b/internal/providers/dbo11y/instances/query.go
@@ -26,9 +26,16 @@ import (
 // metadata as labels.
 const connectionInfoMetric = "database_observability_connection_info"
 
-// Health metrics from postgres_exporter, scoped by the shared service_name label.
+// dbo11yJobValue is the fixed job label the database_observability.postgres
+// and database_observability.mysql Alloy components scrape under, regardless
+// of engine. It disambiguates the universal `up` health signal from any other
+// scrape target that happens to share the same service_name (an application
+// pod's own `up` series, for example) — see buildScrapeUpQuery.
+const dbo11yJobValue = "integrations/db-o11y"
+
+// Postgres-specific metrics, scoped by the shared service_name label. Sourced
+// from postgres_exporter (pg_stat_activity, pg_stat_statements collectors).
 const (
-	pgUpMetric              = "pg_up"
 	pgScrapeErrorMetric     = "pg_exporter_last_scrape_error"
 	pgScrapeDurationMetric  = "pg_exporter_last_scrape_duration_seconds"
 	pgActivityCountMetric   = "pg_stat_activity_count"
@@ -38,10 +45,84 @@ const (
 	pgStatStatementsRows    = "pg_stat_statements_rows_total"
 )
 
+// MySQL-specific metrics, scoped by the shared service_name label. Sourced
+// from mysqld_exporter's Performance Schema eventsstatements collector.
+// Confirmed against the grafana-dbo11y-app v2.30.0 production bundle
+// (module.js chunks 530/917) — there is no live MySQL dbo11y telemetry on any
+// gcx-registered stack to verify end-to-end, so these names are pinned from
+// the shipping plugin's own PromQL literals rather than a query response.
+const (
+	mysqlStatementsCalls   = "mysql_perf_schema_events_statements_total"
+	mysqlStatementsSeconds = "mysql_perf_schema_events_statements_seconds_total"
+	mysqlStatementsRows    = "mysql_perf_schema_events_statements_rows_examined_total"
+	mysqlConnectedMetric   = "mysql_global_status_threads_connected"
+)
+
 // serviceNameLabel is the label every Database Observability metric family
-// shares (inventory, exporter health, and pg_stat_statements alike), so it's
-// the identifier `instances get <name>` scopes queries by.
+// shares (inventory, exporter health, and per-engine query-stats metrics
+// alike), so it's the identifier `instances get <name>` scopes queries by.
 const serviceNameLabel = "service_name"
+
+// engineMySQL and engineDefault are the "engine" label values
+// database_observability_connection_info emits. Any value other than
+// "mysql" (including empty/unknown, when metadata lookup finds nothing)
+// falls back to the Postgres metric family, matching this provider's
+// original and most-verified behavior.
+const engineMySQL = "mysql"
+
+// engineQueryMetrics is the per-engine metric/label vocabulary for the
+// pg_stat_statements-equivalent "top queries" view, plus which of the
+// connections/wait-events/scrape-health signals that engine actually has a
+// metric for. Empty string fields mean "no metric confirmed for this engine" —
+// callers skip that query rather than guess a name and silently return
+// nothing.
+//
+// MySQL has no confirmed per-state connection breakdown (only the single
+// mysql_global_status_threads_connected gauge), no confirmed live wait-event
+// metric (the product's own wait-event analysis is Loki-log-based for both
+// engines — see database_observability_wait_event_seconds_total usage in the
+// dbo11y-app bundle, which is a LogQL `unwrap` field, not a Prometheus
+// metric), and no confirmed exporter self-scrape-health metric analogous to
+// pg_exporter_last_scrape_error/duration_seconds.
+type engineQueryMetrics struct {
+	statementsCalls      string
+	statementsSeconds    string
+	statementsRows       string
+	queryIDLabel         string
+	datnameLabel         string
+	connectedMetric      string // single current-connections gauge (MySQL); empty when a per-state breakdown exists instead
+	activityMetric       string // per-state connections + wait-event breakdown (Postgres only)
+	maxTxMetric          string // longest running transaction (Postgres only)
+	scrapeErrorMetric    string // exporter self-reported scrape health (Postgres only)
+	scrapeDurationMetric string
+}
+
+// metricsForEngine resolves the "engine" label from database_observability_connection_info
+// to its query-metric vocabulary. Falls back to Postgres for any value other
+// than "mysql", including empty (metadata lookup found nothing).
+func metricsForEngine(engine string) engineQueryMetrics {
+	if strings.EqualFold(strings.TrimSpace(engine), engineMySQL) {
+		return engineQueryMetrics{
+			statementsCalls:   mysqlStatementsCalls,
+			statementsSeconds: mysqlStatementsSeconds,
+			statementsRows:    mysqlStatementsRows,
+			queryIDLabel:      "digest",
+			datnameLabel:      "schema",
+			connectedMetric:   mysqlConnectedMetric,
+		}
+	}
+	return engineQueryMetrics{
+		statementsCalls:      pgStatStatementsCalls,
+		statementsSeconds:    pgStatStatementsSeconds,
+		statementsRows:       pgStatStatementsRows,
+		queryIDLabel:         "queryid",
+		datnameLabel:         "datname",
+		activityMetric:       pgActivityCountMetric,
+		maxTxMetric:          pgActivityMaxTxMetric,
+		scrapeErrorMetric:    pgScrapeErrorMetric,
+		scrapeDurationMetric: pgScrapeDurationMetric,
+	}
+}
 
 // escapePromqlValue escapes a raw user-supplied value for safe embedding as
 // the value side of a PromQL label matcher. Mirrors appo11y/services'
@@ -229,11 +310,35 @@ func scopedByServiceName(metric, name string, matchers []Matcher) *promql.Vector
 	return v
 }
 
-// buildUpQuery returns the PromQL for an instant pg_up/scrape-health metric
-// scoped to one instance.
+// buildScrapeUpQuery returns the PromQL for the universal Prometheus scrape-health
+// gauge (`up`), scoped to one instance's dbo11y scrape target specifically —
+// engine-agnostic, unlike pg_up/mysql_up. The job matcher is required: `up`
+// is emitted by every scrape target, so an unscoped service_name match can
+// collide with an unrelated target that happens to share the name (e.g. the
+// database's own application pod).
+func buildScrapeUpQuery(name string) (string, error) {
+	if name == "" {
+		return "", errors.New("instance name is required")
+	}
+	v := promql.Vector("up").
+		Label(serviceNameLabel, escapePromqlValue(name)).
+		Label("job", dbo11yJobValue)
+	expr, err := v.Build()
+	if err != nil {
+		return "", err
+	}
+	return expr.String(), nil
+}
+
+// buildUpQuery returns the PromQL for an instant single-value metric
+// (exporter scrape health, MySQL's current-connections gauge) scoped to one
+// instance.
 func buildUpQuery(metric, name string, matchers []Matcher) (string, error) {
 	if name == "" {
 		return "", errors.New("instance name is required")
+	}
+	if metric == "" {
+		return "", errors.New("metric name is required")
 	}
 	expr, err := scopedByServiceName(metric, name, matchers).Build()
 	if err != nil {
@@ -286,14 +391,19 @@ func buildLongestTxQuery(name string, matchers []Matcher) (string, error) {
 	return expr.String(), nil
 }
 
-// buildTopQueriesRateQuery returns `sum by (queryid, datname) (rate(<metric>{...}[<window>]))`,
-// used for the calls/seconds/rows rates that make up the top-queries view.
-func buildTopQueriesRateQuery(metric, name, window string, matchers []Matcher) (string, error) {
+// buildTopQueriesRateQuery returns `sum by (<queryIDLabel>, <datnameLabel>)
+// (rate(<metric>{...}[<window>]))`, used for the calls/seconds/rows rates
+// that make up the top-queries view. Label names are engine-specific:
+// queryid/datname for Postgres, digest/schema for MySQL.
+func buildTopQueriesRateQuery(metric, name, window string, matchers []Matcher, queryIDLabel, datnameLabel string) (string, error) {
 	if name == "" {
 		return "", errors.New("instance name is required")
 	}
+	if metric == "" {
+		return "", errors.New("metric name is required")
+	}
 	v := scopedByServiceName(metric, name, matchers).Range(window)
-	expr, err := promql.Sum(promql.Rate(v)).By([]string{"queryid", "datname"}).Build()
+	expr, err := promql.Sum(promql.Rate(v)).By([]string{queryIDLabel, datnameLabel}).Build()
 	if err != nil {
 		return "", err
 	}
@@ -434,8 +544,10 @@ type queryKey struct {
 	datname string
 }
 
-// bucketByQueryKey folds a rate-query response into a map keyed by (queryid, datname).
-func bucketByQueryKey(resp *prometheus.QueryResponse) map[queryKey]float64 {
+// bucketByQueryKey folds a rate-query response into a map keyed by
+// (queryIDLabel, datnameLabel) — the engine-specific query-identity labels
+// (queryid/datname for Postgres, digest/schema for MySQL).
+func bucketByQueryKey(resp *prometheus.QueryResponse, queryIDLabel, datnameLabel string) map[queryKey]float64 {
 	out := make(map[queryKey]float64)
 	if resp == nil {
 		return out
@@ -445,7 +557,7 @@ func bucketByQueryKey(resp *prometheus.QueryResponse) map[queryKey]float64 {
 		if !ok {
 			continue
 		}
-		k := queryKey{queryID: sample.Metric["queryid"], datname: sample.Metric["datname"]}
+		k := queryKey{queryID: sample.Metric[queryIDLabel], datname: sample.Metric[datnameLabel]}
 		out[k] = v
 	}
 	return out

--- a/internal/providers/dbo11y/instances/query.go
+++ b/internal/providers/dbo11y/instances/query.go
@@ -11,6 +11,7 @@ package instances
 import (
 	"errors"
 	"fmt"
+	"math"
 	"regexp"
 	"sort"
 	"strconv"
@@ -153,12 +154,34 @@ func parseFilters(raw []string) ([]Matcher, error) {
 	return out, nil
 }
 
+// connectionInfoPromotedLabels are the database_observability_connection_info
+// labels already surfaced as typed Instance fields. Excluded from the
+// catch-all Labels map so a row doesn't carry each value twice — once typed,
+// once raw — and so the "unknown" provider sentinel (stripped from the typed
+// fields by orEmpty) doesn't reappear verbatim in Labels.
+func connectionInfoPromotedLabels() map[string]struct{} {
+	return map[string]struct{}{
+		"__name__":               {},
+		serviceNameLabel:         {},
+		"service_namespace":      {},
+		"engine":                 {},
+		"engine_version":         {},
+		"deployment_environment": {},
+		"instance":               {},
+		"db_instance_identifier": {},
+		"provider_name":          {},
+		"provider_account":       {},
+		"provider_region":        {},
+	}
+}
+
 // parseInstancesResponse converts a database_observability_connection_info
 // instant-query result into a sorted slice of Instance.
 func parseInstancesResponse(resp *prometheus.QueryResponse) ([]Instance, error) {
 	if resp == nil {
 		return nil, errors.New("nil query response")
 	}
+	promoted := connectionInfoPromotedLabels()
 	out := make([]Instance, 0, len(resp.Data.Result))
 	for _, sample := range resp.Data.Result {
 		name := sample.Metric[serviceNameLabel]
@@ -167,7 +190,7 @@ func parseInstancesResponse(resp *prometheus.QueryResponse) ([]Instance, error) 
 		}
 		labels := map[string]string{}
 		for k, v := range sample.Metric {
-			if k == "__name__" || k == serviceNameLabel || v == "" {
+			if _, skip := promoted[k]; skip || v == "" {
 				continue
 			}
 			labels[k] = v
@@ -345,7 +368,7 @@ func sampleScalar(sample prometheus.Sample) (float64, bool) {
 		return 0, false
 	}
 	f, err := strconv.ParseFloat(str, 64)
-	if err != nil {
+	if err != nil || math.IsNaN(f) || math.IsInf(f, 0) {
 		return 0, false
 	}
 	return f, true
@@ -432,8 +455,10 @@ func bucketByQueryKey(resp *prometheus.QueryResponse) map[queryKey]float64 {
 // and sorts by time share (seconds of DB time spent per second) descending —
 // the same "where is the time going" ranking appo11y's operations view uses,
 // applied to SQL statements instead of RPC operations. limit caps the
-// returned rows to the busiest N; 0 means unlimited.
-func mergeTopQueries(calls, seconds, rows map[queryKey]float64, limit int) []TopQuery {
+// returned rows to the busiest N; 0 means unlimited. The second return value
+// reports whether rows were dropped by the cap, so callers can hint at it
+// (mirroring instances list's --limit truncation hint).
+func mergeTopQueries(calls, seconds, rows map[queryKey]float64, limit int) ([]TopQuery, bool) {
 	keys := make(map[queryKey]struct{}, len(calls)+len(seconds)+len(rows))
 	for k := range calls {
 		keys[k] = struct{}{}
@@ -477,8 +502,10 @@ func mergeTopQueries(calls, seconds, rows map[queryKey]float64, limit int) []Top
 		}
 		return out[i].Datname < out[j].Datname
 	})
+	truncated := false
 	if limit > 0 && len(out) > limit {
 		out = out[:limit]
+		truncated = true
 	}
-	return out
+	return out, truncated
 }

--- a/internal/providers/dbo11y/instances/query_test.go
+++ b/internal/providers/dbo11y/instances/query_test.go
@@ -1,0 +1,231 @@
+package instances //nolint:testpackage // Tests cover unexported builders and parsers.
+
+import (
+	"testing"
+
+	"github.com/grafana/gcx/internal/query/prometheus"
+)
+
+func TestBuildConnectionInfoQuery(t *testing.T) {
+	got, err := buildConnectionInfoQuery(nil)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	want := `database_observability_connection_info`
+	if got != want {
+		t.Errorf("got %q\nwant %q", got, want)
+	}
+
+	got, err = buildConnectionInfoQuery([]Matcher{{Label: "service_name", Op: "=", Value: "quickpizza-db"}})
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	want = `database_observability_connection_info{service_name="quickpizza-db"}`
+	if got != want {
+		t.Errorf("got %q\nwant %q", got, want)
+	}
+}
+
+func TestBuildConnectionsByStateQuery(t *testing.T) {
+	got, err := buildConnectionsByStateQuery("quickpizza-db", nil)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	want := `sum by (state) (pg_stat_activity_count{service_name="quickpizza-db"})`
+	if got != want {
+		t.Errorf("got %q\nwant %q", got, want)
+	}
+}
+
+func TestBuildWaitEventsQuery(t *testing.T) {
+	got, err := buildWaitEventsQuery("quickpizza-db", nil)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	want := `sum by (wait_event_type, wait_event) (pg_stat_activity_count{service_name="quickpizza-db",wait_event!=""})`
+	if got != want {
+		t.Errorf("got %q\nwant %q", got, want)
+	}
+}
+
+func TestBuildLongestTxQuery(t *testing.T) {
+	got, err := buildLongestTxQuery("quickpizza-db", nil)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	want := `max(pg_stat_activity_max_tx_duration{service_name="quickpizza-db"})`
+	if got != want {
+		t.Errorf("got %q\nwant %q", got, want)
+	}
+}
+
+func TestBuildTopQueriesRateQuery(t *testing.T) {
+	got, err := buildTopQueriesRateQuery(pgStatStatementsCalls, "quickpizza-db", "5m", nil)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	want := `sum by (queryid, datname) (rate(pg_stat_statements_calls_total{service_name="quickpizza-db"}[5m]))`
+	if got != want {
+		t.Errorf("got %q\nwant %q", got, want)
+	}
+}
+
+func TestBuildTopQueriesRateQuery_RequiresName(t *testing.T) {
+	if _, err := buildTopQueriesRateQuery(pgStatStatementsCalls, "", "5m", nil); err == nil {
+		t.Fatal("expected error for empty instance name")
+	}
+}
+
+func TestParseFilter(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want Matcher
+	}{
+		{`engine=postgres`, Matcher{Label: "engine", Op: "=", Value: "postgres"}},
+		{`engine!=mysql`, Matcher{Label: "engine", Op: "!=", Value: "mysql"}},
+		{`datname=~"pay.*"`, Matcher{Label: "datname", Op: "=~", Value: "pay.*"}},
+	}
+	for _, c := range cases {
+		got, err := parseFilter(c.raw)
+		if err != nil {
+			t.Fatalf("parseFilter(%q) err = %v", c.raw, err)
+		}
+		if got != c.want {
+			t.Errorf("parseFilter(%q) = %+v, want %+v", c.raw, got, c.want)
+		}
+	}
+	if _, err := parseFilter("not-a-filter"); err == nil {
+		t.Fatal("expected error for malformed filter")
+	}
+}
+
+func sampleResponse(samples ...map[string]any) *prometheus.QueryResponse {
+	resp := &prometheus.QueryResponse{}
+	for _, s := range samples {
+		metric, _ := s["metric"].(map[string]string)
+		value, _ := s["value"].([]any)
+		resp.Data.Result = append(resp.Data.Result, prometheus.Sample{Metric: metric, Value: value})
+	}
+	return resp
+}
+
+func TestParseInstancesResponse(t *testing.T) {
+	resp := sampleResponse(map[string]any{
+		"metric": map[string]string{
+			"__name__":               "database_observability_connection_info",
+			"service_name":           "quickpizza-db",
+			"service_namespace":      "quickpizza",
+			"engine":                 "postgres",
+			"engine_version":         "18.1",
+			"deployment_environment": "development",
+			"instance":               "postgres-quickpizza",
+			"db_instance_identifier": "unknown",
+			"provider_name":          "unknown",
+			"provider_account":       "unknown",
+			"provider_region":        "unknown",
+		},
+		"value": []any{float64(1755000000), "1"},
+	})
+
+	items, err := parseInstancesResponse(resp)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("len(items) = %d, want 1", len(items))
+	}
+	got := items[0]
+	if got.Name != "quickpizza-db" || got.Namespace != "quickpizza" || got.Engine != "postgres" || got.EngineVersion != "18.1" {
+		t.Errorf("got %+v", got)
+	}
+	if got.ProviderName != "" || got.InstanceIdentifier != "" || got.ProviderRegion != "" {
+		t.Errorf("expected \"unknown\" provider fields to map to empty string, got %+v", got)
+	}
+}
+
+func TestParseInstancesResponse_SkipsSamplesWithoutServiceName(t *testing.T) {
+	resp := sampleResponse(map[string]any{
+		"metric": map[string]string{"__name__": "database_observability_connection_info"},
+		"value":  []any{float64(1755000000), "1"},
+	})
+	items, err := parseInstancesResponse(resp)
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	if len(items) != 0 {
+		t.Fatalf("len(items) = %d, want 0", len(items))
+	}
+}
+
+func TestParseConnectionsByState(t *testing.T) {
+	resp := sampleResponse(
+		map[string]any{"metric": map[string]string{"state": "active"}, "value": []any{float64(0), "3"}},
+		map[string]any{"metric": map[string]string{"state": "idle"}, "value": []any{float64(0), "12"}},
+	)
+	got := parseConnectionsByState(resp)
+	if len(got) != 2 || got[0].State != "idle" || got[0].Count != 12 {
+		t.Errorf("got %+v", got)
+	}
+}
+
+func TestParseWaitEvents(t *testing.T) {
+	resp := sampleResponse(
+		map[string]any{"metric": map[string]string{"wait_event_type": "Lock", "wait_event": "relation"}, "value": []any{float64(0), "2"}},
+	)
+	got := parseWaitEvents(resp)
+	if len(got) != 1 || got[0].Type != "Lock" || got[0].Event != "relation" || got[0].Count != 2 {
+		t.Errorf("got %+v", got)
+	}
+}
+
+func TestMergeTopQueries(t *testing.T) {
+	calls := map[queryKey]float64{
+		{queryID: "1", datname: "db"}: 10,
+		{queryID: "2", datname: "db"}: 1,
+	}
+	seconds := map[queryKey]float64{
+		{queryID: "1", datname: "db"}: 1,   // 0.1s mean, but low time share
+		{queryID: "2", datname: "db"}: 0.9, // 0.9s mean, high time share despite fewer calls
+	}
+	rows := map[queryKey]float64{
+		{queryID: "1", datname: "db"}: 100,
+	}
+
+	got := mergeTopQueries(calls, seconds, rows, 0)
+	if len(got) != 2 {
+		t.Fatalf("len(got) = %d, want 2", len(got))
+	}
+	// query 2 has higher time share (0.9 > 1.0 is false... recompute: q1 time=1, q2 time=0.9)
+	if got[0].QueryID != "1" {
+		t.Errorf("expected query 1 (time share 1.0) ranked first, got %+v", got)
+	}
+	if !got[0].HasMeanLatency || got[0].MeanLatencySeconds != 0.1 {
+		t.Errorf("expected mean latency 0.1s for query 1, got %+v", got[0])
+	}
+	if !got[0].HasRowsPerCall || got[0].RowsPerCall != 10 {
+		t.Errorf("expected 10 rows/call for query 1, got %+v", got[0])
+	}
+	if got[1].HasRowsPerCall {
+		t.Errorf("query 2 has no rows sample, expected HasRowsPerCall=false, got %+v", got[1])
+	}
+}
+
+func TestMergeTopQueries_Limit(t *testing.T) {
+	calls := map[queryKey]float64{
+		{queryID: "1"}: 1,
+		{queryID: "2"}: 1,
+		{queryID: "3"}: 1,
+	}
+	seconds := map[queryKey]float64{
+		{queryID: "1"}: 3,
+		{queryID: "2"}: 2,
+		{queryID: "3"}: 1,
+	}
+	got := mergeTopQueries(calls, seconds, nil, 2)
+	if len(got) != 2 {
+		t.Fatalf("len(got) = %d, want 2", len(got))
+	}
+	if got[0].QueryID != "1" || got[1].QueryID != "2" {
+		t.Errorf("expected top-2 by time share [1,2], got %+v", got)
+	}
+}

--- a/internal/providers/dbo11y/instances/query_test.go
+++ b/internal/providers/dbo11y/instances/query_test.go
@@ -60,7 +60,7 @@ func TestBuildLongestTxQuery(t *testing.T) {
 }
 
 func TestBuildTopQueriesRateQuery(t *testing.T) {
-	got, err := buildTopQueriesRateQuery(pgStatStatementsCalls, "quickpizza-db", "5m", nil)
+	got, err := buildTopQueriesRateQuery(pgStatStatementsCalls, "quickpizza-db", "5m", nil, "queryid", "datname")
 	if err != nil {
 		t.Fatalf("err = %v", err)
 	}
@@ -70,9 +70,68 @@ func TestBuildTopQueriesRateQuery(t *testing.T) {
 	}
 }
 
+func TestBuildTopQueriesRateQuery_MySQLLabels(t *testing.T) {
+	got, err := buildTopQueriesRateQuery(mysqlStatementsCalls, "prod-mysql", "5m", nil, "digest", "schema")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	want := `sum by (digest, schema) (rate(mysql_perf_schema_events_statements_total{service_name="prod-mysql"}[5m]))`
+	if got != want {
+		t.Errorf("got %q\nwant %q", got, want)
+	}
+}
+
 func TestBuildTopQueriesRateQuery_RequiresName(t *testing.T) {
-	if _, err := buildTopQueriesRateQuery(pgStatStatementsCalls, "", "5m", nil); err == nil {
+	if _, err := buildTopQueriesRateQuery(pgStatStatementsCalls, "", "5m", nil, "queryid", "datname"); err == nil {
 		t.Fatal("expected error for empty instance name")
+	}
+}
+
+func TestMetricsForEngine(t *testing.T) {
+	pg := metricsForEngine("postgres")
+	if pg.statementsCalls != pgStatStatementsCalls || pg.queryIDLabel != "queryid" || pg.datnameLabel != "datname" {
+		t.Errorf("postgres metrics = %+v", pg)
+	}
+	if pg.activityMetric == "" || pg.maxTxMetric == "" || pg.scrapeErrorMetric == "" {
+		t.Errorf("expected postgres to have activity/maxTx/scrapeError metrics, got %+v", pg)
+	}
+	if pg.connectedMetric != "" {
+		t.Errorf("expected postgres to have no separate connected-gauge metric, got %+v", pg)
+	}
+
+	mysql := metricsForEngine("mysql")
+	if mysql.statementsCalls != mysqlStatementsCalls || mysql.queryIDLabel != "digest" || mysql.datnameLabel != "schema" {
+		t.Errorf("mysql metrics = %+v", mysql)
+	}
+	if mysql.connectedMetric == "" {
+		t.Errorf("expected mysql to have a connected-gauge metric, got %+v", mysql)
+	}
+	if mysql.activityMetric != "" || mysql.maxTxMetric != "" || mysql.scrapeErrorMetric != "" || mysql.scrapeDurationMetric != "" {
+		t.Errorf("expected mysql to have no activity/maxTx/scrapeError/scrapeDuration metrics (unconfirmed), got %+v", mysql)
+	}
+
+	// Case-insensitive and unknown-engine fallback: anything other than
+	// "mysql" (including empty, when metadata lookup finds nothing) falls
+	// back to Postgres, matching this provider's original behavior.
+	if got := metricsForEngine("MySQL"); got.queryIDLabel != "digest" {
+		t.Errorf("expected case-insensitive match, got %+v", got)
+	}
+	if got := metricsForEngine(""); got.queryIDLabel != "queryid" {
+		t.Errorf("expected empty engine to fall back to postgres, got %+v", got)
+	}
+	if got := metricsForEngine("cockroachdb"); got.queryIDLabel != "queryid" {
+		t.Errorf("expected unknown engine to fall back to postgres, got %+v", got)
+	}
+}
+
+func TestBuildScrapeUpQuery(t *testing.T) {
+	got, err := buildScrapeUpQuery("quickpizza-db")
+	if err != nil {
+		t.Fatalf("err = %v", err)
+	}
+	want := `up{service_name="quickpizza-db",job="integrations/db-o11y"}`
+	if got != want {
+		t.Errorf("got %q\nwant %q", got, want)
 	}
 }
 

--- a/internal/providers/dbo11y/instances/query_test.go
+++ b/internal/providers/dbo11y/instances/query_test.go
@@ -141,6 +141,11 @@ func TestParseInstancesResponse(t *testing.T) {
 	if got.ProviderName != "" || got.InstanceIdentifier != "" || got.ProviderRegion != "" {
 		t.Errorf("expected \"unknown\" provider fields to map to empty string, got %+v", got)
 	}
+	for _, promotedKey := range []string{"engine", "engine_version", "deployment_environment", "instance", "db_instance_identifier", "provider_name", "provider_account", "provider_region", "service_namespace"} {
+		if _, dup := got.Labels[promotedKey]; dup {
+			t.Errorf("expected label %q to be promoted to a typed field, not duplicated in Labels: %+v", promotedKey, got.Labels)
+		}
+	}
 }
 
 func TestParseInstancesResponse_SkipsSamplesWithoutServiceName(t *testing.T) {
@@ -154,6 +159,19 @@ func TestParseInstancesResponse_SkipsSamplesWithoutServiceName(t *testing.T) {
 	}
 	if len(items) != 0 {
 		t.Fatalf("len(items) = %d, want 0", len(items))
+	}
+}
+
+func TestSampleScalar_RejectsNaNAndInf(t *testing.T) {
+	// postgres_exporter maps SQL NULL to NaN (e.g. pg_stat_activity_max_tx_duration
+	// with no open transaction), which must read as "no data", not a real 0/NaN
+	// value — a NaN reaching the JSON encoder fails the whole command.
+	cases := []string{"NaN", "+Inf", "-Inf"}
+	for _, v := range cases {
+		sample := prometheus.Sample{Value: []any{float64(0), v}}
+		if _, ok := sampleScalar(sample); ok {
+			t.Errorf("sampleScalar(%q) = ok, want !ok", v)
+		}
 	}
 }
 
@@ -191,7 +209,10 @@ func TestMergeTopQueries(t *testing.T) {
 		{queryID: "1", datname: "db"}: 100,
 	}
 
-	got := mergeTopQueries(calls, seconds, rows, 0)
+	got, truncated := mergeTopQueries(calls, seconds, rows, 0)
+	if truncated {
+		t.Error("expected truncated = false when limit is 0 (unlimited)")
+	}
 	if len(got) != 2 {
 		t.Fatalf("len(got) = %d, want 2", len(got))
 	}
@@ -221,7 +242,10 @@ func TestMergeTopQueries_Limit(t *testing.T) {
 		{queryID: "2"}: 2,
 		{queryID: "3"}: 1,
 	}
-	got := mergeTopQueries(calls, seconds, nil, 2)
+	got, truncated := mergeTopQueries(calls, seconds, nil, 2)
+	if !truncated {
+		t.Error("expected truncated = true when 3 rows exceed limit 2")
+	}
 	if len(got) != 2 {
 		t.Fatalf("len(got) = %d, want 2", len(got))
 	}

--- a/internal/providers/dbo11y/provider.go
+++ b/internal/providers/dbo11y/provider.go
@@ -1,0 +1,61 @@
+// Package dbo11y implements the `gcx dbo11y` provider, exposing Grafana
+// Database Observability data (postgres_exporter + pg_stat_statements metrics
+// collected via the `database_observability.postgres` Alloy component /
+// `integrations/db-o11y` job convention) as CLI commands.
+package dbo11y
+
+import (
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/providers/dbo11y/instances"
+	"github.com/grafana/gcx/internal/resources/adapter"
+	"github.com/spf13/cobra"
+)
+
+func init() { //nolint:gochecknoinits // Self-registration pattern (like database/sql drivers).
+	providers.Register(&DBO11yProvider{})
+}
+
+// DBO11yProvider manages Grafana Database Observability resources.
+type DBO11yProvider struct{}
+
+// Name returns the unique identifier for this provider.
+func (p *DBO11yProvider) Name() string { return "dbo11y" }
+
+// ShortDesc returns a one-line description of the provider.
+func (p *DBO11yProvider) ShortDesc() string {
+	return "Inspect Grafana Database Observability instances and query performance"
+}
+
+// ConfigKeys returns the configuration keys used by this provider.
+// Database Observability uses the standard Grafana SA token; no additional keys are required.
+func (p *DBO11yProvider) ConfigKeys() []providers.ConfigKey { return nil }
+
+// Validate checks provider configuration.
+// Database Observability requires no provider-specific configuration.
+func (p *DBO11yProvider) Validate(_ map[string]string) error { return nil }
+
+// Commands returns the Cobra commands contributed by this provider.
+func (p *DBO11yProvider) Commands() []*cobra.Command {
+	loader := &providers.ConfigLoader{}
+
+	cmd := &cobra.Command{
+		Use:   "dbo11y",
+		Short: p.ShortDesc(),
+		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			if root := cmd.Root(); root.PersistentPreRun != nil {
+				root.PersistentPreRun(cmd, args)
+			}
+		},
+	}
+
+	// Bind config flags on the parent — all subcommands inherit these.
+	loader.BindFlags(cmd.PersistentFlags())
+
+	cmd.AddCommand(instances.Commands(loader))
+	return []*cobra.Command{cmd}
+}
+
+// TypedRegistrations returns adapter registrations for Database Observability
+// resource types. Instances are a query/discovery result derived from live
+// telemetry, not a CRUD resource, so there is nothing to register.
+func (p *DBO11yProvider) TypedRegistrations() []adapter.Registration { return nil }


### PR DESCRIPTION
## Summary

- Adds a new `dbo11y` provider mirroring the `appo11y` provider pattern (self-registering, `internal/providers/dbo11y`).
- `gcx dbo11y instances list` — discovers database instances from the `database_observability_connection_info` inventory metric (emitted by the `database_observability.postgres` Alloy component, `job="integrations/db-o11y"`).
- `gcx dbo11y instances get <name>` — per-instance snapshot: `pg_up`/scrape health, connection counts by state, active wait events (`wait_event_type`/`wait_event`), longest running transaction, and top queries by time share from `pg_stat_statements` over `--window` (default 5m).

## Scope note

Grafana's Database Observability product also surfaces query samples, explain plans, and schema — those are log-backed (Loki) in the real product and there was no live log data on any registered stack to verify against in this session, so they're left out of this PR. Metrics-backed views (inventory, health, connections, wait events, query-performance-by-time-share) are covered here since they could be verified end-to-end against real telemetry.

This PR is larger than the repo's usual 500-line target because list/get share a single `query.go` of PromQL builders/parsers — splitting them would have meant shipping `list` alone first (a materially incomplete provider) or duplicating the query-builder file across two PRs.

## Verification against real data

There is no working "DB O11y" tool in `grafana-assistant-app` to port from — investigated via research agent, confirmed only page-context recognition and a `dbo11yAppView` KG allowlist entry exist there. The closest real analog (Cloud Provider Observability) confirmed the general pattern: query the stack's own Prometheus/Mimir datasource directly, no dedicated backend API.

Using the registered `appo11y` gcx context, confirmed `grafana-dbo11y-app` is installed and found live-shaped telemetry (a stopped `quickpizza-db` postgres demo, job `integrations/db-o11y`) via `gcx metrics series`/`gcx metrics labels`. Verified every PromQL expression this provider builds returns correctly-shaped real data at the demo's last-active timestamp (`2026-07-15T00:00:00Z`):

- `database_observability_connection_info` → real engine/version/provider labels
- `pg_up`, `pg_exporter_last_scrape_error/duration_seconds` → real health signal
- `sum by (state) (pg_stat_activity_count{...})` → real connection-state breakdown
- `sum by (wait_event_type, wait_event) (pg_stat_activity_count{...,wait_event!=""})` → real wait-event breakdown (`Client`/`ClientRead`)
- `max(pg_stat_activity_max_tx_duration{...})` → real scalar
- `sum by (queryid, datname) (rate(pg_stat_statements_{calls,seconds,rows}_total{...}[5m]))` → real per-query rows

Also added unit tests (`instances/query_test.go`) pinning the exact PromQL string each builder produces, plus parser tests using the real label shapes observed above.

## Test plan

- [x] `go build ./cmd/gcx/`
- [x] `go test ./...` (full suite, `GCX_AGENT_MODE=false`)
- [x] `mise run lint`
- [x] `GCX_AGENT_MODE=false mise run reference` (new CLI reference pages generated, no drift elsewhere)
- [x] `gcx providers list` shows `dbo11y`
- [x] `gcx dbo11y instances list|get` exercised against the real `appo11y` context (empty at `now` since the demo db is no longer live; confirmed non-empty and correctly parsed at the historical timestamp above)