### PR TITLE
chore(codeowners): replace the deprecated kowalski team on the faro provider

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,7 +14,7 @@
 /internal/query/synth/ @grafana/grafana-gcx @grafana/synthetic-monitoring-dev
 /internal/providers/irm/ @grafana/grafana-gcx @grafana/grafana-irm-backend
 /internal/providers/k6/ @grafana/grafana-gcx @grafana/k6-backend
-/internal/providers/faro/ @grafana/grafana-gcx @grafana/kowalski
+/internal/providers/faro/ @grafana/grafana-gcx @grafana/frontend-o11y @grafana/mobile-o11y
 /internal/providers/fleet/ @grafana/grafana-gcx @grafana/fleet-management-backend
 /internal/fleet/ @grafana/grafana-gcx @grafana/fleet-management-backend
 /internal/providers/instrumentation/ @grafana/grafana-gcx @grafana/o11y-ingest


### PR DESCRIPTION
## Summary

- [.github/CODEOWNERS](.github/CODEOWNERS) — the faro provider rule now names `@grafana/frontend-o11y` and `@grafana/mobile-o11y` in place of the deprecated `@grafana/kowalski`. `@grafana/grafana-gcx` stays, because the last matching pattern wins and the fallback rule would otherwise drop it.

Only the team reference changes. Every other `kowalski` string in the repository is the `grafana-kowalski-app` plugin ID in a live API path, which stays as it is.

## Blocked — do not merge yet

Neither team has access to `grafana/gcx`:

| Team | push to grafana/gcx |
|---|---|
| `@grafana/kowalski` | yes |
| `@grafana/frontend-o11y` | **no access** |
| `@grafana/mobile-o11y` | **no access** |

GitHub ignores a CODEOWNERS entry whose team cannot write to the repository. Merging now would leave `/internal/providers/faro/` with `@grafana/grafana-gcx` as its only effective owner and no domain reviewer — worse than the deprecated entry it replaces. All 18 teams currently in the file have push access, so this is the rule the file relies on.

Grant both teams push access first, then mark this ready.

## Test

Both team slugs verified against the org: `frontend-o11y` (Frontend O11y, 13 members) and `mobile-o11y` (Mobile O11y, 12 members) exist, so neither is a typo that GitHub would report as an unknown owner.

_PR description authored by Claude on Domas's behalf._