### PR TITLE
feat(agento11y): add rules list-scores for online evaluation results

### DIFF
--- a/claude-plugin/skills/agento11y/SKILL.md
+++ b/claude-plugin/skills/agento11y/SKILL.md
@@ -30,7 +30,7 @@ All commands live under `gcx agento11y`. Use `gcx agento11y <subcommand> --help`
 | `generations` | Get a single generation, list its scores |
 | `agents` | List agents, get details, list version history (`list-versions`) |
 | `evaluators` | List, get, upsert, delete, test evaluators |
-| `rules` | List, get, create, update, delete evaluation rules |
+| `rules` | List, get, create, update, delete evaluation rules; `list-scores` for online score rows |
 | `templates` | List, get built-in evaluator templates |
 | `judge` | List judge providers and models |
 | `experiments` | List, get, create, update, cancel runs; `list-scores` and `report` |
@@ -103,6 +103,37 @@ There is no `evaluators update` command; to change an evaluator, re-run `upsert`
 4. Iterate until the evaluator scores as expected
 5. Write a rule YAML (see [rule-templates.md](references/rule-templates.md) for copy-paste templates), create: `gcx agento11y rules create -f rule.yaml`
 6. Verify: `gcx agento11y rules list`
+7. Inspect online scores (failing first): `gcx agento11y rules list-scores <rule-id> --passed=false -o json`
+
+## Checking Online Scores
+
+Scores are produced when a rule matches production traffic. List them by rule.
+The default table is a summary (no explanation column); use `-o json` or `-o wide`
+for LLM-judge explanations.
+
+```bash
+# Recent scores (summary table)
+gcx agento11y rules list-scores <rule-id>
+
+# Failure theme analysis (explanations in JSON)
+gcx agento11y rules list-scores <rule-id> --passed=false --limit 100 -o json
+
+# Wide table with truncated explanation column
+gcx agento11y rules list-scores <rule-id> --passed=false -o wide
+
+# Scope to one evaluator / time window
+gcx agento11y rules list-scores <rule-id> --evaluator-id <id> --from 2026-04-01T00:00:00Z --to 2026-04-02T00:00:00Z -o json
+
+# Per-generation scores (after you have a generation ID)
+gcx agento11y generations list-scores <generation-id>
+```
+
+`rules list-scores` JSON is an envelope: `{"items": [...], "list_meta": {...}}`
+(the `list_meta` key appears only when the result was truncated). Parse rows with
+`jq '.items[]'`. It caps the total at 1000 rows: `--limit 0` returns up to that
+cap (not everything), disclosed via `list_meta.cap` and the stderr hint; narrow
+with filters to see beyond it. `generations list-scores` JSON is the existing
+bare `[...]` array.
 
 ## Rule Selectors
 

--- a/cmd/gcx/root/testdata/output_classes.json
+++ b/cmd/gcx/root/testdata/output_classes.json
@@ -63,6 +63,7 @@
  "gcx agento11y rules delete": "finite",
  "gcx agento11y rules get": "finite",
  "gcx agento11y rules list": "finite",
+ "gcx agento11y rules list-scores": "finite",
  "gcx agento11y rules update": "finite",
  "gcx agento11y saved-conversations collections": "finite",
  "gcx agento11y saved-conversations delete": "finite",

--- a/docs/reference/cli/gcx_agento11y_rules.md
+++ b/docs/reference/cli/gcx_agento11y_rules.md
@@ -27,5 +27,6 @@ Manage rules that route generations to evaluators.
 * [gcx agento11y rules delete](gcx_agento11y_rules_delete.md)	 - Delete evaluation rules.
 * [gcx agento11y rules get](gcx_agento11y_rules_get.md)	 - Get a single evaluation rule.
 * [gcx agento11y rules list](gcx_agento11y_rules_list.md)	 - List evaluation rules.
+* [gcx agento11y rules list-scores](gcx_agento11y_rules_list-scores.md)	 - List online evaluation scores for a rule.
 * [gcx agento11y rules update](gcx_agento11y_rules_update.md)	 - Update an evaluation rule from a file.
 

