### PR TITLE
fix(irm): make alert-groups list --limit 0 return every alert group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixes
 
+- irm: `gcx irm oncall alert-groups list --limit 0` returns every matching alert group instead of stopping at 1000, and `--limit N` above 1000 is honored (#1157).
 - instrumentation: app and service writes (`clusters apps configure`/`remove`, `services include`/`exclude`/`clear`) no longer fail with `otlp_url is required`.
 
 ## v1.1.0 (2026-08-14)

--- a/docs/design/output.md
+++ b/docs/design/output.md
@@ -342,11 +342,15 @@ Maximum number of <subject> to return. 0 means all results are returned
 ```
 
 **Capped-source exception:** commands whose fetch is bounded by a client-side
-safety cap (e.g. `irm oncall alert-groups list`, capped at 1000) must NOT use
-the binder — "0 means all" would be dishonest there. They keep a bespoke flag
-description that discloses the cap, and disclose the cap at runtime via
-`ListMeta.Cap` plus the cap-variant hint (below). `--limit 0` on a capped
-source means "as much as the cap allows", and the output must say so.
+safety cap must NOT use the binder — "0 means all" would be dishonest there.
+They keep a bespoke flag description that discloses the cap, and disclose the
+cap at runtime via `ListMeta.Cap` plus the cap-variant hint (below).
+`--limit 0` on a capped source means "as much as the cap allows", and the
+output must say so. No command currently takes this exception: the last one,
+`irm oncall alert-groups list`, dropped its 1000-item cap in favour of a real
+cursor drain (grafana/gcx#1157). Prefer draining — a cap that a caller cannot
+raise makes the complete set unreachable, which is the defect that issue
+reported.
 
 The binder is deliberately minimal: commands still pass the limit to their
 clients for server-side pushdown where the API supports it.
@@ -402,10 +406,12 @@ PR988 defect where `--limit 0` silently returned a hard-capped page as if it
 were complete. `serverHasMore` must also be true when the final page
 **overshot** the bound and in-hand items were trimmed, even without a next
 cursor — dropped items are truncation evidence. In that drained-overshoot
-case the total was genuinely observed, and the command may attach it to the
-constructed meta when honest (always on a cap-bounded page; otherwise only
-when `--limit 0` can really retrieve it) — observed, never guessed
-(`irm oncall alert-groups list` is the reference implementation).
+case the total was genuinely observed and the command attaches it to the
+constructed meta — observed, never guessed
+(`irm oncall alert-groups list` is the reference implementation). On a capped
+source the total may only be attached when it is honest to do so: always on a
+cap-bounded page (which carries no continuation), otherwise only when
+`--limit 0` can really retrieve it.
 
 The cap-recording rule fires at `limit >= safetyCap`, including
 `limit == safetyCap` exactly: a doubled `--limit` continuation could never
@@ -472,9 +478,9 @@ research doc's remaining-migration section).
 - `cmd/gcx/datasources/list.go` — cheaply complete source, binder,
   default `--limit 0`, known total.
 - `internal/providers/irm/oncall_commands_extra.go` (alert-groups list) —
-  paginated source, both server-reported (`PagedListMeta` with safety cap)
-  and over-fetch-by-one (`TruncatePagedList`, alternate-implementation
-  fallback path) variants.
+  paginated source, both server-reported (`PagedListMeta`, no safety cap:
+  `--limit 0` drains every `next` cursor) and over-fetch-by-one
+  (`TruncatePagedList`, alternate-implementation fallback path) variants.
 
 `alert rules list` is deliberately not migrated yet: its JSON/YAML output is
 a bare array (no envelope to carry `list_meta`) and its `--limit` counts

--- a/docs/reference/cli/gcx_irm_oncall_alert-groups_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_alert-groups_list.md
@@ -22,6 +22,10 @@ interchangeable with --integration: one integration routes to several chains.
 timestamp, or a relative expression like now-30d. --max-age and --from/--to cannot
 be combined.
 
+--limit 0 returns every matching alert group, walking the endpoint's pages until
+they are exhausted. Over a wide window on a busy stack that is many sequential
+requests, so narrow the window or the filters when a partial answer will do.
+
 ```
 gcx irm oncall alert-groups list [flags]
 ```
@@ -58,7 +62,7 @@ gcx irm oncall alert-groups list [flags]
       --integration strings        Filter by integration PK (repeatable, comma-separated)
       --jq string                  jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string                Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-      --limit int                  Maximum number of alert groups to return (0 for all, capped by an internal safety limit) (default 50)
+      --limit int                  Maximum number of alert groups to return. 0 means all results are returned (default 50)
       --max-age string             Exclude groups older than this duration (e.g. 1h, 24h, 7d)
       --mine                       Limit to alert groups for the authenticated user
   -o, --output string              Output format. One of: agents, json, table, wide, yaml (default "table")

--- a/docs/research/2026-07-17-global-limit-investigation.md
+++ b/docs/research/2026-07-17-global-limit-investigation.md
@@ -63,6 +63,14 @@ must never be captured by a uniform contract:
 runaway cap (`alertGroupListHardCap`, `oncall_commands_extra.go`). A global
 "0 means all results are returned" promise would be a lie there.
 
+> **Superseded (grafana/gcx#1157).** The cap was removed: `--limit 0` now
+> follows the endpoint's `next` cursors to exhaustion and `--limit N` is
+> honored above 1000, so the command uses the shared binder and the uniform
+> "0 means all" wording. It was the only capped source, so nothing in the
+> repo takes the capped-source exception today. The finding still stands as
+> a design point — the practical lesson is that a cap a caller cannot raise
+> makes the complete set unreachable, which is worse than a slow drain.
+
 ### 2.4 Chosen architecture
 
 An **opt-in shared binder + uniform contract**, migrated incrementally:
@@ -181,6 +189,16 @@ verified against HEAD and fixed here:
   truncated with cap"), `TestAlertGroupList_RichPath_LimitZeroHitsSafetyCap`,
   `TestAlertGroupList_LegacyPath_LimitZeroDrainsFully`,
   `TestAlertGroupList_LegacyPath_OverFetchDetectsTruncation`.
+- **Follow-up (grafana/gcx#1157):** disclosing the cap was necessary but not
+  sufficient — the cap-variant hint offers no continuation, so a caller had
+  no way to reach the rest. The cap is gone; the rich path drains at
+  `--limit 0` and honors limits above 1000, so a "give me all" page carries
+  no `list_meta` because it genuinely is complete.
+  `TestAlertGroupList_RichPath_LimitZeroHitsSafetyCap` is replaced by
+  `TestAlertGroupList_RichPath_LimitZeroIsComplete` and the drain regressions
+  in `oncall_alertgroup_listraw_test.go`. The shared-helper proofs in
+  `TestPagedListMeta` are unchanged — the capped-source machinery stays in
+  `internal/output` for future capped sources, it simply has no caller.
 
 ## 5. Behavior changes vs pre-contract HEAD
 
@@ -202,6 +220,12 @@ Non-changes (parity kept): `alert-groups list` keeps its bespoke flag wording
 (discloses the cap), its default limit 50, the 1000 hard cap itself, and the
 note/filter/nav-hint ordering; `alert rules list` keeps default 50 and its
 bare-array JSON shape.
+
+> **Later change (grafana/gcx#1157).** The two `alert-groups list` rows above
+> that concern the cap — the bespoke capped-source `--limit` wording and the
+> `cap:1000` + "safety cap" reporting — no longer describe HEAD. The hard cap
+> was removed, the command adopted the shared binder, and `--limit 0` drains
+> every page. Everything else in the table stands.
 
 ## 6. Remaining migration (~40 list commands)
 
@@ -234,11 +258,14 @@ Needs per-command decisions:
   update).
 - **`irm oncall alert-groups` bulk-by-filter actions** — `resolveBulkTargets`
   (`internal/providers/irm/oncall_actions.go`) enumerates targets via
-  `ListAlertGroupsRaw(ctx, filters, 0)` and discards the returned page info,
-  so a sweep whose filter matches more than the 1000-item hard cap silently
-  operates on the first 1000 groups. Needs a per-command decision — a bulk
+  `ListAlertGroupsRaw(ctx, filters, alertGroupBulkTargetCap)` and discards the
+  returned page info, so a sweep whose filter matches more than 1000 groups
+  silently operates on the first 1000. Needs a per-command decision — a bulk
   mutation probably ought to **refuse** on a capped enumeration rather than
-  warn.
+  warn. Still open after grafana/gcx#1157: the read path's cap is gone, but
+  a mutation sweep has no user-supplied limit to bound it, so it keeps a
+  1000-item bound of its own (`alertGroupBulkTargetCap`, same value and same
+  behaviour as the removed read-path cap).
 
 ## 7. Open questions
 
@@ -260,7 +287,8 @@ Needs per-command decisions:
 3. **Capped-source binder variant** — a `BindListLimitCapped(..., cap)` with
    wording like "0 means as many as the safety cap (N) allows" would let
    capped sources join the binder; deferred until a second capped source
-   appears.
+   appears. Moot for now: grafana/gcx#1157 removed the only capped source, so
+   there are **zero**, and `alert-groups list` uses the plain binder.
 4. **`table` output and `list_meta`** — tables ignore the field by design
    (the stderr hint covers humans). If `wide` output ever needs a footer row
    ("… 50 of 219 shown"), that is a codec concern, not a contract change.
@@ -272,10 +300,11 @@ Needs per-command decisions:
 6. **Explicit source shape vs Total-presence inference** —
    `listContinueCommand` infers "the full set is retrievable via
    `--limit 0`" from the mere presence of `Total`, which forces capped
-   sources to withhold an honestly-observed total above the cap (see the
-   guard in `alert-groups list`). Making the cap or source shape an explicit
-   input to `AttachListMeta` would let observed totals always ride;
-   deferred until a second capped source needs it.
+   sources to withhold an honestly-observed total above the cap. Making the
+   cap or source shape an explicit input to `AttachListMeta` would let
+   observed totals always ride; deferred until a second capped source needs
+   it. The `alert-groups list` guard that motivated this is gone with the cap
+   (grafana/gcx#1157) — it now always attaches an observed total.
 
 ## 8. Validation record (2026-07-17, feasibility branch)
 

--- a/internal/providers/irm/oncall_actions.go
+++ b/internal/providers/irm/oncall_actions.go
@@ -800,6 +800,16 @@ func resolveSingleTarget(ctx context.Context, client OnCallAPI, id string) (ackn
 	return acknowledgeTarget{ID: id, State: alertGroupStatusString(ag)}, nil
 }
 
+// alertGroupBulkTargetCap bounds bulk-by-filter target enumeration. The read
+// path (`alert-groups list`) has no client-side ceiling — `--limit 0` there
+// means all (grafana/gcx#1157) — but a mutation sweep has no user-supplied
+// limit to bound it, so it keeps one of its own rather than acking or
+// resolving an unbounded set. A filter matching more than this still operates
+// silently on the first alertGroupBulkTargetCap targets; whether that should
+// warn or refuse is tracked in
+// docs/research/2026-07-17-global-limit-investigation.md § 6.
+const alertGroupBulkTargetCap = 1000
+
 // resolveBulkTargets returns the deduplicated, sorted list of targets to
 // operate on (bulk-by-filter path), plus their current state.
 func resolveBulkTargets(ctx context.Context, client OnCallAPI, opts *alertGroupActionVerbOpts) ([]acknowledgeTarget, error) {
@@ -813,9 +823,9 @@ func resolveBulkTargets(ctx context.Context, client OnCallAPI, opts *alertGroupA
 		return nil, errors.New("bulk-by-filter requires the OAuth plugin proxy; SA-token mode does not support rich list operations")
 	}
 
-	// Bulk action targets aren't UI-truncated — pass limit=0 so the existing
-	// hardCap is the only bound. The hint affordance is list-only.
-	rawItems, _, err := reader.ListAlertGroupsRaw(ctx, filters, 0)
+	// Bulk action targets aren't UI-truncated — pass the bulk cap as the
+	// limit so the sweep stays bounded. The hint affordance is list-only.
+	rawItems, _, err := reader.ListAlertGroupsRaw(ctx, filters, alertGroupBulkTargetCap)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/providers/irm/oncall_alertgroup_list_test.go
+++ b/internal/providers/irm/oncall_alertgroup_list_test.go
@@ -124,8 +124,8 @@ func TestAlertGroupList_RichPath_UserLimitTruncates(t *testing.T) {
 		t.Errorf("list_meta.cap = %d, want 0 (the user's limit, not the safety cap, was the bound)", meta.Cap)
 	}
 	// The continuation derives from argv (filters would survive) and doubles
-	// the limit — it never promises --limit 0 retrieves everything, because
-	// the safety cap exists upstream.
+	// the limit — the total is unknown here (the source was not drained), so
+	// a doubled limit is the honest next step rather than --limit 0.
 	if meta.Continue != "gcx irm oncall alert-groups list --limit 4" {
 		t.Errorf("list_meta.continue = %q, want doubled-limit continuation", meta.Continue)
 	}
@@ -135,33 +135,29 @@ func TestAlertGroupList_RichPath_UserLimitTruncates(t *testing.T) {
 	}
 }
 
-// TestAlertGroupList_RichPath_LimitZeroHitsSafetyCap locks the PR988-review
-// defect (d) fix: `--limit 0` bounded by the runaway cap must report a
-// truncated page with the cap disclosed — never a silent 1000-item "complete"
-// set — and must NOT suggest --limit 0 (it cannot beat the cap).
-func TestAlertGroupList_RichPath_LimitZeroHitsSafetyCap(t *testing.T) {
-	fake := &fakeRichListAPI{items: rawAlertGroups(3), page: alertGroupPageInfo{HasMore: true}}
+// TestAlertGroupList_RichPath_LimitZeroIsComplete locks the grafana/gcx#1157
+// fix: `--limit 0` drains every page, so the fetch reports no more pages and
+// the output carries NO list_meta — which per the contract means "this IS the
+// complete result set". The old client-side safety cap is gone, so no
+// cap-variant hint may appear either.
+func TestAlertGroupList_RichPath_LimitZeroIsComplete(t *testing.T) {
+	fake := &fakeRichListAPI{items: rawAlertGroups(3), page: alertGroupPageInfo{}}
 	payload, stderr := runAlertGroupList(t, fake, "--limit", "0")
 
 	if fake.gotLimit != 0 {
 		t.Errorf("wire limit = %d, want 0", fake.gotLimit)
 	}
-	meta := payload.ListMeta
-	if meta == nil || !meta.Truncated {
-		t.Fatalf("list_meta = %+v, want truncated (hard-capped page is NOT the complete set)", meta)
+	if len(payload.Items) != 3 {
+		t.Fatalf("items = %d, want 3", len(payload.Items))
 	}
-	if meta.Cap != alertGroupListHardCap {
-		t.Errorf("list_meta.cap = %d, want %d (the safety cap was the bound)", meta.Cap, alertGroupListHardCap)
+	if payload.ListMeta != nil {
+		t.Errorf("list_meta = %+v, want absent (--limit 0 drains, so the page IS the complete set)", payload.ListMeta)
 	}
-	if meta.Continue != "" {
-		t.Errorf("list_meta.continue = %q, want empty (no --limit can beat the cap)", meta.Continue)
+	if strings.Contains(stderr, "safety cap") {
+		t.Errorf("stderr carries a cap-variant hint but the cap is gone:\n%s", stderr)
 	}
-	want := "hint: showing first 3 (safety cap). Refine filters to narrow the result set"
-	if !strings.Contains(stderr, want) {
-		t.Errorf("stderr missing cap-variant hint %q:\n%s", want, stderr)
-	}
-	if strings.Contains(stderr, "--limit 0") {
-		t.Errorf("cap-variant hint must not suggest --limit 0:\n%s", stderr)
+	if strings.Contains(stderr, "showing first") {
+		t.Errorf("unexpected truncation hint on stderr:\n%s", stderr)
 	}
 }
 

--- a/internal/providers/irm/oncall_alertgroup_listraw_test.go
+++ b/internal/providers/irm/oncall_alertgroup_listraw_test.go
@@ -334,56 +334,147 @@ func TestAlertGroupList_MaxAgeAndFromAreMutuallyExclusive(t *testing.T) {
 	}
 }
 
-// TestAlertGroupList_RichPath_UnretrievableTotalNotAttached pins the honesty
-// guard on the drained-overshoot total: when the observed total exceeds the
-// hard cap and the cap was not the bound, attaching it would derive a
-// "--limit 0 retrieves everything" continuation that the cap makes a lie —
-// so the total stays unknown and the doubled-limit continuation is used.
-func TestAlertGroupList_RichPath_UnretrievableTotalNotAttached(t *testing.T) {
-	total := alertGroupListHardCap + 500
+// TestAlertGroupList_RichPath_LargeObservedTotalAttached: with the 1000-item
+// safety cap gone (grafana/gcx#1157), a drained-overshoot total is always
+// honest to attach no matter how large — `--limit 0` genuinely retrieves it,
+// so the continuation says exactly that.
+func TestAlertGroupList_RichPath_LargeObservedTotalAttached(t *testing.T) {
+	total := 1500
 	fake := &fakeRichListAPI{
 		items: rawAlertGroups(2),
 		page:  alertGroupPageInfo{HasMore: true, Total: &total},
 	}
-	payload, _ := runAlertGroupList(t, fake, "--limit", "950")
+	payload, stderr := runAlertGroupList(t, fake, "--limit", "950")
 
 	meta := payload.ListMeta
 	if meta == nil || !meta.Truncated {
 		t.Fatalf("list_meta = %+v, want truncated", meta)
 	}
-	if meta.Total != nil {
-		t.Errorf("list_meta.total = %d, want absent (total above the hard cap is not retrievable)", *meta.Total)
-	}
-	if meta.Continue != "gcx irm oncall alert-groups list --limit 4" {
-		t.Errorf("list_meta.continue = %q, want doubled-limit continuation", meta.Continue)
-	}
-}
-
-// TestAlertGroupList_RichPath_CapBoundedDrainedTotalAttached: a cap-bounded
-// page carries no continuation, so an observed total is always honest to
-// attach — the agent learns both the ceiling and the real set size.
-func TestAlertGroupList_RichPath_CapBoundedDrainedTotalAttached(t *testing.T) {
-	total := alertGroupListHardCap + 5
-	fake := &fakeRichListAPI{
-		items: rawAlertGroups(3),
-		page:  alertGroupPageInfo{HasMore: true, Total: &total},
-	}
-	payload, stderr := runAlertGroupList(t, fake, "--limit", "0")
-
-	meta := payload.ListMeta
-	if meta == nil || !meta.Truncated {
-		t.Fatalf("list_meta = %+v, want truncated", meta)
-	}
-	if meta.Cap != alertGroupListHardCap {
-		t.Errorf("list_meta.cap = %d, want %d", meta.Cap, alertGroupListHardCap)
+	if meta.Cap != 0 {
+		t.Errorf("list_meta.cap = %d, want 0 (this source has no client-side cap)", meta.Cap)
 	}
 	if meta.Total == nil || *meta.Total != total {
 		t.Fatalf("list_meta.total = %v, want %d (observed on the drained source)", meta.Total, total)
 	}
-	if meta.Continue != "" {
-		t.Errorf("list_meta.continue = %q, want empty (no --limit can beat the cap)", meta.Continue)
+	if meta.Continue != "gcx irm oncall alert-groups list --limit 0" {
+		t.Errorf("list_meta.continue = %q, want --limit 0 (the observed total is retrievable)", meta.Continue)
 	}
-	if !strings.Contains(stderr, "safety cap") {
-		t.Errorf("stderr missing cap-variant hint:\n%s", stderr)
+	if strings.Contains(stderr, "safety cap") {
+		t.Errorf("stderr carries a cap-variant hint but the cap is gone:\n%s", stderr)
+	}
+}
+
+// oldAlertGroupListHardCap is the client-side ceiling this command used to
+// impose on every fetch (grafana/gcx#1157). It is not a production constant
+// any more — the tests below keep it only to prove the ceiling is gone.
+const oldAlertGroupListHardCap = 1000
+
+// alertGroupPagesOf builds `count` items spread across pages of `perPage`,
+// each page pointing at the next.
+func alertGroupPagesOf(count, perPage int) []alertGroupPage {
+	var pages []alertGroupPage
+	for remaining := count; remaining > 0; remaining -= perPage {
+		n := min(remaining, perPage)
+		pages = append(pages, alertGroupPage{items: rawAlertGroups(n), hasNext: remaining > n})
+	}
+	return pages
+}
+
+// TestListAlertGroupsRaw_LimitZeroDrainsPastOldCap is the grafana/gcx#1157
+// regression: limit 0 follows every `next` cursor instead of stopping at the
+// old 1000-item ceiling, and reports the result as complete.
+func TestListAlertGroupsRaw_LimitZeroDrainsPastOldCap(t *testing.T) {
+	const total = oldAlertGroupListHardCap + 200
+	srv, state := newPagedAlertGroupsServer(t, alertGroupPagesOf(total, 100))
+
+	out, info, err := listAlertGroupsRaw(context.Background(), onCallClientFor(srv), alertGroupListFilters{}, 0)
+	if err != nil {
+		t.Fatalf("listAlertGroupsRaw: %v", err)
+	}
+	if len(out) != total {
+		t.Errorf("items = %d, want %d (limit 0 drains every page)", len(out), total)
+	}
+	if info.HasMore {
+		t.Error("HasMore = true, want false (the source was drained)")
+	}
+	if state.requests != total/100 {
+		t.Errorf("requests = %d, want %d (one per page)", state.requests, total/100)
+	}
+}
+
+// TestListAlertGroupsRaw_LimitAboveOldCap: an explicit limit above the old
+// ceiling is honored in full rather than silently cut down to 1000.
+func TestListAlertGroupsRaw_LimitAboveOldCap(t *testing.T) {
+	const limit = oldAlertGroupListHardCap + 200
+	srv, _ := newPagedAlertGroupsServer(t, alertGroupPagesOf(limit+300, 100))
+
+	out, info, err := listAlertGroupsRaw(context.Background(), onCallClientFor(srv), alertGroupListFilters{}, limit)
+	if err != nil {
+		t.Fatalf("listAlertGroupsRaw: %v", err)
+	}
+	if len(out) != limit {
+		t.Errorf("items = %d, want %d (the user's limit is the only bound)", len(out), limit)
+	}
+	if !info.HasMore {
+		t.Error("HasMore = false, want true (more pages remain beyond the limit)")
+	}
+}
+
+// TestListAlertGroupsRaw_NonAdvancingCursor: an unbounded drain trusts the
+// server to advance, so a `next` cursor that points back at the page just
+// fetched must terminate the walk rather than spin forever.
+func TestListAlertGroupsRaw_NonAdvancingCursor(t *testing.T) {
+	var (
+		srv      *httptest.Server
+		requests int
+	)
+	mux := http.NewServeMux()
+	mux.HandleFunc(BasePath+"/alertgroups/", func(w http.ResponseWriter, _ *http.Request) {
+		requests++
+		if requests > 10 {
+			t.Fatal("pagination did not terminate on a non-advancing cursor")
+		}
+		next := srv.URL + "/oncall/api/internal/v1/alertgroups/?page=2"
+		body, err := json.Marshal(map[string]any{"results": rawAlertGroups(2), "next": &next})
+		if err != nil {
+			t.Fatalf("marshal page: %v", err)
+		}
+		_, _ = w.Write(body)
+	})
+	srv = httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+
+	out, _, err := listAlertGroupsRaw(context.Background(), onCallClientFor(srv), alertGroupListFilters{}, 0)
+	if err != nil {
+		t.Fatalf("listAlertGroupsRaw: %v", err)
+	}
+	// Two requests: the initial path, then the cursor once. The third would
+	// repeat the second, so the walk stops with those four items in hand.
+	if requests != 2 {
+		t.Errorf("requests = %d, want 2 (stop once the cursor stops advancing)", requests)
+	}
+	if len(out) != 4 {
+		t.Errorf("items = %d, want 4 (whatever the server handed over before repeating)", len(out))
+	}
+}
+
+// TestAlertGroupList_LimitZeroReturnsEverything is the end-to-end form of the
+// grafana/gcx#1157 report: `--limit 0` over a window holding more than 1000
+// groups returns all of them, with no list_meta and no truncation hint — the
+// contract's signal that the output IS the complete set.
+func TestAlertGroupList_LimitZeroReturnsEverything(t *testing.T) {
+	const total = oldAlertGroupListHardCap + 200
+	srv, _ := newPagedAlertGroupsServer(t, alertGroupPagesOf(total, 100))
+
+	payload, stderr := runAlertGroupList(t, onCallClientFor(srv), "--all", "--max-age", "24h", "--limit", "0")
+
+	if len(payload.Items) != total {
+		t.Errorf("items = %d, want %d", len(payload.Items), total)
+	}
+	if payload.ListMeta != nil {
+		t.Errorf("list_meta = %+v, want absent (the page IS the complete set)", payload.ListMeta)
+	}
+	if strings.Contains(stderr, "showing first") {
+		t.Errorf("unexpected truncation hint on stderr:\n%s", stderr)
 	}
 }

--- a/internal/providers/irm/oncall_commands_extra.go
+++ b/internal/providers/irm/oncall_commands_extra.go
@@ -44,8 +44,8 @@ type alertGroupListOpts struct {
 	MaxAge string
 
 	// Limit caps the number of alert groups returned. Default
-	// alertGroupListDefaultLimit; pass 0 to disable (subject to client-side
-	// hardCap to avoid runaway memory).
+	// alertGroupListDefaultLimit; 0 means all — the fetch follows the
+	// endpoint's `next` cursors to exhaustion.
 	Limit int
 
 	// Filter flags. See ADR 001 § 1 (alert-groups list defaults).
@@ -78,7 +78,7 @@ func (o *alertGroupListOpts) setup(flags *pflag.FlagSet) {
 	// severity, state, ...) is preserved instead of alphabetized.
 	o.IO.RegisterCustomCodec("yaml", format.NewOrderedYAMLCodec())
 	flags.StringVar(&o.MaxAge, "max-age", "", "Exclude groups older than this duration (e.g. 1h, 24h, 7d)")
-	flags.IntVar(&o.Limit, "limit", alertGroupListDefaultLimit, "Maximum number of alert groups to return (0 for all, capped by an internal safety limit)")
+	o.IO.BindListLimit(flags, &o.Limit, "alert groups", alertGroupListDefaultLimit)
 	flags.StringSliceVar(&o.States, "state", nil, "Filter by state (firing|acknowledged|resolved|silenced; repeatable, comma-separated). Default: firing,acknowledged,silenced")
 	flags.StringSliceVar(&o.Teams, "team", nil, "Filter by team PK (repeatable, comma-separated)")
 	flags.StringSliceVar(&o.Integrations, "integration", nil, "Filter by integration PK (repeatable, comma-separated)")
@@ -96,17 +96,14 @@ func (o *alertGroupListOpts) setup(flags *pflag.FlagSet) {
 	flags.BoolVar(&o.IncludeChildGroups, "include-child-groups", false, "Include child groups (drops the is_root filter while keeping the status default)")
 }
 
-// Validate rejects negative --limit values before any config or network work,
-// mirroring the shape of the shared BindListLimit validation
-// (internal/output/format.go) with capped-source wording: this command binds
-// --limit bespoke instead of using the binder because --limit 0 is bounded by
-// a client-side safety cap (alertGroupListHardCap), so neither the flag help
-// nor this error may promise "0 means all results are returned"
-// (docs/design/output.md § 15.1).
+// Validate checks the time-window flags before any config or network work.
+// Negative --limit values are rejected by the shared binder's validation
+// (Options.Validate, internal/output/format.go), which RunE calls immediately
+// after this method — the fetch is no longer bounded by a client-side safety
+// cap, so this command uses the uniform "0 means all results are returned"
+// contract rather than bespoke capped-source wording (docs/design/output.md
+// § 15.1).
 func (o *alertGroupListOpts) Validate() error {
-	if o.Limit < 0 {
-		return fmt.Errorf("invalid --limit %d: must be >= 0 (0 means as many results as the safety cap allows)", o.Limit)
-	}
 	// --max-age and --from/--to both compile into the same started_at range
 	// param, so combining them would be ambiguous.
 	if o.MaxAge != "" && (o.From != "" || o.To != "") {
@@ -345,7 +342,11 @@ interchangeable with --integration: one integration routes to several chains.
 --max-age anchors to now; use --from/--to for a historical started-at window, and
 --resolved-from/--resolved-to for a resolved-at window. They accept RFC3339, a unix
 timestamp, or a relative expression like now-30d. --max-age and --from/--to cannot
-be combined.`
+be combined.
+
+--limit 0 returns every matching alert group, walking the endpoint's pages until
+they are exhausted. Over a wide window on a busy stack that is many sequential
+requests, so narrow the window or the filters when a partial answer will do.`
 
 const alertGroupListExample = `  # List firing, acknowledged, and silenced root groups
   gcx irm oncall alert-groups list
@@ -417,20 +418,17 @@ func newAlertGroupListCommand(loader OnCallConfigLoader) *cobra.Command {
 			}
 
 			// Truncation metadata: pageInfo.HasMore is true whenever the
-			// fetch stopped at the effective bound — the user's --limit or
-			// the runaway safety cap (alertGroupListHardCap) — with
-			// truncation evidence in hand (a next cursor, or a final page
-			// that overshot the bound). PagedListMeta honors it even at
-			// --limit 0 and records the cap when it was the binding ceiling,
-			// so a hard-capped "give me all" page is never reported as the
-			// complete set.
-			meta := cmdio.PagedListMeta(len(envs), opts.Limit, pageInfo.HasMore, alertGroupListHardCap)
+			// fetch stopped at the user's --limit with truncation evidence in
+			// hand (a next cursor, or a final page that overshot the limit).
+			// The source carries no client-side safety cap, so no cap is
+			// passed and --limit 0 always drains — meaning a "give me all"
+			// page reports no metadata at all, which per the contract is the
+			// honest signal that the output IS the complete set.
+			meta := cmdio.PagedListMeta(len(envs), opts.Limit, pageInfo.HasMore, 0)
 			// Drained-overshoot case: pagination ended, so the total was
-			// genuinely observed. Attach it when honest — always for a
-			// cap-bounded page (it carries no continuation), otherwise only
-			// when the full set is actually retrievable via --limit 0 (a
-			// total above the hard cap would make that continuation a lie).
-			if meta != nil && pageInfo.Total != nil && (meta.Cap > 0 || *pageInfo.Total <= alertGroupListHardCap) {
+			// genuinely observed — attach it, and the continuation honestly
+			// becomes --limit 0.
+			if meta != nil && pageInfo.Total != nil {
 				meta.Total = pageInfo.Total
 			}
 			meta = cmdio.AttachListMeta(meta, os.Args)
@@ -462,9 +460,8 @@ func newAlertGroupListCommand(loader OnCallConfigLoader) *cobra.Command {
 			// Contract), emitted only when the metadata says the page is
 			// partial. Replaces the bespoke D2-round-14 doubled-limit hint —
 			// the shared helper suggests the same doubled limit for a
-			// user-bounded page, renders the argv-derived continuation from
-			// AttachListMeta (so filter flags survive), and switches to the
-			// "refine filters" variant when the safety cap was the bound.
+			// user-bounded page and renders the argv-derived continuation
+			// from AttachListMeta (so filter flags survive).
 			cmdio.EmitListTruncationHint(stderr, meta)
 
 			// Filter-summary hint (D2 round 17): silent only when --all is
@@ -788,11 +785,6 @@ func listAlertGroupsLegacy(cmd *cobra.Command, opts *alertGroupListOpts, filters
 	return nil
 }
 
-// alertGroupListHardCap bounds the maximum number of items returned by
-// listAlertGroupsRaw when no caller-supplied limit applies. Prevents runaway
-// memory when --limit 0 is passed and the server has very many groups.
-const alertGroupListHardCap = 1000
-
 // alertGroupListPerPageMax bounds the per-page request size sent to the
 // internal API. Conservative — keeps individual round trips small while still
 // fitting the default limit (50) into a single request.
@@ -801,9 +793,9 @@ const alertGroupListPerPageMax = 100
 // alertGroupPageInfo reports how a paginated alert-group fetch ended.
 type alertGroupPageInfo struct {
 	// HasMore is true when items beyond the returned page exist: the fetch
-	// stopped at the effective bound (the caller's limit or the hard cap)
-	// with the server reporting a next cursor, or the in-hand items of the
-	// final page exceeded the bound and were trimmed.
+	// stopped at the caller's limit with the server reporting a next cursor,
+	// or the in-hand items of the final page exceeded the limit and were
+	// trimmed. Always false for limit == 0, which drains every page.
 	HasMore bool
 	// Total is the observed size of the complete result set. It is set only
 	// when the source was fully drained (pagination ended with no next
@@ -819,18 +811,22 @@ type alertGroupPageInfo struct {
 //
 // limit semantics:
 //   - limit > 0  → fetch up to `limit` items; perpage=min(limit, perPageMax).
-//   - limit == 0 → fetch up to alertGroupListHardCap items; perpage=perPageMax.
+//   - limit == 0 → fetch every page, following `next` cursors to exhaustion.
 //
-// HasMore is true whenever the fetch stopped at the effective bound — the
-// caller-supplied limit or the runaway hard cap — with truncation evidence
-// in hand: the stopping page reported a non-empty `next` cursor, or the
-// in-hand items exceeded the bound (a final overshooting page proves
-// truncation even without a cursor). It stays false only when the server's
-// pagination ends at or before the bound. Nothing is silenced here; each
-// caller decides how to surface the page info. The list command emits
-// list_meta plus stderr hints; resolveBulkTargets (oncall_actions.go)
-// currently discards it, so a hard-capped bulk-by-filter sweep is still
-// silent — tracked for a per-command decision in
+// There is no client-side ceiling: `--limit 0` genuinely means all
+// (grafana/gcx#1157). Callers that need a bound pass one as `limit` —
+// resolveBulkTargets (oncall_actions.go) passes alertGroupBulkTargetCap so a
+// bulk mutation sweep stays bounded.
+//
+// HasMore is true whenever the fetch stopped at the caller's limit with
+// truncation evidence in hand: the stopping page reported a non-empty `next`
+// cursor, or the in-hand items exceeded the limit (a final overshooting page
+// proves truncation even without a cursor). It stays false when the server's
+// pagination ends at or before the limit, and always at limit == 0. Nothing
+// is silenced here; each caller decides how to surface the page info. The
+// list command emits list_meta plus stderr hints; resolveBulkTargets
+// discards it, so a bounded bulk-by-filter sweep is still silent — tracked
+// for a per-command decision in
 // docs/research/2026-07-17-global-limit-investigation.md § 6.
 func listAlertGroupsRaw(ctx context.Context, c *OnCallClient, filters alertGroupListFilters, limit int) ([]json.RawMessage, alertGroupPageInfo, error) {
 	params := url.Values{}
@@ -886,13 +882,6 @@ func listAlertGroupsRaw(ctx context.Context, c *OnCallClient, filters alertGroup
 
 	path := alertGroupsPath + "?" + params.Encode()
 
-	// effectiveCap: the upper bound on `out`. When the user passes --limit 0
-	// we still want a runaway guard, so fall back to alertGroupListHardCap.
-	effectiveCap := alertGroupListHardCap
-	if limit > 0 && limit < effectiveCap {
-		effectiveCap = limit
-	}
-
 	var (
 		out  []json.RawMessage
 		next = path
@@ -923,18 +912,20 @@ func listAlertGroupsRaw(ctx context.Context, c *OnCallClient, filters alertGroup
 		if page.Next != nil {
 			pageNext = *page.Next
 		}
-		if len(out) >= effectiveCap {
+		// limit is the only bound on `out`; limit == 0 is unbounded, so this
+		// block never fires and the walk runs until the cursors are exhausted.
+		if limit > 0 && len(out) >= limit {
 			// Truncation evidence comes from either signal: the stopping page
-			// reported a next cursor, or the final page overshot the bound and
+			// reported a next cursor, or the final page overshot the limit and
 			// in-hand items are about to be dropped. Evaluate BEFORE trimming.
-			info.HasMore = pageNext != "" || len(out) > effectiveCap
-			if pageNext == "" && len(out) > effectiveCap {
+			info.HasMore = pageNext != "" || len(out) > limit
+			if pageNext == "" && len(out) > limit {
 				// Pagination ended naturally, so the source was fully drained
 				// and the total is genuinely observed — not a guess.
 				total := len(out)
 				info.Total = &total
 			}
-			out = out[:effectiveCap]
+			out = out[:limit]
 			break
 		}
 		if pageNext == "" {
@@ -943,6 +934,12 @@ func listAlertGroupsRaw(ctx context.Context, c *OnCallClient, filters alertGroup
 		np, err := ExtractNextPath(pageNext)
 		if err != nil {
 			return nil, alertGroupPageInfo{}, err
+		}
+		// An unbounded drain trusts the server to advance; a cursor that
+		// points back at the page we just fetched would otherwise spin
+		// forever. Stop instead — the items in hand are what the server gave.
+		if np == next {
+			break
 		}
 		next = np
 	}

--- a/internal/providers/irm/oncall_commands_extra_test.go
+++ b/internal/providers/irm/oncall_commands_extra_test.go
@@ -112,46 +112,57 @@ func TestStringifyAlertGroupListFilters(t *testing.T) {
 	}
 }
 
-// TestAlertGroupListOptsValidate covers the negative --limit rejection: it
-// must fire at validation time — before any config or network work — with the
-// capped-source wording (never "0 means all results are returned": --limit 0
-// on this command is bounded by alertGroupListHardCap).
-func TestAlertGroupListOptsValidate(t *testing.T) {
-	t.Parallel()
+// TestAlertGroupListLimitValidation covers the negative --limit rejection. It
+// must fire before any config or network work, and it now carries the uniform
+// binder wording — the fetch is no longer bounded by a client-side safety cap,
+// so "0 means all results are returned" is an honest promise on this command
+// (grafana/gcx#1157). The check lives in the shared Options.Validate, which
+// RunE calls right after the command's own Validate, so this drives the real
+// command rather than the opts method.
+func TestAlertGroupListLimitValidation(t *testing.T) {
 	cases := []struct {
 		name    string
-		limit   int
-		wantErr string // exact error message; empty means Validate must pass
+		limit   string
+		wantErr string // exact error message; empty means the flag is accepted
 	}{
 		{
 			name:    "negative limit rejected",
-			limit:   -1,
-			wantErr: "invalid --limit -1: must be >= 0 (0 means as many results as the safety cap allows)",
+			limit:   "-1",
+			wantErr: "invalid --limit -1: must be >= 0 (0 means all results are returned)",
 		},
 		{
 			name:    "large negative limit rejected",
-			limit:   -50,
-			wantErr: "invalid --limit -50: must be >= 0 (0 means as many results as the safety cap allows)",
+			limit:   "-50",
+			wantErr: "invalid --limit -50: must be >= 0 (0 means all results are returned)",
 		},
-		{name: "zero limit accepted", limit: 0},
-		{name: "default limit accepted", limit: alertGroupListDefaultLimit},
+		{name: "zero limit accepted", limit: "0"},
+		{name: "limit above the retired 1000 hard cap accepted", limit: "5000"},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-			opts := &alertGroupListOpts{Limit: tc.limit}
-			err := opts.Validate()
+			srv, state := newPagedAlertGroupsServer(t, []alertGroupPage{{items: rawAlertGroups(1)}})
+			resetAgentMode(t)
+
+			cmd := newAlertGroupListCommand(&fakeLoader{client: onCallClientFor(srv)})
+			cmd.SetOut(&strings.Builder{})
+			cmd.SetErr(&strings.Builder{})
+			cmd.SetArgs([]string{"-o", "json", "--limit", tc.limit})
+
+			err := cmd.Execute()
 			if tc.wantErr == "" {
 				if err != nil {
-					t.Fatalf("Validate() = %v, want nil", err)
+					t.Fatalf("Execute() = %v, want nil", err)
 				}
 				return
 			}
 			if err == nil {
-				t.Fatalf("Validate() = nil, want error %q", tc.wantErr)
+				t.Fatalf("Execute() = nil, want error %q", tc.wantErr)
 			}
 			if err.Error() != tc.wantErr {
-				t.Fatalf("Validate() error = %q, want %q", err.Error(), tc.wantErr)
+				t.Fatalf("error = %q, want %q", err.Error(), tc.wantErr)
+			}
+			if state.requests != 0 {
+				t.Errorf("requests = %d, want 0 (validation must fire before any network work)", state.requests)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #1157

## Problem

The rich list path bounded **every** fetch at `alertGroupListHardCap = 1000`, so:

- `--limit 0` returned at most 1000 alert groups. On a busy stack that is under a day of history, so no complete result set was retrievable for any useful window.
- `--limit N` for `N > 1000` was *also* silently cut down to 1000 — `effectiveCap` only ever shrank, never grew — so there was no way to raise the ceiling either.

The truncation was reported honestly via `list_meta.cap`, but the cap variant deliberately carries **no continuation**, because no larger `--limit` could beat the cap. So a caller had no action to take: the only escape was to bypass gcx and follow the endpoint's opaque `next` cursors by hand — exactly the mechanical work the client already does internally.

## Fix

Remove the cap. `--limit 0` follows `next` cursors to exhaustion, and `--limit N` is honored exactly.

That lets the command adopt the shared `BindListLimit` binder and its uniform *"0 means all results are returned"* wording, which is now an honest promise — so this **removes** the documented capped-source special case rather than adding a flag. `alert-groups list` was the only command taking that exception.

A drained page carries no `list_meta`, which per the truncation contract is the signal that the output **is** the complete set. A user-limited page is unchanged: `truncated`/`returned`, plus the observed `total` and a `--limit 0` continuation when the source happened to drain, or a doubled-limit continuation when it did not. The old honesty guard that withheld a large observed `total` is gone — `--limit 0` genuinely retrieves it now.

Two safety details:

- **Bulk-by-filter mutations** (`acknowledge`/`resolve`/`delete --team ...`) have no user-supplied limit to bound them, so `resolveBulkTargets` now passes its own `alertGroupBulkTargetCap = 1000`. Same value, same `perpage`, same trimming — that path is byte-for-byte unchanged.
- The unbounded walk **stops if a `next` cursor stops advancing**, so a misbehaving server cannot spin the loop forever.

`internal/output` is untouched: the cap machinery stays as documented general contract with its own tests, it simply has no caller now.

## Verification

Live against a busy stack — the case from the issue:

| invocation | before | after |
|---|---|---|
| `--all --max-age 24h --limit 0` | 1000 items, `list_meta.cap: 1000` | **3412 items, no `list_meta`** |
| `--all --max-age 24h --limit 2500` | 1000 items | 2500 items, truncated + `--limit 5000` continuation |
| `--all --max-age 24h --limit 10` | unchanged | 10 items, truncated + `--limit 20` continuation |

New tests: `--limit 0` drains past 1200 items, `--limit 1200` is honored in full, a non-advancing cursor terminates, and an end-to-end `--limit 0` returns everything with no `list_meta`. The two cap-dependent tests were rewritten and the `--limit` validation test retargeted at the real command path (the check moved to the shared `Options.Validate`).

`GCX_AGENT_MODE=false go test ./...` passes, `-race` passes on `irm` and `output`, `golangci-lint run ./...` reports only 3 gosec findings that pre-exist on `main`, and all four reference generators re-run with no drift beyond the expected `--limit` help-text change.

## Compliance

- **CONSTITUTION § frozen public surface** — no command path, alias, flag or positional syntax changes. `--limit 0` moves toward what the flag help already promised ("0 for all"), so this is a defect fix rather than a flag change. Anyone who wants the old ceiling can pass `--limit 1000`.
- **Output contract** — still exactly one JSON value on stdout (`finite`); hints stay on stderr.
- **docs/design/output.md §15** — absence of `list_meta` still means "complete set", and it is now *true* for `--limit 0`, where it previously could not be. No new hint strings; all truncation still flows through the shared helpers. §15.1/§15.3/§15.6 and the research doc are updated to record that no capped source remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)