### PR TITLE
docs: define and enforce how experimental commands are marked

### DIFF
--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -81,7 +81,10 @@ OnCall, Fleet Management, etc.) using product-specific REST APIs.
   release, unless the surface was explicitly marked experimental before
   release. The complete v1.0.0 command surface is therefore a supported
   compatibility exception for all v1.x releases, including invocations that
-  predate or deviate from the rules above.
+  predate or deviate from the rules above. One caveat to this rule is that commands marked as experimental may be removed or
+  changed without following the normal semver conventions - see
+  [experimental-commands.md](docs/design/experimental-commands.md) for how a command
+  is marked.
 
 ## Dual-Purpose Design
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -159,4 +159,5 @@ Prescriptive implementation rules live in [docs/design/](docs/design/), split by
 | [help-text.md](docs/design/help-text.md) | Command descriptions, examples format |
 | [naming.md](docs/design/naming.md) | Resource kinds, file naming, config keys, flags |
 | [command-naming.md](docs/design/command-naming.md) | Canonical command verbs and placement |
+| [experimental-commands.md](docs/design/experimental-commands.md) | Marking experimental commands in help text and agent metadata |
 | [environment-variables.md](docs/design/environment-variables.md) | Canonical environment variable reference |

--- a/cmd/gcx/root/experimental_test.go
+++ b/cmd/gcx/root/experimental_test.go
@@ -1,0 +1,133 @@
+package root_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/internal/agent"
+	"github.com/spf13/cobra"
+)
+
+// The marker and preamble are written as literal prose at each call site so
+// that help text stays greppable; these tests are what keep the wording, the
+// placement, and the agent.stability annotation in agreement.
+// See docs/design/experimental-commands.md.
+const (
+	experimentalMarker   = "[experimental]"
+	experimentalPreamble = "This command is experimental. It may be removed, or its subcommands, " +
+		"flags and responses may change without following the normal semantic versioning conventions."
+)
+
+func isExperimental(cmd *cobra.Command) bool {
+	return cmd.Annotations[agent.AnnotationStability] == agent.StabilityExperimental
+}
+
+// hasExperimentalShort reports whether the short description carries the marker
+// in the one position the standard allows.
+func hasExperimentalShort(cmd *cobra.Command) bool {
+	return strings.HasPrefix(cmd.Short, experimentalMarker+" ")
+}
+
+// nearestMarkedAncestor returns the closest ancestor whose short description is
+// marked, or nil when the command is not inside a marked subtree.
+func nearestMarkedAncestor(cmd *cobra.Command) *cobra.Command {
+	for parent := cmd.Parent(); parent != nil; parent = parent.Parent() {
+		if hasExperimentalShort(parent) {
+			return parent
+		}
+	}
+	return nil
+}
+
+// TestExperimental_MarkerIsShortDescriptionPrefix rejects the marker anywhere
+// but the start of the short description, where readers scanning a command list
+// would miss it.
+func TestExperimental_MarkerIsShortDescriptionPrefix(t *testing.T) {
+	agent.WalkCommands(buildRootCmd(), func(cmd *cobra.Command) {
+		if !strings.Contains(cmd.Short, experimentalMarker) {
+			return
+		}
+		t.Run(cmd.CommandPath(), func(t *testing.T) {
+			if !hasExperimentalShort(cmd) {
+				t.Errorf("short description must begin with %q, got %q", experimentalMarker+" ", cmd.Short)
+			}
+		})
+	})
+}
+
+// TestExperimental_MarkedCommandsCarryStabilityAnnotation keeps the prose and
+// the machine-readable metadata from drifting apart.
+func TestExperimental_MarkedCommandsCarryStabilityAnnotation(t *testing.T) {
+	agent.WalkCommands(buildRootCmd(), func(cmd *cobra.Command) {
+		if !hasExperimentalShort(cmd) {
+			return
+		}
+		t.Run(cmd.CommandPath(), func(t *testing.T) {
+			if !isExperimental(cmd) {
+				t.Errorf("short description is marked %s but %s annotation is %q, want %q",
+					experimentalMarker, agent.AnnotationStability,
+					cmd.Annotations[agent.AnnotationStability], agent.StabilityExperimental)
+			}
+		})
+	})
+}
+
+// TestExperimental_AnnotatedCommandsAreAdvertised is the other direction: an
+// annotated command must say so itself, or sit under a command that does.
+func TestExperimental_AnnotatedCommandsAreAdvertised(t *testing.T) {
+	agent.WalkCommands(buildRootCmd(), func(cmd *cobra.Command) {
+		if !isExperimental(cmd) {
+			return
+		}
+		t.Run(cmd.CommandPath(), func(t *testing.T) {
+			if !hasExperimentalShort(cmd) && nearestMarkedAncestor(cmd) == nil {
+				t.Errorf("annotated %s but neither its short description nor any ancestor's carries %q",
+					agent.StabilityExperimental, experimentalMarker)
+			}
+		})
+	})
+}
+
+// TestExperimental_LongDescriptionCarriesPreamble checks the wording users are
+// shown when they ask for the full help.
+func TestExperimental_LongDescriptionCarriesPreamble(t *testing.T) {
+	agent.WalkCommands(buildRootCmd(), func(cmd *cobra.Command) {
+		if !hasExperimentalShort(cmd) {
+			return
+		}
+		t.Run(cmd.CommandPath(), func(t *testing.T) {
+			long := strings.TrimSpace(cmd.Long)
+			if long == "" {
+				t.Errorf("no long description; it must begin with %q", experimentalPreamble)
+				return
+			}
+			// The preamble is wrapped across lines in source, so compare on
+			// collapsed whitespace.
+			if !strings.HasPrefix(strings.Join(strings.Fields(long), " "), experimentalPreamble) {
+				t.Errorf("long description must begin with %q, got %q", experimentalPreamble, firstLine(long))
+			}
+		})
+	})
+}
+
+// TestExperimental_SubtreeMarkedOnlyAtItsRoot enforces the one-marker rule: a
+// command under an already-marked command must not repeat the marker.
+func TestExperimental_SubtreeMarkedOnlyAtItsRoot(t *testing.T) {
+	agent.WalkCommands(buildRootCmd(), func(cmd *cobra.Command) {
+		if !hasExperimentalShort(cmd) {
+			return
+		}
+		t.Run(cmd.CommandPath(), func(t *testing.T) {
+			if ancestor := nearestMarkedAncestor(cmd); ancestor != nil {
+				t.Errorf("%q is already marked, so this command must not repeat the marker", ancestor.CommandPath())
+			}
+		})
+	})
+}
+
+func firstLine(s string) string {
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		return s[:i]
+	}
+	return s
+}