--- a/docs/reference/cli/gcx_agento11y_rules_list-scores.md
+++ b/docs/reference/cli/gcx_agento11y_rules_list-scores.md
@@ -1,0 +1,73 @@
+## gcx agento11y rules list-scores
+
+List online evaluation scores for a rule.
+
+### Synopsis
+
+List online evaluation score rows for a rule.
+
+Each row may include an LLM-judge explanation in the payload. The default table
+shows score key, value, pass/fail, evaluator, and timestamp only; use -o wide
+(truncated explanation column) or -o json for full explanation text.
+
+Use --passed=false to focus on failing scores for failure theme analysis.
+Filter by evaluator, time range, agent, model, or provider as needed.
+
+```
+gcx agento11y rules list-scores <rule-id> [flags]
+```
+
+### Examples
+
+```
+  # Recent scores (summary table; no explanations).
+  gcx agento11y rules list-scores <rule-id>
+
+  # Failing scores with explanations.
+  gcx agento11y rules list-scores <rule-id> --passed=false -o json
+
+  # Wide table with truncated explanation column.
+  gcx agento11y rules list-scores <rule-id> --passed=false -o wide
+
+  # Scoped to one evaluator and time window.
+  gcx agento11y rules list-scores <rule-id> --evaluator-id <id> --from 2026-04-01T00:00:00Z --to 2026-04-02T00:00:00Z -o json
+```
+
+### Options
+
+```
+      --agent-name stringArray    Filter by exact agent name, case-sensitive (repeat to OR; not comma-split)
+      --evaluator-id string       Filter by evaluator ID
+      --from string               Inclusive lower bound on created_at (RFC3339)
+  -h, --help                      help for list-scores
+      --jq string                 jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string               Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --limit int                 Maximum number of scores to return. 0, or a value above 1000, returns up to the 1000-row safety cap; narrow with filters to see beyond it (default 100)
+      --max-value float           Inclusive upper bound on numeric score value (omit for no upper bound)
+      --min-value float           Inclusive lower bound on numeric score value (omit for no lower bound)
+      --model stringArray         Filter by exact generation model, case-sensitive (repeat to OR; not comma-split)
+  -o, --output string             Output format. One of: agents, json, table, wide, yaml (default "table")
+      --passed                    Filter by pass/fail (omit for all scores)
+      --provider stringArray      Filter by exact generation provider, case-sensitive (repeat to OR; not comma-split)
+      --score-value stringArray   Filter by exact score value, case-sensitive (repeat to OR; not comma-split, max 20)
+      --sort-by string            Sort field: created_at or value (default "created_at")
+      --sort-dir string           Sort direction: asc or desc (default "desc")
+      --to string                 Exclusive upper bound on created_at (RFC3339)
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, OPENCODE, PI_CODING_AGENT, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx agento11y rules](gcx_agento11y_rules.md)	 - Manage rules that route generations to evaluators.
+

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -534,11 +534,12 @@ var commandAnnotations = map[string]annotation{
 	"gcx agento11y judge list-models":    {Cost: "small"},
 	"gcx agento11y judge list-providers": {Cost: "small"},
 
-	"gcx agento11y rules create": {Cost: "small"},
-	"gcx agento11y rules delete": {Cost: "small"},
-	"gcx agento11y rules get":    {Cost: "small"},
-	"gcx agento11y rules list":   {Cost: "small"},
-	"gcx agento11y rules update": {Cost: "small"},
+	"gcx agento11y rules create":      {Cost: "small"},
+	"gcx agento11y rules delete":      {Cost: "small"},
+	"gcx agento11y rules get":         {Cost: "small"},
+	"gcx agento11y rules list":        {Cost: "small"},
+	"gcx agento11y rules list-scores": {Cost: "medium", Hint: "<rule-id> --passed=false --limit 100 -o json"},
+	"gcx agento11y rules update":      {Cost: "small"},
 
 	"gcx agento11y templates get":           {Cost: "small"},
 	"gcx agento11y templates list":          {Cost: "small"},

--- a/internal/providers/agento11y/agento11yhttp/client.go
+++ b/internal/providers/agento11y/agento11yhttp/client.go
@@ -68,11 +68,20 @@ func (c *Client) DoRequest(ctx context.Context, method, path string, body io.Rea
 // using the common { "items": [...], "next_cursor": "..." } envelope.
 // Pass maxItems <= 0 for no limit (fetch all pages).
 func ListAll[T any](ctx context.Context, c *Client, basePath string, query url.Values, maxItems ...int) ([]T, error) {
+	items, _, err := ListAllWithHasMore[T](ctx, c, basePath, query, maxItems...)
+	return items, err
+}
+
+// ListAllWithHasMore is like [ListAll] but reports whether the result was
+// truncated by maxItems. hasMore is true when a next page exists or the final
+// page overshot the bound — not when the source is genuinely complete.
+func ListAllWithHasMore[T any](ctx context.Context, c *Client, basePath string, query url.Values, maxItems ...int) ([]T, bool, error) {
 	limit := 0
 	if len(maxItems) > 0 {
 		limit = maxItems[0]
 	}
 	var all []T
+	var hasMore bool
 
 	// Copy to avoid mutating the caller's map during pagination.
 	q := make(url.Values, len(query))
@@ -86,25 +95,26 @@ func ListAll[T any](ctx context.Context, c *Client, basePath string, query url.V
 
 		resp, err := c.DoRequest(ctx, http.MethodGet, path, nil)
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 
 		if resp.StatusCode != http.StatusOK {
 			err := HandleErrorResponse(resp)
 			resp.Body.Close()
-			return nil, err
+			return nil, false, err
 		}
 
 		var page listResponse[T]
 		if err := json.NewDecoder(resp.Body).Decode(&page); err != nil {
 			resp.Body.Close()
-			return nil, fmt.Errorf("failed to decode response: %w", err)
+			return nil, false, fmt.Errorf("failed to decode response: %w", err)
 		}
 		resp.Body.Close()
 
 		all = append(all, page.Items...)
 
 		if limit > 0 && len(all) >= limit {
+			hasMore = page.NextCursor != "" || len(all) > limit
 			all = all[:limit]
 			break
 		}
@@ -116,9 +126,9 @@ func ListAll[T any](ctx context.Context, c *Client, basePath string, query url.V
 	}
 
 	if all == nil {
-		return []T{}, nil
+		return []T{}, hasMore, nil
 	}
-	return all, nil
+	return all, hasMore, nil
 }
 
 // DoJSON executes an HTTP request against the plugin API, optionally

--- a/internal/providers/agento11y/agento11yhttp/client_test.go
+++ b/internal/providers/agento11y/agento11yhttp/client_test.go
@@ -144,6 +144,60 @@ func TestListAll_LimitStopsPagination(t *testing.T) {
 	assert.Equal(t, 1, callCount, "should not fetch second page when limit already reached")
 }
 
+func TestListAllWithHasMore_CompleteAtLimit(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		writeJSON(w, map[string]any{
+			"items": []testItem{
+				{ID: "1", Name: "first"},
+				{ID: "2", Name: "second"},
+			},
+		})
+	}))
+
+	items, hasMore, err := agento11yhttp.ListAllWithHasMore[testItem](context.Background(), client, "/query/items", nil, 2)
+	require.NoError(t, err)
+	assert.Len(t, items, 2)
+	assert.False(t, hasMore)
+}
+
+func TestListAllWithHasMore_TruncatedMidPage(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		writeJSON(w, map[string]any{
+			"items": []testItem{
+				{ID: "1", Name: "first"},
+				{ID: "2", Name: "second"},
+				{ID: "3", Name: "third"},
+			},
+			"next_cursor": "page2",
+		})
+	}))
+
+	items, hasMore, err := agento11yhttp.ListAllWithHasMore[testItem](context.Background(), client, "/query/items", nil, 2)
+	require.NoError(t, err)
+	assert.Len(t, items, 2)
+	assert.True(t, hasMore)
+}
+
+func TestListAllWithHasMore_TruncatedWithNextPage(t *testing.T) {
+	callCount := 0
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+		writeJSON(w, map[string]any{
+			"items":       []testItem{{ID: "1"}},
+			"next_cursor": "more",
+		})
+	}))
+
+	items, hasMore, err := agento11yhttp.ListAllWithHasMore[testItem](context.Background(), client, "/query/items", nil, 1)
+	require.NoError(t, err)
+	assert.Len(t, items, 1)
+	assert.True(t, hasMore)
+	assert.Equal(t, 1, callCount)
+}
+
 func TestListAll_ErrorResponse(t *testing.T) {
 	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "forbidden", http.StatusForbidden)

--- a/internal/providers/agento11y/eval/rules/commands.go
+++ b/internal/providers/agento11y/eval/rules/commands.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/gcx/internal/providers/agento11y/agento11yhttp"
 	"github.com/grafana/gcx/internal/providers/agento11y/commandutil"
 	"github.com/grafana/gcx/internal/providers/agento11y/eval"
+	"github.com/grafana/gcx/internal/providers/agento11y/scores"
 	"github.com/grafana/gcx/internal/resources/adapter"
 	"github.com/grafana/gcx/internal/style"
 	"github.com/spf13/cobra"
@@ -35,6 +36,7 @@ func Commands(loader *providers.ConfigLoader) *cobra.Command {
 		newCreateCommand(loader),
 		newUpdateCommand(loader),
 		newDeleteCommand(loader),
+		scores.NewListRuleScoresCommand(loader),
 	)
 	return cmd
 }

--- a/internal/providers/agento11y/provider.go
+++ b/internal/providers/agento11y/provider.go
@@ -70,7 +70,7 @@ func (p *Agento11yProvider) Commands() []*cobra.Command {
 	rulesCmd := rules.Commands(loader)
 	rulesCmd.Annotations = map[string]string{
 		agent.AnnotationTokenCost: "low",
-		agent.AnnotationLLMHint:   `gcx agento11y rules list -o json; gcx agento11y rules get <id> -o yaml; gcx agento11y rules create -f rule.yaml -o json; gcx agento11y rules update <id> -f patch.yaml -o json; gcx agento11y rules delete <id> --force`,
+		agent.AnnotationLLMHint:   `gcx agento11y rules list -o json; gcx agento11y rules get <id> -o yaml; gcx agento11y rules create -f rule.yaml -o json; gcx agento11y rules update <id> -f patch.yaml -o json; gcx agento11y rules list-scores <id> -o json; gcx agento11y rules delete <id> --force`,
 	}
 
 	guardsCmd := guards.Commands(loader)

--- a/internal/providers/agento11y/scores/client.go
+++ b/internal/providers/agento11y/scores/client.go
@@ -9,7 +9,24 @@ import (
 	"github.com/grafana/gcx/internal/providers/agento11y/agento11yhttp"
 )
 
-const generationScoresPathFmt = "/query/generations/%s/scores"
+const (
+	generationScoresPathFmt = "/query/generations/%s/scores"
+	ruleScoresPathFmt       = "/eval/rules/%s/scores"
+
+	// ruleScoreDefaultLimit is higher than the generation default (50) because
+	// rule scores are the failure-theme-analysis surface (the llm_hint suggests
+	// --limit 100); a single generation's score set is small, so 50 suffices.
+	ruleScoreDefaultLimit = 100
+	ruleScoreMaxValues    = 20
+
+	// scoreMaxPageLimit is the largest per-request page size sent to the API.
+	scoreMaxPageLimit = 500
+	// scoreHardCap bounds the total rows fetched when no smaller user --limit
+	// applies. Both rule and generation score tables can grow large, so an
+	// unbounded --limit 0 could load an unbounded set into memory; the cap keeps
+	// that bounded and is disclosed to the caller via ListMeta.Cap.
+	scoreHardCap = 1000
+)
 
 // Client is an HTTP client for Agent Observability generation score endpoints.
 type Client struct {
@@ -28,4 +45,98 @@ func (c *Client) ListByGeneration(ctx context.Context, generationID string, limi
 		query.Set("limit", strconv.Itoa(limit))
 	}
 	return agento11yhttp.ListAll[Score](ctx, c.base, fmt.Sprintf(generationScoresPathFmt, url.PathEscape(generationID)), query)
+}
+
+// ListScoresOptions holds filters for ListByRule.
+type ListScoresOptions struct {
+	Limit       int
+	EvaluatorID string
+	Passed      *bool
+	From        string
+	To          string
+	AgentNames  []string
+	Models      []string
+	Providers   []string
+	ScoreValues []string
+	MinValue    *float64
+	MaxValue    *float64
+	SortBy      string
+	SortDir     string
+}
+
+// ListByRule returns online evaluation score rows for a rule, paginated. The
+// bool is true when more rows exist beyond the returned page. opts is assumed
+// valid: the sole caller (the CLI command) validates it before calling.
+func (c *Client) ListByRule(ctx context.Context, ruleID string, opts ListScoresOptions) ([]Score, bool, error) {
+	query := buildRuleScoreQuery(opts)
+	items, hasMore, err := agento11yhttp.ListAllWithHasMore[Score](ctx, c.base, fmt.Sprintf(ruleScoresPathFmt, url.PathEscape(ruleID)), query, ruleScoreFetchCap(opts.Limit))
+	return items, hasMore, err
+}
+
+// ruleScoreFetchCap is the total-rows bound passed to ListAll as maxItems for the
+// rule command. A user --limit within (0, scoreHardCap] is honored verbatim; 0
+// ("no limit") or a limit above the cap is bounded by scoreHardCap — a rule's
+// score table grows with traffic and filters, not a larger --limit, are the route
+// beyond the cap. Validation rejects negatives upstream.
+func ruleScoreFetchCap(limit int) int {
+	if limit <= 0 || limit > scoreHardCap {
+		return scoreHardCap
+	}
+	return limit
+}
+
+// ScoreHardCap reports the safety cap for use as PagedListMeta's safetyCap and as
+// a test assertion hook.
+func ScoreHardCap() int { return scoreHardCap }
+
+// scorePageLimit is the per-request limit query param sent to the API.
+// The server caps page size at scoreMaxPageLimit; use that when fetching all pages.
+func scorePageLimit(limit int) int {
+	if limit <= 0 || limit > scoreMaxPageLimit {
+		return scoreMaxPageLimit
+	}
+	return limit
+}
+
+// buildRuleScoreQuery renders validated options into query params. It does not
+// validate; the CLI command validates before ListByRule is reached, so sort
+// fields are non-empty and filter slices carry no empty entries (guaranteed by
+// listRuleOpts.Validate).
+func buildRuleScoreQuery(opts ListScoresOptions) url.Values {
+	params := url.Values{}
+	params.Set("sort_by", opts.SortBy)
+	params.Set("sort_dir", opts.SortDir)
+	params.Set("limit", strconv.Itoa(scorePageLimit(opts.Limit)))
+
+	if opts.EvaluatorID != "" {
+		params.Set("evaluator_id", opts.EvaluatorID)
+	}
+	if opts.Passed != nil {
+		params.Set("passed", strconv.FormatBool(*opts.Passed))
+	}
+	if opts.From != "" {
+		params.Set("from", opts.From)
+	}
+	if opts.To != "" {
+		params.Set("to", opts.To)
+	}
+	if opts.MinValue != nil {
+		params.Set("min_value", strconv.FormatFloat(*opts.MinValue, 'f', -1, 64))
+	}
+	if opts.MaxValue != nil {
+		params.Set("max_value", strconv.FormatFloat(*opts.MaxValue, 'f', -1, 64))
+	}
+	for _, v := range opts.AgentNames {
+		params.Add("agent_name", v)
+	}
+	for _, v := range opts.Models {
+		params.Add("model", v)
+	}
+	for _, v := range opts.Providers {
+		params.Add("provider", v)
+	}
+	for _, v := range opts.ScoreValues {
+		params.Add("score_value", v)
+	}
+	return params
 }

--- a/internal/providers/agento11y/scores/client_test.go
+++ b/internal/providers/agento11y/scores/client_test.go
@@ -91,3 +91,183 @@ func TestClient_ListByGeneration_Empty(t *testing.T) {
 	require.NoError(t, err)
 	assert.Empty(t, items)
 }
+
+func TestClient_ListByRule(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Contains(t, r.URL.Path, "/eval/rules/rule-1/scores")
+		assert.Equal(t, "eval-1", r.URL.Query().Get("evaluator_id"))
+		assert.Equal(t, "false", r.URL.Query().Get("passed"))
+		assert.Equal(t, "2026-04-01T00:00:00Z", r.URL.Query().Get("from"))
+		assert.Equal(t, "2026-04-02T00:00:00Z", r.URL.Query().Get("to"))
+		assert.Equal(t, []string{"agent-a", "agent-b"}, r.URL.Query()["agent_name"])
+		assert.Equal(t, []string{"gpt-4"}, r.URL.Query()["model"])
+		assert.Equal(t, []string{"openai"}, r.URL.Query()["provider"])
+		assert.Equal(t, []string{"fail"}, r.URL.Query()["score_value"])
+		assert.Equal(t, "0.1", r.URL.Query().Get("min_value"))
+		assert.Equal(t, "0.9", r.URL.Query().Get("max_value"))
+		assert.Equal(t, "created_at", r.URL.Query().Get("sort_by"))
+		assert.Equal(t, "desc", r.URL.Query().Get("sort_dir"))
+		assert.Equal(t, "50", r.URL.Query().Get("limit"))
+
+		w.Header().Set("Content-Type", "application/json")
+		writeJSON(w, map[string]any{
+			"items": []scores.Score{
+				{
+					ScoreID:           "s-1",
+					GenerationID:      "gen-1",
+					ConversationID:    "conv-1",
+					ConversationTitle: "Help with billing",
+					EvaluatorID:       "eval-1",
+					EvaluatorVersion:  "1",
+					RuleID:            "rule-1",
+					ScoreKey:          "relevance",
+					ScoreType:         "number",
+					Value:             scores.ScoreValue{Number: new(0.2)},
+					Passed:            new(false),
+					Explanation:       "Off topic",
+					AgentName:         "agent-a",
+					GenModel:          "gpt-4",
+					GenProvider:       "openai",
+					CreatedAt:         now,
+				},
+			},
+		})
+	}))
+
+	passed := false
+	minV, maxV := 0.1, 0.9
+	items, hasMore, err := client.ListByRule(context.Background(), "rule-1", scores.ListScoresOptions{
+		Limit:       50,
+		EvaluatorID: "eval-1",
+		Passed:      &passed,
+		From:        "2026-04-01T00:00:00Z",
+		To:          "2026-04-02T00:00:00Z",
+		AgentNames:  []string{"agent-a", "agent-b"},
+		Models:      []string{"gpt-4"},
+		Providers:   []string{"openai"},
+		ScoreValues: []string{"fail"},
+		MinValue:    &minV,
+		MaxValue:    &maxV,
+		SortBy:      "created_at",
+		SortDir:     "desc",
+	})
+	require.NoError(t, err)
+	require.Len(t, items, 1)
+	assert.False(t, hasMore)
+	assert.Equal(t, "relevance", items[0].ScoreKey)
+	assert.Equal(t, "Help with billing", items[0].ConversationTitle)
+	assert.Equal(t, "agent-a", items[0].AgentName)
+	assert.Equal(t, "gpt-4", items[0].GenModel)
+	assert.Equal(t, "openai", items[0].GenProvider)
+	assert.False(t, *items[0].Passed)
+}
+
+func TestClient_ListByRule_Empty(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.Path, "/eval/rules/rule-1/scores")
+		assert.Equal(t, "100", r.URL.Query().Get("limit"))
+		assert.Equal(t, "created_at", r.URL.Query().Get("sort_by"))
+		assert.Equal(t, "desc", r.URL.Query().Get("sort_dir"))
+		w.Header().Set("Content-Type", "application/json")
+		writeJSON(w, map[string]any{"items": []any{}})
+	}))
+
+	// The client trusts validated input: the CLI always supplies the sort
+	// defaults, so pass them here rather than relying on client-side defaulting.
+	items, hasMore, err := client.ListByRule(context.Background(), "rule-1", scores.ListScoresOptions{
+		Limit: 100, SortBy: "created_at", SortDir: "desc",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, items)
+	assert.False(t, hasMore)
+}
+
+func TestClient_ListByRule_ZeroLimitFetchesAllPages(t *testing.T) {
+	pages := 0
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "500", r.URL.Query().Get("limit"))
+		pages++
+		w.Header().Set("Content-Type", "application/json")
+		if pages == 1 {
+			writeJSON(w, map[string]any{
+				"items":       []scores.Score{{ScoreID: "s-1", ScoreKey: "a"}},
+				"next_cursor": "page-2",
+			})
+			return
+		}
+		writeJSON(w, map[string]any{
+			"items": []scores.Score{{ScoreID: "s-2", ScoreKey: "b"}},
+		})
+	}))
+
+	items, hasMore, err := client.ListByRule(context.Background(), "rule-1", scores.ListScoresOptions{Limit: 0})
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+	assert.False(t, hasMore)
+	assert.Equal(t, 2, pages)
+}
+
+func TestClient_ListByRule_HasMoreWhenTruncated(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "2", r.URL.Query().Get("limit"))
+		w.Header().Set("Content-Type", "application/json")
+		writeJSON(w, map[string]any{
+			"items": []scores.Score{
+				{ScoreID: "s-1", ScoreKey: "a"},
+				{ScoreID: "s-2", ScoreKey: "b"},
+				{ScoreID: "s-3", ScoreKey: "c"},
+			},
+			"next_cursor": "page-2",
+		})
+	}))
+
+	items, hasMore, err := client.ListByRule(context.Background(), "rule-1", scores.ListScoresOptions{Limit: 2})
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+	assert.True(t, hasMore)
+}
+
+func TestClient_ListByRule_CompleteAtLimit(t *testing.T) {
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "2", r.URL.Query().Get("limit"))
+		w.Header().Set("Content-Type", "application/json")
+		writeJSON(w, map[string]any{
+			"items": []scores.Score{
+				{ScoreID: "s-1", ScoreKey: "a"},
+				{ScoreID: "s-2", ScoreKey: "b"},
+			},
+		})
+	}))
+
+	items, hasMore, err := client.ListByRule(context.Background(), "rule-1", scores.ListScoresOptions{Limit: 2})
+	require.NoError(t, err)
+	require.Len(t, items, 2)
+	assert.False(t, hasMore, "exactly limit items with no next page is complete")
+}
+
+func TestClient_ListByRule_ZeroLimitBoundedByHardCap(t *testing.T) {
+	hardCap := scores.ScoreHardCap()
+	// The cap bounds total ROWS: a server that keeps returning full non-empty
+	// pages plus a cursor would otherwise page until the cursor runs out; with
+	// --limit 0 the fetch stops once the accumulated rows reach the hard cap.
+	// (It is not a request-count guard — an empty page with a cursor would not
+	// grow the row count; that pre-existing ListAll behavior is out of scope.)
+	client := newTestClient(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "500", r.URL.Query().Get("limit"))
+		page := make([]scores.Score, 500)
+		for i := range page {
+			page[i] = scores.Score{ScoreID: "s", ScoreKey: "a"}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		writeJSON(w, map[string]any{"items": page, "next_cursor": "more"})
+	}))
+
+	items, hasMore, err := client.ListByRule(context.Background(), "rule-1", scores.ListScoresOptions{
+		Limit: 0, SortBy: "created_at", SortDir: "desc",
+	})
+	require.NoError(t, err)
+	assert.True(t, hasMore)
+	assert.Len(t, items, hardCap, "fetch is bounded by the hard cap")
+}

--- a/internal/providers/agento11y/scores/commands.go
+++ b/internal/providers/agento11y/scores/commands.go
@@ -2,7 +2,13 @@ package scores
 
 import (
 	"errors"
+	"fmt"
 	"io"
+	"math"
+	"os"
+	"slices"
+	"strings"
+	"time"
 
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
@@ -13,6 +19,14 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// scoreListMeta builds finalized §15.4 truncation metadata for a score list
+// page: nil when the page is complete, otherwise a ListMeta carrying the
+// safety-cap flag (when safetyCap bounded the fetch) and an argv-derived
+// continuation command. safetyCap is 0 for sources with no client-side cap.
+func scoreListMeta(returned, limit int, hasMore bool, safetyCap int) *cmdio.ListMeta {
+	return cmdio.AttachListMeta(cmdio.PagedListMeta(returned, limit, hasMore, safetyCap), os.Args)
+}
+
 func newClient(cmd *cobra.Command, loader *providers.ConfigLoader) (*Client, error) {
 	base, err := agento11yhttp.NewClientFromCommand(cmd, loader)
 	if err != nil {
@@ -21,7 +35,7 @@ func newClient(cmd *cobra.Command, loader *providers.ConfigLoader) (*Client, err
 	return NewClient(base), nil
 }
 
-// --- list-scores ---
+// --- list-scores (generation) ---
 
 type listOpts struct {
 	IO    cmdio.Options
@@ -66,11 +80,282 @@ func NewListScoresCommand(loader *providers.ConfigLoader) *cobra.Command {
 	return cmd
 }
 
+// --- list-scores (rule) ---
+
+// ruleScoresEnvelope wraps rule score rows in the list envelope so stdout is
+// `{"items": [...]}` — never a bare array — and truncation metadata can ride
+// in-band in list_meta (output.md §15.2/§15.6). The table/wide codec recognizes
+// this shape; json/yaml/agents codecs serialize it verbatim and `--json list`
+// discovery follows the items key.
+type ruleScoresEnvelope struct {
+	Items    []Score         `json:"items" yaml:"items"`
+	ListMeta *cmdio.ListMeta `json:"list_meta,omitempty" yaml:"list_meta,omitempty"`
+}
+
+type listRuleOpts struct {
+	IO          cmdio.Options
+	Limit       int
+	EvaluatorID string
+	Passed      bool
+	From        string
+	To          string
+	AgentNames  []string
+	Models      []string
+	Providers   []string
+	ScoreValues []string
+	MinValue    float64
+	MaxValue    float64
+	SortBy      string
+	SortDir     string
+}
+
+func (o *listRuleOpts) setup(flags *pflag.FlagSet) {
+	// GenMeta only affects the wide layout (AGENT/MODEL columns), so the plain
+	// table codec is left at its default.
+	o.IO.RegisterCustomCodec("table", &TableCodec{})
+	o.IO.RegisterCustomCodec("wide", &TableCodec{Wide: true, GenMeta: true})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+	// A client-side safety cap bounds --limit 0, so the standard "0 means all"
+	// binder does not apply; disclose the cap in the help instead.
+	flags.IntVar(&o.Limit, "limit", ruleScoreDefaultLimit, fmt.Sprintf("Maximum number of scores to return. 0, or a value above %d, returns up to the %d-row safety cap; narrow with filters to see beyond it", scoreHardCap, scoreHardCap))
+	flags.StringVar(&o.EvaluatorID, "evaluator-id", "", "Filter by evaluator ID")
+	flags.BoolVar(&o.Passed, "passed", false, "Filter by pass/fail (omit for all scores)")
+	flags.StringVar(&o.From, "from", "", "Inclusive lower bound on created_at (RFC3339)")
+	flags.StringVar(&o.To, "to", "", "Exclusive upper bound on created_at (RFC3339)")
+	flags.StringArrayVar(&o.AgentNames, "agent-name", nil, "Filter by exact agent name, case-sensitive (repeat to OR; not comma-split)")
+	flags.StringArrayVar(&o.Models, "model", nil, "Filter by exact generation model, case-sensitive (repeat to OR; not comma-split)")
+	flags.StringArrayVar(&o.Providers, "provider", nil, "Filter by exact generation provider, case-sensitive (repeat to OR; not comma-split)")
+	flags.StringArrayVar(&o.ScoreValues, "score-value", nil, "Filter by exact score value, case-sensitive (repeat to OR; not comma-split, max 20)")
+	flags.Float64Var(&o.MinValue, "min-value", 0, "Inclusive lower bound on numeric score value (omit for no lower bound)")
+	flags.Float64Var(&o.MaxValue, "max-value", 0, "Inclusive upper bound on numeric score value (omit for no upper bound)")
+	flags.StringVar(&o.SortBy, "sort-by", "created_at", "Sort field: created_at or value")
+	flags.StringVar(&o.SortDir, "sort-dir", "desc", "Sort direction: asc or desc")
+	// Different filter flags combine with AND; repeats of one flag OR together.
+}
+
+// Validate checks IO options and the request options. It is the single
+// validation site: buildRuleScoreQuery trusts its input, so every filter error
+// is reported here with flag names. scoreOpts is passed in (rather than rebuilt)
+// so RunE builds once and reuses the same value for validation and the request;
+// flags is needed to tell an explicit empty value from an omitted flag.
+func (o *listRuleOpts) Validate(flags *pflag.FlagSet, scoreOpts ListScoresOptions) error {
+	if err := o.IO.Validate(); err != nil {
+		return err
+	}
+	if err := o.validateNonEmptyFilters(flags); err != nil {
+		return err
+	}
+	return validateScoreOptions(scoreOpts)
+}
+
+// validateNonEmptyFilters rejects filters set to an empty value, so an unset
+// shell variable (--evaluator-id "") fails loudly instead of silently widening
+// the query scope. sort-by/sort-dir are deliberately excluded: they are not
+// filters (omitting them applies a default, not "skip"), and validateScoreOptions
+// already reports empty with the allowed-values message.
+func (o *listRuleOpts) validateNonEmptyFilters(flags *pflag.FlagSet) error {
+	scalars := []struct {
+		name, val string
+	}{
+		{"evaluator-id", o.EvaluatorID},
+		{"from", o.From},
+		{"to", o.To},
+	}
+	for _, s := range scalars {
+		if flags.Changed(s.name) && s.val == "" {
+			return fmt.Errorf("--%s was set to an empty value; omit the flag to skip this filter", s.name)
+		}
+	}
+	repeatables := []struct {
+		name string
+		vals []string
+	}{
+		{"agent-name", o.AgentNames},
+		{"model", o.Models},
+		{"provider", o.Providers},
+		{"score-value", o.ScoreValues},
+	}
+	for _, s := range repeatables {
+		if slices.Contains(s.vals, "") {
+			return fmt.Errorf("--%s contains an empty value; remove the empty entry", s.name)
+		}
+	}
+	return nil
+}
+
+// checkFinite rejects NaN/±Inf for an optional numeric bound. nil (omitted) is
+// fine.
+func checkFinite(flag string, v *float64) error {
+	if v == nil {
+		return nil
+	}
+	if math.IsNaN(*v) || math.IsInf(*v, 0) {
+		return fmt.Errorf("%s must be a finite number (got %v)", flag, *v)
+	}
+	return nil
+}
+
+// validateScoreOptions checks the score-list filters, reporting errors with CLI
+// flag names.
+func validateScoreOptions(opts ListScoresOptions) error {
+	if opts.Limit < 0 {
+		return fmt.Errorf("--limit must be >= 0 (got %d)", opts.Limit)
+	}
+	if len(opts.ScoreValues) > ruleScoreMaxValues {
+		return fmt.Errorf(
+			"--score-value supports at most %d entries (got %d); narrow the filter or split the request",
+			ruleScoreMaxValues, len(opts.ScoreValues),
+		)
+	}
+	// pflag's float64 flag is strconv.ParseFloat, which accepts NaN/Inf; reject
+	// them here so they never reach the wire (NaN comparisons are all false, so
+	// the min<=max guard below would pass a NaN through untouched).
+	if err := checkFinite("--min-value", opts.MinValue); err != nil {
+		return err
+	}
+	if err := checkFinite("--max-value", opts.MaxValue); err != nil {
+		return err
+	}
+	if opts.MinValue != nil && opts.MaxValue != nil && *opts.MinValue > *opts.MaxValue {
+		return fmt.Errorf("--min-value (%v) must be <= --max-value (%v)", *opts.MinValue, *opts.MaxValue)
+	}
+	if err := validateScoreTimeBounds(opts.From, opts.To); err != nil {
+		return err
+	}
+	switch opts.SortBy {
+	case "created_at", "value":
+	default:
+		return fmt.Errorf("--sort-by must be \"created_at\" or \"value\" (got %q)", opts.SortBy)
+	}
+	switch opts.SortDir {
+	case "asc", "desc":
+	default:
+		return fmt.Errorf("--sort-dir must be \"asc\" or \"desc\" (got %q)", opts.SortDir)
+	}
+	return nil
+}
+
+// validateScoreTimeBounds checks optional RFC3339 time bounds. Either bound may
+// be omitted; when both are set, from must be before to. Each string is parsed
+// once.
+func validateScoreTimeBounds(from, to string) error {
+	var fromT, toT time.Time
+	if from != "" {
+		t, err := time.Parse(time.RFC3339, from)
+		if err != nil {
+			return fmt.Errorf("invalid --from value: %w", err)
+		}
+		fromT = t
+	}
+	if to != "" {
+		t, err := time.Parse(time.RFC3339, to)
+		if err != nil {
+			return fmt.Errorf("invalid --to value: %w", err)
+		}
+		toT = t
+	}
+	if from != "" && to != "" && !fromT.Before(toT) {
+		return errors.New("--from must be before --to")
+	}
+	return nil
+}
+
+func (o *listRuleOpts) toOptions(flags *pflag.FlagSet) ListScoresOptions {
+	opts := ListScoresOptions{
+		Limit:       o.Limit,
+		EvaluatorID: o.EvaluatorID,
+		From:        o.From,
+		To:          o.To,
+		AgentNames:  o.AgentNames,
+		Models:      o.Models,
+		Providers:   o.Providers,
+		ScoreValues: o.ScoreValues,
+		SortBy:      o.SortBy,
+		SortDir:     o.SortDir,
+	}
+	if flags.Changed("passed") {
+		passed := o.Passed
+		opts.Passed = &passed
+	}
+	if flags.Changed("min-value") {
+		minVal := o.MinValue
+		opts.MinValue = &minVal
+	}
+	if flags.Changed("max-value") {
+		maxVal := o.MaxValue
+		opts.MaxValue = &maxVal
+	}
+	return opts
+}
+
+// NewListRuleScoresCommand returns the `list-scores` leaf command mounted under
+// `gcx agento11y rules`. Scores are addressed by the parent rule's ID.
+func NewListRuleScoresCommand(loader *providers.ConfigLoader) *cobra.Command {
+	opts := &listRuleOpts{}
+	cmd := &cobra.Command{
+		Use:   "list-scores <rule-id>",
+		Short: "List online evaluation scores for a rule.",
+		Long: `List online evaluation score rows for a rule.
+
+Each row may include an LLM-judge explanation in the payload. The default table
+shows score key, value, pass/fail, evaluator, and timestamp only; use -o wide
+(truncated explanation column) or -o json for full explanation text.
+
+Use --passed=false to focus on failing scores for failure theme analysis.
+Filter by evaluator, time range, agent, model, or provider as needed.`,
+		Example: `  # Recent scores (summary table; no explanations).
+  gcx agento11y rules list-scores <rule-id>
+
+  # Failing scores with explanations.
+  gcx agento11y rules list-scores <rule-id> --passed=false -o json
+
+  # Wide table with truncated explanation column.
+  gcx agento11y rules list-scores <rule-id> --passed=false -o wide
+
+  # Scoped to one evaluator and time window.
+  gcx agento11y rules list-scores <rule-id> --evaluator-id <id> --from 2026-04-01T00:00:00Z --to 2026-04-02T00:00:00Z -o json`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ruleID := strings.TrimSpace(args[0])
+			if ruleID == "" {
+				return errors.New("rule ID must not be empty")
+			}
+			scoreOpts := opts.toOptions(cmd.Flags())
+			if err := opts.Validate(cmd.Flags(), scoreOpts); err != nil {
+				return err
+			}
+			client, err := newClient(cmd, loader)
+			if err != nil {
+				return err
+			}
+			scores, hasMore, err := client.ListByRule(cmd.Context(), ruleID, scoreOpts)
+			if err != nil {
+				return err
+			}
+			// New command: use the list envelope so truncation rides in-band in
+			// list_meta, and report the client-side safety cap (ScoreHardCap).
+			meta := scoreListMeta(len(scores), opts.Limit, hasMore, ScoreHardCap())
+			if err := opts.IO.Encode(cmd.OutOrStdout(), ruleScoresEnvelope{Items: scores, ListMeta: meta}); err != nil {
+				return err
+			}
+			cmdio.EmitListTruncationHint(cmd.ErrOrStderr(), meta)
+			return nil
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
 // --- table codec ---
 
-// TableCodec renders scores as a text table.
+// TableCodec renders scores as a text table. Wide adds the VERSION/RULE/
+// EXPLANATION columns. GenMeta adds AGENT/MODEL columns, but only under Wide
+// (the plain table ignores it); it is set only for the rule endpoint, which
+// populates those fields — the generation endpoint leaves them empty.
 type TableCodec struct {
-	Wide bool
+	Wide    bool
+	GenMeta bool
 }
 
 func (c *TableCodec) Format() format.Format {
@@ -81,43 +366,65 @@ func (c *TableCodec) Format() format.Format {
 }
 
 func (c *TableCodec) Encode(w io.Writer, v any) error {
-	items, ok := v.([]Score)
-	if !ok {
-		return errors.New("invalid data type for table codec: expected []Score")
+	// Accept both the bare slice (generation list-scores) and the rule
+	// list-scores envelope, so the codec renders the rows either way.
+	var items []Score
+	switch t := v.(type) {
+	case []Score:
+		items = t
+	case ruleScoresEnvelope:
+		items = t.Items
+	default:
+		return errors.New("invalid data type for table codec: expected []Score or ruleScoresEnvelope")
 	}
 
 	var t *style.TableBuilder
-	if c.Wide {
+	switch {
+	case c.Wide && c.GenMeta:
+		t = style.NewTable("SCORE KEY", "TYPE", "VALUE", "PASSED", "EVALUATOR", "VERSION", "RULE", "AGENT", "MODEL", "EXPLANATION", "CREATED AT")
+	case c.Wide:
 		t = style.NewTable("SCORE KEY", "TYPE", "VALUE", "PASSED", "EVALUATOR", "VERSION", "RULE", "EXPLANATION", "CREATED AT")
-	} else {
+	default:
 		t = style.NewTable("SCORE KEY", "VALUE", "PASSED", "EVALUATOR", "CREATED AT")
 	}
 
 	for _, s := range items {
-		passed := "-"
-		if s.Passed != nil {
-			if *s.Passed {
-				passed = "yes"
-			} else {
-				passed = "no"
-			}
-		}
-
-		if c.Wide {
-			ruleID := s.RuleID
-			if ruleID == "" {
-				ruleID = "-"
-			}
-			explanation := agento11yhttp.Truncate(s.Explanation, 80)
+		passed := scorePassedDisplay(s.Passed)
+		switch {
+		case c.Wide && c.GenMeta:
 			t.Row(s.ScoreKey, s.ScoreType, s.Value.Display(), passed,
-				s.EvaluatorID, s.EvaluatorVersion, ruleID, explanation,
-				agento11yhttp.FormatTime(s.CreatedAt))
-		} else {
+				s.EvaluatorID, s.EvaluatorVersion, dashOrEmpty(s.RuleID), dashOrEmpty(s.AgentName), dashOrEmpty(s.GenModel),
+				agento11yhttp.Truncate(s.Explanation, 80), agento11yhttp.FormatTime(s.CreatedAt))
+		case c.Wide:
+			t.Row(s.ScoreKey, s.ScoreType, s.Value.Display(), passed,
+				s.EvaluatorID, s.EvaluatorVersion, dashOrEmpty(s.RuleID),
+				agento11yhttp.Truncate(s.Explanation, 80), agento11yhttp.FormatTime(s.CreatedAt))
+		default:
 			t.Row(s.ScoreKey, s.Value.Display(), passed,
 				s.EvaluatorID, agento11yhttp.FormatTime(s.CreatedAt))
 		}
 	}
 	return t.Render(w)
+}
+
+// dashOrEmpty renders an empty cell value as "-".
+func dashOrEmpty(s string) string {
+	if s == "" {
+		return "-"
+	}
+	return s
+}
+
+// scorePassedDisplay renders the tri-state pass/fail as yes/no/-.
+func scorePassedDisplay(passed *bool) string {
+	switch {
+	case passed == nil:
+		return "-"
+	case *passed:
+		return "yes"
+	default:
+		return "no"
+	}
 }
 
 func (c *TableCodec) Decode(_ io.Reader, _ any) error {

--- a/internal/providers/agento11y/scores/commands_test.go
+++ b/internal/providers/agento11y/scores/commands_test.go
@@ -2,10 +2,19 @@ package scores_test
 
 import (
 	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
 	"github.com/grafana/gcx/internal/providers/agento11y/scores"
+	"github.com/grafana/gcx/internal/testutils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -36,42 +45,39 @@ func TestTableCodec_Encode(t *testing.T) {
 	}
 
 	tests := []struct {
-		name string
-		wide bool
-		want []string
+		name       string
+		wide       bool
+		genMeta    bool
+		want       []string
+		wantAbsent []string
 	}{
 		{
 			name: "table format",
-			wide: false,
 			want: []string{"SCORE KEY", "VALUE", "PASSED", "EVALUATOR", "CREATED AT",
 				"relevance", "0.95", "yes", "eval-1", "2026-04-02 18:30"},
 		},
 		{
-			name: "wide includes VERSION, RULE, EXPLANATION",
-			wide: true,
-			want: []string{"TYPE", "VERSION", "RULE", "EXPLANATION",
+			name:    "wide with gen meta includes VERSION, RULE, AGENT, MODEL, EXPLANATION",
+			wide:    true,
+			genMeta: true,
+			want: []string{"TYPE", "VERSION", "RULE", "AGENT", "MODEL", "EXPLANATION",
 				"number", "1.0", "rule-1", "High relevance"},
 		},
 		{
+			name:       "wide without gen meta omits AGENT and MODEL",
+			wide:       true,
+			want:       []string{"TYPE", "VERSION", "RULE", "EXPLANATION", "High relevance"},
+			wantAbsent: []string{"AGENT", "MODEL"},
+		},
+		{
 			name: "failed shows no",
-			wide: false,
 			want: []string{"harmful", "no"},
-		},
-		{
-			name: "nil passed shows dash",
-			wide: false,
-			want: []string{"sentiment", "-"},
-		},
-		{
-			name: "empty rule shows dash in wide",
-			wide: true,
-			want: []string{"eval-2", "-"},
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			codec := &scores.TableCodec{Wide: tc.wide}
+			codec := &scores.TableCodec{Wide: tc.wide, GenMeta: tc.genMeta}
 			var buf bytes.Buffer
 			require.NoError(t, codec.Encode(&buf, items))
 
@@ -79,8 +85,420 @@ func TestTableCodec_Encode(t *testing.T) {
 			for _, s := range tc.want {
 				assert.Contains(t, output, s)
 			}
+			for _, s := range tc.wantAbsent {
+				assert.NotContains(t, output, s)
+			}
 		})
 	}
+}
+
+func TestNewListRuleScoresCommand_Flags(t *testing.T) {
+	cmd := scores.NewListRuleScoresCommand(nil)
+	require.Equal(t, "list-scores <rule-id>", cmd.Use)
+
+	f := cmd.Flags()
+	assert.NotNil(t, f.Lookup("limit"))
+	assert.NotNil(t, f.Lookup("evaluator-id"))
+	assert.NotNil(t, f.Lookup("passed"))
+	assert.NotNil(t, f.Lookup("from"))
+	assert.NotNil(t, f.Lookup("to"))
+	assert.NotNil(t, f.Lookup("agent-name"))
+	assert.NotNil(t, f.Lookup("model"))
+	assert.NotNil(t, f.Lookup("provider"))
+	assert.NotNil(t, f.Lookup("score-value"))
+	assert.NotNil(t, f.Lookup("min-value"))
+	assert.NotNil(t, f.Lookup("max-value"))
+	assert.NotNil(t, f.Lookup("sort-by"))
+	assert.NotNil(t, f.Lookup("sort-dir"))
+
+	// Tri-state: --passed is unset by default.
+	assert.False(t, f.Changed("passed"))
+	require.NoError(t, f.Set("passed", "false"))
+	assert.True(t, f.Changed("passed"))
+	passed, err := f.GetBool("passed")
+	require.NoError(t, err)
+	assert.False(t, passed)
+}
+
+func writeSandboxGrafanaConfig(t *testing.T, home, serverURL string) {
+	t.Helper()
+	cfgPath := filepath.Join(home, ".config", "gcx", "config.yaml")
+	require.NoError(t, os.MkdirAll(filepath.Dir(cfgPath), 0o755))
+	cfg := fmt.Sprintf(`version: 1
+stacks:
+  main:
+    grafana:
+      server: %s
+      token: test-token
+      stack-id: 11111
+contexts:
+  default:
+    stack: main
+current-context: default
+`, serverURL)
+	require.NoError(t, os.WriteFile(cfgPath, []byte(cfg), 0o600))
+}
+
+func TestNewListRuleScoresCommand_FlagMapping(t *testing.T) {
+	home := testutils.SandboxConfigEnv(t)
+
+	tests := []struct {
+		name        string
+		args        []string
+		assertQuery func(t *testing.T, q url.Values)
+	}{
+		{
+			name: "all flags map to query params",
+			args: []string{
+				"rule-1",
+				"--limit", "50",
+				"--evaluator-id", "eval-1",
+				"--passed=false",
+				"--from", "2026-04-01T00:00:00Z",
+				"--to", "2026-04-02T00:00:00Z",
+				"--agent-name", "agent-a", "--agent-name", "agent-b",
+				"--model", "gpt-4",
+				"--provider", "openai",
+				"--score-value", "fail",
+				"--min-value", "0.1",
+				"--max-value", "0.9",
+				"--sort-by", "value",
+				"--sort-dir", "asc",
+			},
+			assertQuery: func(t *testing.T, q url.Values) {
+				t.Helper()
+				assert.Equal(t, "eval-1", q.Get("evaluator_id"))
+				assert.Equal(t, "false", q.Get("passed"))
+				assert.Equal(t, "2026-04-01T00:00:00Z", q.Get("from"))
+				assert.Equal(t, "2026-04-02T00:00:00Z", q.Get("to"))
+				assert.Equal(t, []string{"agent-a", "agent-b"}, q["agent_name"])
+				assert.Equal(t, []string{"gpt-4"}, q["model"])
+				assert.Equal(t, []string{"openai"}, q["provider"])
+				assert.Equal(t, []string{"fail"}, q["score_value"])
+				assert.Equal(t, "0.1", q.Get("min_value"))
+				assert.Equal(t, "0.9", q.Get("max_value"))
+				assert.Equal(t, "value", q.Get("sort_by"))
+				assert.Equal(t, "asc", q.Get("sort_dir"))
+				assert.Equal(t, "50", q.Get("limit"))
+			},
+		},
+		{
+			name: "passed omitted",
+			args: []string{"rule-1"},
+			assertQuery: func(t *testing.T, q url.Values) {
+				t.Helper()
+				_, ok := q["passed"]
+				assert.False(t, ok, "unset --passed must not send passed filter")
+				_, hasMin := q["min_value"]
+				_, hasMax := q["max_value"]
+				assert.False(t, hasMin, "unset --min-value must not send min_value filter")
+				assert.False(t, hasMax, "unset --max-value must not send max_value filter")
+				assert.Equal(t, "100", q.Get("limit"))
+				assert.Equal(t, "created_at", q.Get("sort_by"))
+				assert.Equal(t, "desc", q.Get("sort_dir"))
+			},
+		},
+		{
+			name: "passed true",
+			args: []string{"rule-1", "--passed=true"},
+			assertQuery: func(t *testing.T, q url.Values) {
+				t.Helper()
+				assert.Equal(t, "true", q.Get("passed"))
+			},
+		},
+		{
+			name: "min and max explicitly set",
+			args: []string{"rule-1", "--min-value", "0.1", "--max-value", "0.9"},
+			assertQuery: func(t *testing.T, q url.Values) {
+				t.Helper()
+				assert.Equal(t, "0.1", q.Get("min_value"))
+				assert.Equal(t, "0.9", q.Get("max_value"))
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var captured url.Values
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodGet, r.Method)
+				assert.Contains(t, r.URL.Path, "/eval/rules/rule-1/scores")
+				captured = r.URL.Query()
+				w.Header().Set("Content-Type", "application/json")
+				assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{"items": []any{}}))
+			}))
+			t.Cleanup(srv.Close)
+			writeSandboxGrafanaConfig(t, home, srv.URL)
+
+			cmd := scores.NewListRuleScoresCommand(nil)
+			var stdout, stderr bytes.Buffer
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&stderr)
+			cmd.SetArgs(tc.args)
+
+			require.NoError(t, cmd.ExecuteContext(context.Background()), "stderr: %s", stderr.String())
+			require.NotNil(t, captured, "command must reach the API")
+			tc.assertQuery(t, captured)
+		})
+	}
+}
+
+func TestNewListRuleScoresCommand_ValidateBeforeClient(t *testing.T) {
+	run := func(args ...string) error {
+		cmd := scores.NewListRuleScoresCommand(nil)
+		cmd.SetOut(&bytes.Buffer{})
+		cmd.SetErr(&bytes.Buffer{})
+		cmd.SetArgs(append([]string{"rule-1"}, args...))
+		return cmd.Execute()
+	}
+
+	t.Run("invalid sort-dir", func(t *testing.T) {
+		err := run("--sort-dir", "sideways")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--sort-dir")
+		assert.NotContains(t, err.Error(), "sort_dir")
+	})
+
+	t.Run("invalid sort-by", func(t *testing.T) {
+		err := run("--sort-by", "score_key")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--sort-by")
+	})
+
+	t.Run("negative limit", func(t *testing.T) {
+		err := run("--limit", "-1")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--limit")
+	})
+
+	t.Run("too many score values", func(t *testing.T) {
+		args := make([]string, 0, 42)
+		for range 21 {
+			args = append(args, "--score-value", "v")
+		}
+		err := run(args...)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--score-value")
+	})
+
+	t.Run("min greater than max", func(t *testing.T) {
+		err := run("--min-value", "1", "--max-value", "0.5")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--min-value")
+		assert.Contains(t, err.Error(), "--max-value")
+	})
+
+	t.Run("invalid from", func(t *testing.T) {
+		err := run("--from", "yesterday")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid --from value:")
+	})
+
+	t.Run("invalid to", func(t *testing.T) {
+		err := run("--to", "not-a-time")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid --to value:")
+	})
+
+	t.Run("from after to", func(t *testing.T) {
+		err := run("--from", "2026-04-02T00:00:00Z", "--to", "2026-04-01T00:00:00Z")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--from must be before --to")
+	})
+
+	t.Run("non-finite min-value", func(t *testing.T) {
+		err := run("--min-value", "NaN")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--min-value")
+		assert.Contains(t, err.Error(), "finite")
+	})
+
+	t.Run("non-finite max-value", func(t *testing.T) {
+		err := run("--max-value", "Inf")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--max-value")
+		assert.Contains(t, err.Error(), "finite")
+	})
+
+	t.Run("explicit empty scalar filter", func(t *testing.T) {
+		err := run("--evaluator-id", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--evaluator-id")
+		assert.Contains(t, err.Error(), "empty value")
+	})
+
+	t.Run("explicit empty sort-by reports allowed values", func(t *testing.T) {
+		// sort-by is not a filter: an empty value falls through to the sort switch,
+		// which gives the more useful allowed-values error rather than "omit ...".
+		err := run("--sort-by", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--sort-by must be")
+		assert.Contains(t, err.Error(), "created_at")
+	})
+
+	t.Run("empty repeatable filter entry", func(t *testing.T) {
+		err := run("--agent-name", "")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "--agent-name")
+		assert.Contains(t, err.Error(), "empty")
+	})
+}
+
+func TestNewListRuleScoresCommand_TruncationWarning(t *testing.T) {
+	home := testutils.SandboxConfigEnv(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"items": []scores.Score{
+				{ScoreID: "s-1", ScoreKey: "relevance"},
+				{ScoreID: "s-2", ScoreKey: "harmful"},
+			},
+			"next_cursor": "page-2",
+		}))
+	}))
+	t.Cleanup(srv.Close)
+	writeSandboxGrafanaConfig(t, home, srv.URL)
+
+	cmd := scores.NewListRuleScoresCommand(nil)
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"rule-1", "--limit", "2", "-o", "json"})
+	require.NoError(t, cmd.ExecuteContext(context.Background()), "stderr: %s", stderr.String())
+
+	// Standardized §15.4 truncation hint on stderr; the hint never leaks to stdout.
+	assert.Contains(t, stderr.String(), "showing first 2")
+	assert.Contains(t, stderr.String(), "more results are available")
+	assert.NotContains(t, stdout.String(), "showing first")
+
+	// The rule command emits the list envelope, carrying list_meta in-band.
+	var got struct {
+		Items    []scores.Score `json:"items"`
+		ListMeta *struct {
+			Truncated bool `json:"truncated"`
+		} `json:"list_meta"`
+	}
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &got))
+	assert.Len(t, got.Items, 2)
+	require.NotNil(t, got.ListMeta, "envelope must carry list_meta when truncated")
+	assert.True(t, got.ListMeta.Truncated)
+}
+
+func TestNewListRuleScoresCommand_CapBoundedHint(t *testing.T) {
+	home := testutils.SandboxConfigEnv(t)
+	// Always return a full page + cursor: --limit 0 must stop at the hard cap.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		page := make([]scores.Score, 500)
+		for i := range page {
+			page[i] = scores.Score{ScoreID: "s", ScoreKey: "a"}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{"items": page, "next_cursor": "more"}))
+	}))
+	t.Cleanup(srv.Close)
+	writeSandboxGrafanaConfig(t, home, srv.URL)
+
+	cmd := scores.NewListRuleScoresCommand(nil)
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"rule-1", "--limit", "0", "-o", "json"})
+	require.NoError(t, cmd.ExecuteContext(context.Background()), "stderr: %s", stderr.String())
+
+	// Cap-bounded: the hint says so and offers no --limit continuation.
+	assert.Contains(t, stderr.String(), "safety cap")
+	assert.Contains(t, stderr.String(), "Refine filters")
+
+	var got struct {
+		Items    []scores.Score `json:"items"`
+		ListMeta *struct {
+			Truncated bool   `json:"truncated"`
+			Cap       int    `json:"cap"`
+			Continue  string `json:"continue"`
+		} `json:"list_meta"`
+	}
+	require.NoError(t, json.Unmarshal(stdout.Bytes(), &got))
+	assert.Len(t, got.Items, scores.ScoreHardCap())
+	require.NotNil(t, got.ListMeta)
+	assert.Equal(t, scores.ScoreHardCap(), got.ListMeta.Cap)
+	assert.Empty(t, got.ListMeta.Continue, "cap-bounded page offers no larger --limit continuation")
+}
+
+func TestNewListRuleScoresCommand_RejectEmptyID(t *testing.T) {
+	cmd := scores.NewListRuleScoresCommand(nil)
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"   "})
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "rule ID must not be empty")
+}
+
+func TestNewListRuleScoresCommand_TrimIDBeforeRequest(t *testing.T) {
+	home := testutils.SandboxConfigEnv(t)
+	var gotPath string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{"items": []any{}}))
+	}))
+	t.Cleanup(srv.Close)
+	writeSandboxGrafanaConfig(t, home, srv.URL)
+
+	cmd := scores.NewListRuleScoresCommand(nil)
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"  rule-1  "})
+	require.NoError(t, cmd.ExecuteContext(context.Background()))
+	// The padded ID is trimmed before it reaches the URL — no %20 padding.
+	assert.Contains(t, gotPath, "/eval/rules/rule-1/scores")
+	assert.NotContains(t, gotPath, "%20")
+	assert.NotContains(t, gotPath, "  ")
+}
+
+func TestNewListRuleScoresCommand_TableOutput(t *testing.T) {
+	home := testutils.SandboxConfigEnv(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		assert.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"items": []scores.Score{{ScoreID: "s-1", ScoreKey: "relevance", EvaluatorID: "eval-1"}},
+		}))
+	}))
+	t.Cleanup(srv.Close)
+	writeSandboxGrafanaConfig(t, home, srv.URL)
+
+	cmd := scores.NewListRuleScoresCommand(nil)
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	// Default (table) output must render the envelope's rows, not error on the type.
+	cmd.SetArgs([]string{"rule-1"})
+	require.NoError(t, cmd.ExecuteContext(context.Background()), "stderr: %s", stderr.String())
+	assert.Contains(t, stdout.String(), "SCORE KEY")
+	assert.Contains(t, stdout.String(), "relevance")
+}
+
+func TestTableCodec_WideWithAgentModel(t *testing.T) {
+	b := func(v bool) *bool { return &v }
+	f := func(v float64) *float64 { return &v }
+	now := time.Date(2026, 4, 2, 18, 30, 0, 0, time.UTC)
+	items := []scores.Score{
+		{
+			ScoreKey: "relevance", ScoreType: "number",
+			Value: scores.ScoreValue{Number: f(0.2)}, Passed: b(false),
+			EvaluatorID: "eval-1", EvaluatorVersion: "1.0", RuleID: "rule-1",
+			AgentName: "billing-bot", GenModel: "gpt-4",
+			Explanation: "Off topic", CreatedAt: now,
+		},
+	}
+
+	codec := &scores.TableCodec{Wide: true, GenMeta: true}
+	var buf bytes.Buffer
+	require.NoError(t, codec.Encode(&buf, items))
+	output := buf.String()
+	assert.Contains(t, output, "billing-bot")
+	assert.Contains(t, output, "gpt-4")
+	assert.Contains(t, output, "Off topic")
 }
 
 func TestTableCodec_WrongType(t *testing.T) {

--- a/internal/providers/agento11y/scores/types.go
+++ b/internal/providers/agento11y/scores/types.go
@@ -1,31 +1,63 @@
 package scores
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"time"
 )
 
-// Score is a single evaluation score for a generation.
+// Score is a single evaluation score for a generation or rule.
 type Score struct {
-	ScoreID          string         `json:"score_id"`
-	GenerationID     string         `json:"generation_id"`
-	ConversationID   string         `json:"conversation_id,omitempty"`
-	EvaluatorID      string         `json:"evaluator_id"`
-	EvaluatorVersion string         `json:"evaluator_version"`
-	RuleID           string         `json:"rule_id,omitempty"`
-	RunID            string         `json:"run_id,omitempty"`
-	ScoreKey         string         `json:"score_key"`
-	ScoreType        string         `json:"score_type"` // number, bool, string
-	Value            ScoreValue     `json:"value"`
-	Unit             string         `json:"unit,omitempty"`
-	Passed           *bool          `json:"passed,omitempty"`
-	Explanation      string         `json:"explanation,omitempty"`
-	Metadata         map[string]any `json:"metadata,omitempty"`
-	TraceID          string         `json:"trace_id,omitempty"`
-	SpanID           string         `json:"span_id,omitempty"`
-	Source           *ScoreSource   `json:"source,omitempty"`
-	CreatedAt        time.Time      `json:"created_at"`
+	ScoreID           string         `json:"score_id"`
+	GenerationID      string         `json:"generation_id"`
+	ConversationID    string         `json:"conversation_id,omitempty"`
+	ConversationTitle string         `json:"conversation_title,omitempty"`
+	EvaluatorID       string         `json:"evaluator_id"`
+	EvaluatorVersion  string         `json:"evaluator_version"`
+	RuleID            string         `json:"rule_id,omitempty"`
+	RunID             string         `json:"run_id,omitempty"`
+	ScoreKey          string         `json:"score_key"`
+	ScoreType         string         `json:"score_type"` // number, bool, string
+	Value             ScoreValue     `json:"value"`
+	Unit              string         `json:"unit,omitempty"`
+	Passed            *bool          `json:"passed,omitempty"`
+	Explanation       string         `json:"explanation,omitempty"`
+	Metadata          map[string]any `json:"metadata,omitempty"`
+	TraceID           string         `json:"trace_id,omitempty"`
+	SpanID            string         `json:"span_id,omitempty"`
+	// Source is the provenance. The generation endpoint
+	// (/query/generations/<id>/scores) returns a nested {source: {kind, id}}
+	// envelope; the eval endpoints (/eval/rules/<id>/scores, experiments) return
+	// a flat source_kind/source_id pair. SourceKind/SourceID capture the flat
+	// wire form on decode; UnmarshalJSON folds them into Source so callers see a
+	// single shape regardless of which endpoint produced the row.
+	Source      *ScoreSource `json:"source,omitempty"`
+	SourceKind  string       `json:"source_kind,omitempty"`
+	SourceID    string       `json:"source_id,omitempty"`
+	AgentName   string       `json:"agent_name,omitempty"`
+	GenModel    string       `json:"gen_model,omitempty"`
+	GenProvider string       `json:"gen_provider,omitempty"`
+	CreatedAt   time.Time    `json:"created_at"`
+}
+
+// UnmarshalJSON decodes a score and normalizes provenance to the nested Source
+// form: when the wire carries the eval endpoints' flat source_kind/source_id
+// pair and no nested source, they are folded into Source and the flat fields
+// cleared, so re-marshaling (e.g. -o json) emits one consistent shape.
+func (s *Score) UnmarshalJSON(data []byte) error {
+	type alias Score
+	var a alias
+	if err := json.Unmarshal(data, &a); err != nil {
+		return err
+	}
+	*s = Score(a)
+	if s.Source == nil && (s.SourceKind != "" || s.SourceID != "") {
+		s.Source = &ScoreSource{Kind: s.SourceKind, ID: s.SourceID}
+		s.SourceKind = ""
+		s.SourceID = ""
+	}
+	return nil
 }
 
 // ScoreValue is a union type for score values (number, bool, or string).

--- a/internal/providers/agento11y/scores/types_test.go
+++ b/internal/providers/agento11y/scores/types_test.go
@@ -1,11 +1,46 @@
 package scores_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/grafana/gcx/internal/providers/agento11y/scores"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestScore_UnmarshalJSON_SourceShapes(t *testing.T) {
+	t.Run("flat source_kind/source_id folds into nested Source", func(t *testing.T) {
+		var s scores.Score
+		require.NoError(t, json.Unmarshal([]byte(`{"score_id":"s-1","source_kind":"rule","source_id":"r-1"}`), &s))
+		require.NotNil(t, s.Source)
+		assert.Equal(t, "rule", s.Source.Kind)
+		assert.Equal(t, "r-1", s.Source.ID)
+		// Flat fields are cleared so re-marshaling emits a single shape.
+		assert.Empty(t, s.SourceKind)
+		assert.Empty(t, s.SourceID)
+
+		out, err := json.Marshal(s)
+		require.NoError(t, err)
+		assert.Contains(t, string(out), `"source":{`)
+		assert.NotContains(t, string(out), "source_kind")
+		assert.NotContains(t, string(out), "source_id")
+	})
+
+	t.Run("nested source is preserved and not overwritten", func(t *testing.T) {
+		var s scores.Score
+		require.NoError(t, json.Unmarshal([]byte(`{"score_id":"s-1","source":{"kind":"generation","id":"g-1"}}`), &s))
+		require.NotNil(t, s.Source)
+		assert.Equal(t, "generation", s.Source.Kind)
+		assert.Equal(t, "g-1", s.Source.ID)
+	})
+
+	t.Run("no provenance leaves Source nil", func(t *testing.T) {
+		var s scores.Score
+		require.NoError(t, json.Unmarshal([]byte(`{"score_id":"s-1"}`), &s))
+		assert.Nil(t, s.Source)
+	})
+}
 
 func TestScoreValue_Display(t *testing.T) {
 	f := func(v float64) *float64 { return &v }


### PR DESCRIPTION
## Summary
- Add `gcx agento11y rules list-scores <rule-id>` to fetch online evaluation score rows from `GET /eval/rules/{rule_id}/scores`
- Support full filter parity (evaluator, pass/fail, time range, agent/model/provider, score value, min/max, sort, limit) and table/wide/json/yaml output, with the list envelope (`{"items": [...], "list_meta": {...}}`) so truncation rides in-band, and a 1000-row client-side safety cap on `--limit 0`
- Extend score types with rule-scores metadata (conversation title, agent, model, provider) and document the command in CLI reference and the agento11y skill

## Scope note
- This PR is **purely additive** — it adds the new `rules list-scores` command and leaves the shipped `generations list-scores` command untouched. An earlier revision changed `generations list-scores`'s `--limit` from page-size-with-drain to a real cap; that is a v1.x frozen-surface change per CONSTITUTION.md and was pulled out per review. It will land separately with a release note (see Follow-ups). `generations list-scores` in this branch is byte-identical to `main`.

## Test plan
- [x] `go test ./internal/providers/agento11y/scores/...`
- [x] `go test ./cmd/gcx/root/... -run 'Consistency|SkillsGcx'`
- [x] `mise run lint`
- [x] `mise run gate`
- [x] `GCX_AGENT_MODE=false mise run reference`
- [ ] Manual: `./bin/gcx agento11y rules list-scores <rule-id> --passed=false -o json` against a stack with online eval traffic
- [ ] Manual: confirm the real `/eval/rules/{id}/scores` wire keys for `gen_model` and `gen_provider` (no sibling precedent — `experiments.ScoreItem` carries `source_kind`/`source_id`/`agent_name` but no model/provider). If the keys differ, the `MODEL` column in `-o wide` renders `-` and `--model`/`--provider` silently filter nothing.

## Deliberately not fixed here (with rationale)
This came up in review and is intentionally left out of this PR — it is shared infrastructure, and folding it in would widen the blast radius beyond "add `rules list-scores`". Filing as a follow-up keeps the decision reviewable on its own.

- **Truncation continuation can suggest a `--limit` above the 1000-row safety cap.** For a `list-scores --limit N` with `N` roughly in (500, 1000) and more than 1000 matching rows, the "see more with `--limit 2N`" hint proposes a limit the cap silently reduces back to 1000 (a two-step discovery; the data is never wrong). The doubling is produced by the shared `internal/output` helpers (`BuildListLimitCommand` / `listContinueCommand`), which don't know about a per-command cap — `irm oncall alert-groups list` uses the same helper and has the same behavior. Fixing it means teaching the shared helper to clamp the continuation to the cap, which affects every command that uses it; that belongs in its own change, not a feature PR.

## Follow-ups (out of scope)
- Give `generations list-scores` a real `--limit` cap (default page behavior currently drains all pages) as its own PR with a release note, since it changes a v1.0.0 flag behavior — pulled out of this PR per review.
- `experiments list-scores` and `experiments trials list-scores` still cap silently and treat negative `--limit` as "no limit"; converging the whole `list-scores` family onto the standard limit/truncation contract is worth a separate change.
- Clamp the shared list-truncation continuation hint to a command's safety cap (see "Deliberately not fixed here").

Made with [Cursor](https://cursor.com)
