### PR TITLE
tweak claude CI review process

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -79,14 +79,12 @@ Do that even when the argument for them is strong.
 
 ## Report shape
 
-Use bold text for headings in the report, not markdown headings
+Use bold text for headings in the report, not markdown headings. Each section should be at most two sentences.
 
 1. **Intent.** The problem, and how the change solves it. Say whether the
    approach is sound before you list what is wrong with it. Do not give an opinion non whether the approach is sound or not here - that will become obvious from the rest. Keep this as short as possible.
 2. **Blocking.** Fix before merge: correctness bugs, regressions to shipped
-   behaviour, safety defects, and violations of CONSTITUTION.md or DESIGN.md.
-   Put two more things here. Behaviour that changes inside a described refactor.
-   A call to a function, field, or option that does not exist. Overengineering issues from T12 and T5. If nothing blocks the merge, omit this section.
+   behaviour, safety defects, and violations of CONSTITUTION.md or DESIGN.md. Also: Behaviour that changes inside a described refactor. A call to a function, field, or option that does not exist. Overengineering issues from T12 and T5. If nothing blocks the merge, omit this section.
 3. **Other findings.** Everything that does not block, worst first. Include
    documentation that contradicts the code it describes. Give each finding the
    space its argument needs and no more. Some take a paragraph. Most take a

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -79,20 +79,21 @@ Do that even when the argument for them is strong.
 
 ## Report shape
 
+Use bold text for headings in the report, not markdown headings
+
 1. **Intent.** The problem, and how the change solves it. Say whether the
-   approach is sound before you list what is wrong with it.
+   approach is sound before you list what is wrong with it. Do not give an opinion non whether the approach is sound or not here - that will become obvious from the rest. Keep this as short as possible.
 2. **Blocking.** Fix before merge: correctness bugs, regressions to shipped
    behaviour, safety defects, and violations of CONSTITUTION.md or DESIGN.md.
    Put two more things here. Behaviour that changes inside a described refactor.
-   A call to a function, field, or option that does not exist.
+   A call to a function, field, or option that does not exist. Overengineering issues from T12 and T5. If nothing blocks the merge, omit this section.
 3. **Other findings.** Everything that does not block, worst first. Include
    documentation that contradicts the code it describes. Give each finding the
    space its argument needs and no more. Some take a paragraph. Most take a
    line. The label shows the difference, so a one-line nit and a
    worth-fixing defect can share the list.
-4. **Over-engineering.** Findings from T12 and T5. Rank and cap them as below.
-5. **The smaller version.** One combined remedy. Omit this section when section
-   4 is empty.
+5. **Fix summary** One combined remedy. Omit this section when section
+   2 and 3 are empty.
 6. **Verdict.** Approve or request changes. Name the findings that decide it. If
    you would merge a reduced version, say so, and say how much smaller.
 
@@ -148,15 +149,12 @@ Five things change when no human is present. The rest of the review is the same.
   can answer a speculative finding here, and a wrong one makes them disprove it
   in public.
 - **Use tighter caps**: at most three blocking findings, and eight comments in
-  total. Drop the lowest-ranked findings rather than relabelling them. Say in
-  the summary that you dropped some.
-- **Close the summary with this exact line**, so an author who pushes a fix
-  knows how to ask again:
+  total. Drop the lowest-ranked findings.
+- **Close the summary with this exact line**:
 
   > Comment `@claude review` for a fresh review.
 
-Silence is a valid result. When nothing meets the bar, say in one line that the
-diff looked clean, and stop. Never invent a finding.
+Silence is a valid result. If there are no findings, say so in one line. Never invent a finding.
 
 ## Offering to post the review
 
@@ -264,6 +262,7 @@ Write the report and the comments in plain English:
 - Active voice.
 - Plain words instead of figurative ones.
 - No idiom.
+- Avoid phrases or terms that hyphenate words together. Find simpler alternatives.
 
 This applies to prose. It does not apply to identifiers, code comments,
 suggested diffs, or quoted output.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -96,11 +96,13 @@ jobs:
 
             Base the report on both sets combined: drop duplicates, and where
             the two disagree, resolve it against the code and report one
-            conclusion rather than both. Then post what survives.
-          # Pin the model instead of inheriting the action's default. That
-          # default moves as new models ship, so review behaviour changes with
-          # no commit to point at. Pinning keeps runs reproducible and makes
-          # each upgrade an explicit change someone reviewed.
+            conclusion rather than both. Then post what survives. The report
+            should always follow the structure in .claude/skills/review-pr/SKILL.md#Report-shape.
+            Do not mention the process you used to generate the report.
+
+            We should categorise findings as blocking or nits. Recommended findings should be
+            upgraded to blocking.
+          # Pin the model to keep the behaviour consistent
           claude_args: '--model claude-opus-5 --allowedTools "Read,Grep,Glob,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr review:*),mcp__github_inline_comment__create_inline_comment"'
 
       - name: Add claude-reviewed label

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -96,14 +96,16 @@ jobs:
 
             Base the report on both sets combined: drop duplicates, and where
             the two disagree, resolve it against the code and report one
-            conclusion rather than both. Then post what survives. The report
-            should always follow the structure in .claude/skills/review-pr/SKILL.md#Report-shape.
-            Do not mention the process you used to generate the report.
+            conclusion rather than both. The report should always follow the 
+            structure in .claude/skills/review-pr/SKILL.md#Report-shape, but
+            prefer to put blocking and nits feedback in inline comments. do
+            not duplicate inline comments in the main report body. Do not
+            mention the process you used to generate the report. 
 
-            We should categorise findings as blocking or nits. Recommended findings should be
-            upgraded to blocking.
+            We should categorise findings as blocking or nits. Recommended
+            findings should be upgraded to blocking.
           # Pin the model to keep the behaviour consistent
-          claude_args: '--model claude-opus-5 --allowedTools "Read,Grep,Glob,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr review:*),mcp__github_inline_comment__create_inline_comment"'
+          claude_args: '--model claude-opus-4-6 --allowedTools "Read,Grep,Glob,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr review:*),mcp__github_inline_comment__create_inline_comment"'
 
       - name: Add claude-reviewed label
         if: success()


### PR DESCRIPTION
tweak the skill and prompt for claude code review, to try and:

- push back a bit harder on "recommended" changes. recommended is ambiguous to unfamiliar authors.
- Try and make [a report](https://github.com/grafana/gcx/pull/1194#issuecomment-5292873671) a bit less sloppy. H2 headers are overwhelming, "this is a good idea" fluff is tedious, combine some of the sections. Tr and push back on claude's love of referencing its own processes.