--- a/cmd/gcx/root/experimental_test.go
+++ b/cmd/gcx/root/experimental_test.go
@@ -89,10 +89,13 @@ func TestExperimental_AnnotatedCommandsAreAdvertised(t *testing.T) {
 }
 
 // TestExperimental_LongDescriptionCarriesPreamble checks the wording users are
-// shown when they ask for the full help.
+// shown when they ask for the full help. Unlike the marker, the preamble is
+// required on every experimental command, including those inside a subtree
+// marked only at its root: --help on a child is reached directly, so it cannot
+// rely on the parent to carry the warning.
 func TestExperimental_LongDescriptionCarriesPreamble(t *testing.T) {
 	agent.WalkCommands(buildRootCmd(), func(cmd *cobra.Command) {
-		if !hasExperimentalShort(cmd) {
+		if !isExperimental(cmd) {
 			return
 		}
 		t.Run(cmd.CommandPath(), func(t *testing.T) {

--- a/cmd/gcx/root/experimental_test.go
+++ b/cmd/gcx/root/experimental_test.go
@@ -126,8 +126,6 @@ func TestExperimental_SubtreeMarkedOnlyAtItsRoot(t *testing.T) {
 }
 
 func firstLine(s string) string {
-	if i := strings.IndexByte(s, '\n'); i >= 0 {
-		return s[:i]
-	}
-	return s
+	line, _, _ := strings.Cut(s, "\n")
+	return line
 }

--- a/cmd/gcx/root/experimental_test.go
+++ b/cmd/gcx/root/experimental_test.go
@@ -28,17 +28,6 @@ func hasExperimentalShort(cmd *cobra.Command) bool {
 	return strings.HasPrefix(cmd.Short, experimentalMarker+" ")
 }
 
-// nearestMarkedAncestor returns the closest ancestor whose short description is
-// marked, or nil when the command is not inside a marked subtree.
-func nearestMarkedAncestor(cmd *cobra.Command) *cobra.Command {
-	for parent := cmd.Parent(); parent != nil; parent = parent.Parent() {
-		if hasExperimentalShort(parent) {
-			return parent
-		}
-	}
-	return nil
-}
-
 // TestExperimental_MarkerIsShortDescriptionPrefix rejects the marker anywhere
 // but the start of the short description, where readers scanning a command list
 // would miss it.
@@ -72,16 +61,18 @@ func TestExperimental_MarkedCommandsCarryStabilityAnnotation(t *testing.T) {
 	})
 }
 
-// TestExperimental_AnnotatedCommandsAreAdvertised is the other direction: an
-// annotated command must say so itself, or sit under a command that does.
+// TestExperimental_AnnotatedCommandsAreAdvertised is the other direction: every
+// annotated command must say so in its own short description. Help, the command
+// catalog and `gcx commands --flat` each show one command's short description
+// without its ancestors', so a child cannot inherit the marker.
 func TestExperimental_AnnotatedCommandsAreAdvertised(t *testing.T) {
 	agent.WalkCommands(buildRootCmd(), func(cmd *cobra.Command) {
 		if !isExperimental(cmd) {
 			return
 		}
 		t.Run(cmd.CommandPath(), func(t *testing.T) {
-			if !hasExperimentalShort(cmd) && nearestMarkedAncestor(cmd) == nil {
-				t.Errorf("annotated %s but neither its short description nor any ancestor's carries %q",
+			if !hasExperimentalShort(cmd) {
+				t.Errorf("annotated %s but its short description does not carry %q",
 					agent.StabilityExperimental, experimentalMarker)
 			}
 		})
@@ -108,21 +99,6 @@ func TestExperimental_LongDescriptionCarriesPreamble(t *testing.T) {
 			// collapsed whitespace.
 			if !strings.HasPrefix(strings.Join(strings.Fields(long), " "), experimentalPreamble) {
 				t.Errorf("long description must begin with %q, got %q", experimentalPreamble, firstLine(long))
-			}
-		})
-	})
-}
-
-// TestExperimental_SubtreeMarkedOnlyAtItsRoot enforces the one-marker rule: a
-// command under an already-marked command must not repeat the marker.
-func TestExperimental_SubtreeMarkedOnlyAtItsRoot(t *testing.T) {
-	agent.WalkCommands(buildRootCmd(), func(cmd *cobra.Command) {
-		if !hasExperimentalShort(cmd) {
-			return
-		}
-		t.Run(cmd.CommandPath(), func(t *testing.T) {
-			if ancestor := nearestMarkedAncestor(cmd); ancestor != nil {
-				t.Errorf("%q is already marked, so this command must not repeat the marker", ancestor.CommandPath())
 			}
 		})
 	})

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -18,4 +18,5 @@ New commands and providers **must comply with all rules documented here**.
 | [help-text.md](help-text.md) | Command descriptions, examples format |
 | [naming.md](naming.md) | Resource kinds, file naming, config keys, flags |
 | [command-naming.md](command-naming.md) | Canonical command verbs and placement |
+| [experimental-commands.md](experimental-commands.md) | Marking experimental commands in help text and agent metadata |
 | [environment-variables.md](environment-variables.md) | Canonical environment variable reference |

--- a/docs/design/experimental-commands.md
+++ b/docs/design/experimental-commands.md
@@ -1,0 +1,36 @@
+# Experimental Commands
+
+> How experimental commands should be advertised
+
+Experimental commands are commands that are not yet stable, or interact with features in Grafana Cloud that are not yet Generally Available. For more information on what that means, see [Release life cycle for Grafana Labs](https://grafana.com/docs/release-life-cycle/).
+
+Marking a command experimental is what buys the exemption from the compatibility promise in [CONSTITUTION.md](../../CONSTITUTION.md#cli-grammar): an unmarked command cannot be changed or removed within a major version.
+
+## Command docs
+
+The short description for experimental commands should begin with `[experimental]`.
+
+If an entire command subtree is experimental, only the top-level command should be marked as experimental in the short description.
+
+The long description for an experimental command should begin with:
+
+> This command is experimental. It may be removed, or its subcommands, flags and responses may change without following the normal semantic versioning conventions.
+
+## Agent metadata
+
+Every experimental command carries the `agent.stability` annotation
+(`agent.StabilityExperimental`), including each command inside an experimental
+subtree. Agents read one command's metadata at a time and do not walk ancestors,
+so the annotation is repeated where the short description is not.
+
+## Enforcement
+
+`cmd/gcx/root/experimental_test.go` checks the three surfaces agree: the
+annotation, the `[experimental]` prefix on the short description, and the
+preamble on the long description. Flag help uses the same `[experimental]`
+prefix by convention, but is not enforced.
+
+## What users are told
+
+The guarantee itself is documented for users in
+[docs/sources/overview.md](../sources/overview.md#experimental-commands).

--- a/docs/design/experimental-commands.md
+++ b/docs/design/experimental-commands.md
@@ -1,16 +1,14 @@
 # Experimental Commands
 
-> How experimental commands should be advertised
-
 Experimental commands are commands that are not yet stable, or interact with features in Grafana Cloud that are not yet Generally Available. For more information on what that means, see [Release life cycle for Grafana Labs](https://grafana.com/docs/release-life-cycle/).
 
-Marking a command experimental is what buys the exemption from the compatibility promise in [CONSTITUTION.md](../../CONSTITUTION.md#cli-grammar): an unmarked command cannot be changed or removed within a major version.
+Experimental commands are exempt from the compatibility promise in [CONSTITUTION.md](../../CONSTITUTION.md#cli-grammar)
 
 ## Command docs
 
 The short description for experimental commands should begin with `[experimental]`.
 
-If an entire command subtree is experimental, only the top-level command should be marked as experimental in the short description.
+If an entire command subtree is experimental, only the top-level command will be marked as experimental in the short description.
 
 The long description for an experimental command should begin with:
 
@@ -18,19 +16,12 @@ The long description for an experimental command should begin with:
 
 ## Agent metadata
 
-Every experimental command carries the `agent.stability` annotation
-(`agent.StabilityExperimental`), including each command inside an experimental
-subtree. Agents read one command's metadata at a time and do not walk ancestors,
-so the annotation is repeated where the short description is not.
+Every experimental command carries the `agent.stability` annotation `agent.StabilityExperimental`, including each command inside an experimental subtree.
 
 ## Enforcement
 
-`cmd/gcx/root/experimental_test.go` checks the three surfaces agree: the
-annotation, the `[experimental]` prefix on the short description, and the
-preamble on the long description. Flag help uses the same `[experimental]`
-prefix by convention, but is not enforced.
+`cmd/gcx/root/experimental_test.go` checks that the short descriptions, long descriptions, and metadata for experimental commands conform to this design.
 
 ## What users are told
 
-The guarantee itself is documented for users in
-[docs/sources/overview.md](../sources/overview.md#experimental-commands).
+The guarantee itself is documented for users in [docs/sources/overview.md](../sources/overview.md#experimental-commands).

--- a/docs/design/experimental-commands.md
+++ b/docs/design/experimental-commands.md
@@ -8,13 +8,11 @@ Experimental commands are exempt from the compatibility promise in [CONSTITUTION
 
 The short description for experimental commands should begin with `[experimental]`.
 
-If an entire command subtree is experimental, only the top-level command will be marked as experimental in the short description.
+Every command in an experimental subtree is marked, including its children: help and `gcx commands --flat` show a command's short description without its ancestors'.
 
 The long description for an experimental command should begin with:
 
 > This command is experimental. It may be removed, or its subcommands, flags and responses may change without following the normal semantic versioning conventions.
-
-Unlike the short description, the long description is required on every command in an experimental subtree, including those not marked in the short description.
 
 ## Agent metadata
 

--- a/docs/design/experimental-commands.md
+++ b/docs/design/experimental-commands.md
@@ -14,6 +14,8 @@ The long description for an experimental command should begin with:
 
 > This command is experimental. It may be removed, or its subcommands, flags and responses may change without following the normal semantic versioning conventions.
 
+Unlike the short description, the long description is required on every command in an experimental subtree, including those not marked in the short description.
+
 ## Agent metadata
 
 Every experimental command carries the `agent.stability` annotation `agent.StabilityExperimental`, including each command inside an experimental subtree.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,6 +17,11 @@ Whether you're automating workflows in CI/CD pipelines or switching between stag
 
 gcx is Generally Available. It is still under active development.
 
+Individual commands labelled `[experimental]` in their help text are exempt from
+the usual stability guarantee: they may be removed, or their subcommands, flags
+and responses may change, without following the normal semantic versioning
+conventions.
+
 Additional information can be found in
 [Release life cycle for Grafana Labs](https://grafana.com/docs/release-life-cycle/).
 

--- a/docs/reference/cli/gcx_datasources_tempo_baseline.md
+++ b/docs/reference/cli/gcx_datasources_tempo_baseline.md
@@ -4,7 +4,10 @@
 
 ### Synopsis
 
-[experimental] Find healthy, same-operation candidate traces to compare against a seed trace.
+This command is experimental. It may be removed, or its subcommands, flags and
+responses may change without following the normal semantic versioning conventions.
+
+Find healthy, same-operation candidate traces to compare against a seed trace.
 
 TRACE_ID is the seed trace (typically a faulty one). The command fetches it,
 reads its root service/operation and its busiest downstream services, then

--- a/docs/reference/cli/gcx_datasources_tempo_diff.md
+++ b/docs/reference/cli/gcx_datasources_tempo_diff.md
@@ -4,10 +4,11 @@
 
 ### Synopsis
 
-[experimental] Compare two traces using the Tempo trace-diff API.
+This command is experimental. It may be removed, or its subcommands, flags and
+responses may change without following the normal semantic versioning conventions.
 
-This is an experimental, Grafana Cloud-only endpoint: it may be unavailable on
-self-hosted or OSS Tempo, and its request/response shape may change.
+Compare two traces using the Tempo trace-diff API. This is a Grafana Cloud-only
+endpoint: it may be unavailable on self-hosted or OSS Tempo.
 
 TRACE_A is the baseline trace and TRACE_B is the comparison trace. Deltas use
 B - A semantics: negative means B is faster (improvement), positive means B is

--- a/docs/reference/cli/gcx_kg.md
+++ b/docs/reference/cli/gcx_kg.md
@@ -33,7 +33,7 @@ Manage Grafana Knowledge Graph rules, entities, and insights
 * [gcx kg prom-rules](gcx_kg_prom-rules.md)	 - Manage Knowledge Graph Custom Prometheus rules.
 * [gcx kg quality](gcx_kg_quality.md)	 - Inspect Knowledge Graph entity quality reports.
 * [gcx kg relabel-rules](gcx_kg_relabel-rules.md)	 - Inspect Mimir relabel rules used by the Knowledge Graph.
-* [gcx kg relationships](gcx_kg_relationships.md)	 - Manage custom Knowledge Graph relationships [experimental].
+* [gcx kg relationships](gcx_kg_relationships.md)	 - [experimental] Manage custom Knowledge Graph relationships.
 * [gcx kg stats](gcx_kg_stats.md)	 - Show entity and active-insight counts, broken down by type, severity, and insight name.
 * [gcx kg status](gcx_kg_status.md)	 - Show Knowledge Graph stack status.
 * [gcx kg suppressions](gcx_kg_suppressions.md)	 - Manage alert suppressions in the Knowledge Graph.

--- a/docs/reference/cli/gcx_kg_entities.md
+++ b/docs/reference/cli/gcx_kg_entities.md
@@ -47,9 +47,9 @@ Pick the read verb by what you start with:
 
 * [gcx kg](gcx_kg.md)	 - Manage Grafana Knowledge Graph rules, entities, and insights
 * [gcx kg entities correlate](gcx_kg_entities_correlate.md)	 - Resolve the affected entities for a firing alert from its labels.
-* [gcx kg entities delete](gcx_kg_entities_delete.md)	 - Delete a custom entity [experimental].
+* [gcx kg entities delete](gcx_kg_entities_delete.md)	 - [experimental] Delete a custom entity.
 * [gcx kg entities inspect](gcx_kg_entities_inspect.md)	 - Show the insight timeline and related entities for a single entity (root-cause analysis).
 * [gcx kg entities list](gcx_kg_entities_list.md)	 - List entities by type/scope, or look up an entity's identity and properties.
 * [gcx kg entities query](gcx_kg_entities_query.md)	 - Query entities by running a read-only Cypher query against the Knowledge Graph.
-* [gcx kg entities upsert](gcx_kg_entities_upsert.md)	 - Create or update a custom entity (upsert) [experimental].
+* [gcx kg entities upsert](gcx_kg_entities_upsert.md)	 - [experimental] Create or update a custom entity (upsert).
 

--- a/docs/reference/cli/gcx_kg_entities_delete.md
+++ b/docs/reference/cli/gcx_kg_entities_delete.md
@@ -1,15 +1,17 @@
 ## gcx kg entities delete
 
-Delete a custom entity [experimental].
+[experimental] Delete a custom entity.
 
 ### Synopsis
+
+This command is experimental. It may be removed, or its subcommands, flags and
+responses may change without following the normal semantic versioning conventions.
 
 Delete an API-origin entity. Scope is part of the entity's identity, so it must
 match the value used at upsert — omitting it targets the scope-less entity, and a
 mismatch returns 404 (not found).
 
-Experimental: this command uses the Knowledge Graph write API, which is gated
-server-side and may change.
+This command uses the Knowledge Graph write API, which is gated server-side.
 
 ```
 gcx kg entities delete [Type--Name] [flags]

--- a/docs/reference/cli/gcx_kg_entities_upsert.md
+++ b/docs/reference/cli/gcx_kg_entities_upsert.md
@@ -1,14 +1,17 @@
 ## gcx kg entities upsert
 
-Create or update a custom entity (upsert) [experimental].
+[experimental] Create or update a custom entity (upsert).
 
 ### Synopsis
 
+This command is experimental. It may be removed, or its subcommands, flags and
+responses may change without following the normal semantic versioning conventions.
+
 Create or update an API-origin entity in a writable domain.
 
-Experimental: this command uses the Knowledge Graph write API, which is gated
-server-side and may change. If the write API is not enabled on your stack, the
-server returns an error explaining how to request access.
+This command uses the Knowledge Graph write API, which is gated server-side. If
+the write API is not enabled on your stack, the server returns an error
+explaining how to request access.
 
 Identity is (type, name, scope) + domain; re-running with the same identity
 updates the entity. Scope is optional but identity-significant.

--- a/docs/reference/cli/gcx_kg_relationships.md
+++ b/docs/reference/cli/gcx_kg_relationships.md
@@ -1,6 +1,13 @@
 ## gcx kg relationships
 
-Manage custom Knowledge Graph relationships [experimental].
+[experimental] Manage custom Knowledge Graph relationships.
+
+### Synopsis
+
+This command is experimental. It may be removed, or its subcommands, flags and
+responses may change without following the normal semantic versioning conventions.
+
+Create, update, and delete API-origin edges between Knowledge Graph entities.
 
 ### Options
 
@@ -23,6 +30,6 @@ Manage custom Knowledge Graph relationships [experimental].
 ### SEE ALSO
 
 * [gcx kg](gcx_kg.md)	 - Manage Grafana Knowledge Graph rules, entities, and insights
-* [gcx kg relationships delete](gcx_kg_relationships_delete.md)	 - Delete a custom relationship [experimental].
-* [gcx kg relationships upsert](gcx_kg_relationships_upsert.md)	 - Create or update a custom relationship (upsert) [experimental].
+* [gcx kg relationships delete](gcx_kg_relationships_delete.md)	 - Delete a custom relationship.
+* [gcx kg relationships upsert](gcx_kg_relationships_upsert.md)	 - Create or update a custom relationship (upsert).
 

--- a/docs/reference/cli/gcx_kg_relationships.md
+++ b/docs/reference/cli/gcx_kg_relationships.md
@@ -30,6 +30,6 @@ Create, update, and delete API-origin edges between Knowledge Graph entities.
 ### SEE ALSO
 
 * [gcx kg](gcx_kg.md)	 - Manage Grafana Knowledge Graph rules, entities, and insights
-* [gcx kg relationships delete](gcx_kg_relationships_delete.md)	 - Delete a custom relationship.
-* [gcx kg relationships upsert](gcx_kg_relationships_upsert.md)	 - Create or update a custom relationship (upsert).
+* [gcx kg relationships delete](gcx_kg_relationships_delete.md)	 - [experimental] Delete a custom relationship.
+* [gcx kg relationships upsert](gcx_kg_relationships_upsert.md)	 - [experimental] Create or update a custom relationship (upsert).
 

--- a/docs/reference/cli/gcx_kg_relationships_delete.md
+++ b/docs/reference/cli/gcx_kg_relationships_delete.md
@@ -1,6 +1,6 @@
 ## gcx kg relationships delete
 
-Delete a custom relationship [experimental].
+Delete a custom relationship.
 
 ### Synopsis
 
@@ -50,5 +50,5 @@ gcx kg relationships delete [flags]
 
 ### SEE ALSO
 
-* [gcx kg relationships](gcx_kg_relationships.md)	 - Manage custom Knowledge Graph relationships [experimental].
+* [gcx kg relationships](gcx_kg_relationships.md)	 - [experimental] Manage custom Knowledge Graph relationships.
 

--- a/docs/reference/cli/gcx_kg_relationships_delete.md
+++ b/docs/reference/cli/gcx_kg_relationships_delete.md
@@ -1,6 +1,6 @@
 ## gcx kg relationships delete
 
-Delete a custom relationship.
+[experimental] Delete a custom relationship.
 
 ### Synopsis
 

--- a/docs/reference/cli/gcx_kg_relationships_delete.md
+++ b/docs/reference/cli/gcx_kg_relationships_delete.md
@@ -4,11 +4,13 @@ Delete a custom relationship.
 
 ### Synopsis
 
+This command is experimental. It may be removed, or its subcommands, flags and
+responses may change without following the normal semantic versioning conventions.
+
 Delete an API-origin edge of the given type between the from/to entities.
 The endpoint refs (incl. scope) must match the values used at upsert.
 
-Experimental: this command uses the Knowledge Graph write API, which is gated
-server-side and may change.
+This command uses the Knowledge Graph write API, which is gated server-side.
 
 ```
 gcx kg relationships delete [flags]

--- a/docs/reference/cli/gcx_kg_relationships_upsert.md
+++ b/docs/reference/cli/gcx_kg_relationships_upsert.md
@@ -1,6 +1,6 @@
 ## gcx kg relationships upsert
 
-Create or update a custom relationship (upsert) [experimental].
+Create or update a custom relationship (upsert).
 
 ### Synopsis
 
@@ -58,5 +58,5 @@ gcx kg relationships upsert [flags]
 
 ### SEE ALSO
 
-* [gcx kg relationships](gcx_kg_relationships.md)	 - Manage custom Knowledge Graph relationships [experimental].
+* [gcx kg relationships](gcx_kg_relationships.md)	 - [experimental] Manage custom Knowledge Graph relationships.
 

--- a/docs/reference/cli/gcx_kg_relationships_upsert.md
+++ b/docs/reference/cli/gcx_kg_relationships_upsert.md
@@ -4,11 +4,13 @@ Create or update a custom relationship (upsert).
 
 ### Synopsis
 
+This command is experimental. It may be removed, or its subcommands, flags and
+responses may change without following the normal semantic versioning conventions.
+
 Create or update an API-origin edge between two existing entities.
 Both endpoints must already exist.
 
-Experimental: this command uses the Knowledge Graph write API, which is gated
-server-side and may change.
+This command uses the Knowledge Graph write API, which is gated server-side.
 
 With -f, the input may be a single object or a YAML/JSON array. Array entries
 are processed in order as independent upserts: the operation is not atomic,

--- a/docs/reference/cli/gcx_kg_relationships_upsert.md
+++ b/docs/reference/cli/gcx_kg_relationships_upsert.md
@@ -1,6 +1,6 @@
 ## gcx kg relationships upsert
 
-Create or update a custom relationship (upsert).
+[experimental] Create or update a custom relationship (upsert).
 
 ### Synopsis
 

--- a/docs/reference/cli/gcx_traces_baseline.md
+++ b/docs/reference/cli/gcx_traces_baseline.md
@@ -4,7 +4,10 @@
 
 ### Synopsis
 
-[experimental] Find healthy, same-operation candidate traces to compare against a seed trace.
+This command is experimental. It may be removed, or its subcommands, flags and
+responses may change without following the normal semantic versioning conventions.
+
+Find healthy, same-operation candidate traces to compare against a seed trace.
 
 TRACE_ID is the seed trace (typically a faulty one). The command fetches it,
 reads its root service/operation and its busiest downstream services, then

--- a/docs/reference/cli/gcx_traces_diff.md
+++ b/docs/reference/cli/gcx_traces_diff.md
@@ -4,10 +4,11 @@
 
 ### Synopsis
 
-[experimental] Compare two traces using the Tempo trace-diff API.
+This command is experimental. It may be removed, or its subcommands, flags and
+responses may change without following the normal semantic versioning conventions.
 
-This is an experimental, Grafana Cloud-only endpoint: it may be unavailable on
-self-hosted or OSS Tempo, and its request/response shape may change.
+Compare two traces using the Tempo trace-diff API. This is a Grafana Cloud-only
+endpoint: it may be unavailable on self-hosted or OSS Tempo.
 
 TRACE_A is the baseline trace and TRACE_B is the comparison trace. Deltas use
 B - A semantics: negative means B is faster (improvement), positive means B is

--- a/docs/sources/overview.md
+++ b/docs/sources/overview.md
@@ -57,6 +57,12 @@ The following applies:
 
 - `gcx` works across a wide range of Grafana product offerings. Feature availability depends on your Grafana deployment. For more information, refer to the [Compatibility matrix](https://github.com/grafana/gcx#compatibility).
 
+## Experimental commands
+
+Some commands are labelled `[experimental]` in their help text and carry a `stability` field of `experimental` in `gcx commands` output. An experimental command may be removed, or its subcommands, flags, and responses may change, without following the normal semantic versioning conventions. Every other command is stable within a major version.
+
+Commands are labelled experimental when they are not yet stable, or when they operate a Grafana Cloud feature that is not yet Generally Available. For more information, refer to [Release life cycle for Grafana Labs](https://grafana.com/docs/release-life-cycle/).
+
 ## Migrate from `grafanactl`
 
 If you want to migrate from `grafanctl` to `gcx`, search-and-replace `grafanactl` with `gcx`. For `grafanactl resources serve`, use `gcx dev serve` instead.

--- a/internal/datasources/tempo/baseline.go
+++ b/internal/datasources/tempo/baseline.go
@@ -89,7 +89,10 @@ func BaselineCmd(loader *providers.ConfigLoader) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "baseline TRACE_ID",
 		Short: "[experimental] Find healthy baseline candidates for a trace",
-		Long: `[experimental] Find healthy, same-operation candidate traces to compare against a seed trace.
+		Long: `This command is experimental. It may be removed, or its subcommands, flags and
+responses may change without following the normal semantic versioning conventions.
+
+Find healthy, same-operation candidate traces to compare against a seed trace.
 
 TRACE_ID is the seed trace (typically a faulty one). The command fetches it,
 reads its root service/operation and its busiest downstream services, then

--- a/internal/datasources/tempo/diff.go
+++ b/internal/datasources/tempo/diff.go
@@ -44,10 +44,11 @@ func DiffCmd(loader *providers.ConfigLoader) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "diff TRACE_A TRACE_B",
 		Short: "[experimental] Compare two traces (baseline vs comparison)",
-		Long: `[experimental] Compare two traces using the Tempo trace-diff API.
+		Long: `This command is experimental. It may be removed, or its subcommands, flags and
+responses may change without following the normal semantic versioning conventions.
 
-This is an experimental, Grafana Cloud-only endpoint: it may be unavailable on
-self-hosted or OSS Tempo, and its request/response shape may change.
+Compare two traces using the Tempo trace-diff API. This is a Grafana Cloud-only
+endpoint: it may be unavailable on self-hosted or OSS Tempo.
 
 TRACE_A is the baseline trace and TRACE_B is the comparison trace. Deltas use
 B - A semantics: negative means B is faster (improvement), positive means B is

--- a/internal/providers/kg/write_commands.go
+++ b/internal/providers/kg/write_commands.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/grafana/gcx/internal/agent"
 	"github.com/grafana/gcx/internal/format"
 	"github.com/grafana/gcx/internal/gcxerrors"
 	cmdio "github.com/grafana/gcx/internal/output"
@@ -74,12 +75,15 @@ func newEntitiesCreateCommand(loader RESTConfigLoader) *cobra.Command {
 	opts := &entityCreateOpts{}
 	cmd := &cobra.Command{
 		Use:   "upsert",
-		Short: "Create or update a custom entity (upsert) [experimental].",
-		Long: `Create or update an API-origin entity in a writable domain.
+		Short: "[experimental] Create or update a custom entity (upsert).",
+		Long: `This command is experimental. It may be removed, or its subcommands, flags and
+responses may change without following the normal semantic versioning conventions.
 
-Experimental: this command uses the Knowledge Graph write API, which is gated
-server-side and may change. If the write API is not enabled on your stack, the
-server returns an error explaining how to request access.
+Create or update an API-origin entity in a writable domain.
+
+This command uses the Knowledge Graph write API, which is gated server-side. If
+the write API is not enabled on your stack, the server returns an error
+explaining how to request access.
 
 Identity is (type, name, scope) + domain; re-running with the same identity
 updates the entity. Scope is optional but identity-significant.
@@ -89,6 +93,7 @@ are processed in order as independent upserts: the operation is not atomic,
 and entries already written stay written if a later entry fails.`,
 		Example: `  gcx kg entities upsert --domain myapp --type Service --name checkout --scope env=prod --ttl 1h
   gcx kg entities upsert -f entity.yaml`,
+		Annotations: map[string]string{agent.AnnotationStability: agent.StabilityExperimental},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := opts.IO.Validate(); err != nil {
 				return err
@@ -256,14 +261,17 @@ func newEntitiesDeleteCommand(loader RESTConfigLoader) *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "delete [Type--Name]",
-		Short: "Delete a custom entity [experimental].",
-		Long: `Delete an API-origin entity. Scope is part of the entity's identity, so it must
+		Short: "[experimental] Delete a custom entity.",
+		Long: `This command is experimental. It may be removed, or its subcommands, flags and
+responses may change without following the normal semantic versioning conventions.
+
+Delete an API-origin entity. Scope is part of the entity's identity, so it must
 match the value used at upsert — omitting it targets the scope-less entity, and a
 mismatch returns 404 (not found).
 
-Experimental: this command uses the Knowledge Graph write API, which is gated
-server-side and may change.`,
-		Args: cobra.MaximumNArgs(1),
+This command uses the Knowledge Graph write API, which is gated server-side.`,
+		Args:        cobra.MaximumNArgs(1),
+		Annotations: map[string]string{agent.AnnotationStability: agent.StabilityExperimental},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := ioOpts.Validate(); err != nil {
 				return err
@@ -331,7 +339,12 @@ func newRelationshipsCommand(loader RESTConfigLoader) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "relationships",
 		Aliases: []string{"relationship", "rels"},
-		Short:   "Manage custom Knowledge Graph relationships [experimental].",
+		Short:   "[experimental] Manage custom Knowledge Graph relationships.",
+		Long: `This command is experimental. It may be removed, or its subcommands, flags and
+responses may change without following the normal semantic versioning conventions.
+
+Create, update, and delete API-origin edges between Knowledge Graph entities.`,
+		Annotations: map[string]string{agent.AnnotationStability: agent.StabilityExperimental},
 	}
 	cmd.AddCommand(newRelationshipsCreateCommand(loader), newRelationshipsDeleteCommand(loader))
 	return cmd
@@ -417,7 +430,7 @@ func newRelationshipsCreateCommand(loader RESTConfigLoader) *cobra.Command {
 	opts := &relCreateOpts{}
 	cmd := &cobra.Command{
 		Use:   "upsert",
-		Short: "Create or update a custom relationship (upsert) [experimental].",
+		Short: "Create or update a custom relationship (upsert).",
 		Long: `Create or update an API-origin edge between two existing entities.
 Both endpoints must already exist.
 
@@ -430,6 +443,7 @@ and entries already written stay written if a later entry fails.`,
 		Example: `  gcx kg relationships upsert --type CALLS --domain myapp \
     --from myapp/Service/checkout --to myapp/Service/cart --to-scope env=prod --ttl 1h
   gcx kg relationships upsert -f rel.yaml`,
+		Annotations: map[string]string{agent.AnnotationStability: agent.StabilityExperimental},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := opts.IO.Validate(); err != nil {
 				return err
@@ -599,7 +613,7 @@ func newRelationshipsDeleteCommand(loader RESTConfigLoader) *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "delete",
-		Short: "Delete a custom relationship [experimental].",
+		Short: "Delete a custom relationship.",
 		Long: `Delete an API-origin edge of the given type between the from/to entities.
 The endpoint refs (incl. scope) must match the values used at upsert.
 
@@ -607,6 +621,7 @@ Experimental: this command uses the Knowledge Graph write API, which is gated
 server-side and may change.`,
 		Example: `  gcx kg relationships delete --type CALLS \
     --from myapp/Service/checkout --to myapp/Service/cart --force`,
+		Annotations: map[string]string{agent.AnnotationStability: agent.StabilityExperimental},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := ioOpts.Validate(); err != nil {
 				return err

--- a/internal/providers/kg/write_commands.go
+++ b/internal/providers/kg/write_commands.go
@@ -431,11 +431,13 @@ func newRelationshipsCreateCommand(loader RESTConfigLoader) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "upsert",
 		Short: "Create or update a custom relationship (upsert).",
-		Long: `Create or update an API-origin edge between two existing entities.
+		Long: `This command is experimental. It may be removed, or its subcommands, flags and
+responses may change without following the normal semantic versioning conventions.
+
+Create or update an API-origin edge between two existing entities.
 Both endpoints must already exist.
 
-Experimental: this command uses the Knowledge Graph write API, which is gated
-server-side and may change.
+This command uses the Knowledge Graph write API, which is gated server-side.
 
 With -f, the input may be a single object or a YAML/JSON array. Array entries
 are processed in order as independent upserts: the operation is not atomic,
@@ -614,11 +616,13 @@ func newRelationshipsDeleteCommand(loader RESTConfigLoader) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "delete",
 		Short: "Delete a custom relationship.",
-		Long: `Delete an API-origin edge of the given type between the from/to entities.
+		Long: `This command is experimental. It may be removed, or its subcommands, flags and
+responses may change without following the normal semantic versioning conventions.
+
+Delete an API-origin edge of the given type between the from/to entities.
 The endpoint refs (incl. scope) must match the values used at upsert.
 
-Experimental: this command uses the Knowledge Graph write API, which is gated
-server-side and may change.`,
+This command uses the Knowledge Graph write API, which is gated server-side.`,
 		Example: `  gcx kg relationships delete --type CALLS \
     --from myapp/Service/checkout --to myapp/Service/cart --force`,
 		Annotations: map[string]string{agent.AnnotationStability: agent.StabilityExperimental},

--- a/internal/providers/kg/write_commands.go
+++ b/internal/providers/kg/write_commands.go
@@ -430,7 +430,7 @@ func newRelationshipsCreateCommand(loader RESTConfigLoader) *cobra.Command {
 	opts := &relCreateOpts{}
 	cmd := &cobra.Command{
 		Use:   "upsert",
-		Short: "Create or update a custom relationship (upsert).",
+		Short: "[experimental] Create or update a custom relationship (upsert).",
 		Long: `This command is experimental. It may be removed, or its subcommands, flags and
 responses may change without following the normal semantic versioning conventions.
 
@@ -615,7 +615,7 @@ func newRelationshipsDeleteCommand(loader RESTConfigLoader) *cobra.Command {
 	)
 	cmd := &cobra.Command{
 		Use:   "delete",
-		Short: "Delete a custom relationship.",
+		Short: "[experimental] Delete a custom relationship.",
 		Long: `This command is experimental. It may be removed, or its subcommands, flags and
 responses may change without following the normal semantic versioning conventions.
 


### PR DESCRIPTION
 #1165 introduced the `agent.stability` annotation. This PR documents what "experimental" actually means for a gcx command, enforces it, and adjusts existing experimental commands to fit that format.

## Summary

- adds `docs/design/experimental-commands.md` to describe the implementation for agents
- adds a CI check that walks the command tree and checks that the design is enforced
- fixes the existing experimental commands: kg's five write commands and `gcx traces diff`
- documents the guarantee for users on the grafana.com overview page and in the docs site Maturity section



