### PR TITLE
docs(skills): teach add-datasource the shared raw-SQL contract

### DIFF
--- a/.claude/skills/add-datasource/SKILL.md
+++ b/.claude/skills/add-datasource/SKILL.md
@@ -161,8 +161,8 @@ types. Do not duplicate that logic or re-declare
 shared too** — `querysql.BuildRawQueryBody` and `querysql.EnforceLimit` with a
 dialect-local `bail` predicate, never a hand-rolled clamp. Read
 `references/raw-sql.md` before writing either: it carries the plugin-`format`
-exception, the stderr disclosure `capped` owes the caller, and the four bail
-traps that have each cost a real PR a review round.
+exception, the stderr disclosure `capped` owes the caller, the four statement
+shapes `bail` has to catch, and which of the existing dialects is safe to copy.
 
 **Pick the client shape from what your commands actually call — there are three,
 and the middle one is the common case.** The two transports are not alternatives:

--- a/.claude/skills/add-datasource/SKILL.md
+++ b/.claude/skills/add-datasource/SKILL.md
@@ -157,6 +157,13 @@ types. Do not duplicate that logic or re-declare
 `GrafanaQueryResponse`/`DataFrame`. Check the current set with
 `grep -rl query/grafanaquery internal/query/` and copy the closest one.
 
+**If the datasource takes raw SQL, the request body and `--limit` enforcement are
+shared too** — `querysql.BuildRawQueryBody` and `querysql.EnforceLimit` with a
+dialect-local `bail` predicate, never a hand-rolled clamp. Read
+`references/raw-sql.md` before writing either: it carries the plugin-`format`
+exception, the stderr disclosure `capped` owes the caller, and the four bail
+traps that have each cost a real PR a review round.
+
 **Pick the client shape from what your commands actually call — there are three,
 and the middle one is the common case.** The two transports are not alternatives:
 unified query is a POST to `/apis/query.grafana.app/.../query`, while label,

--- a/.claude/skills/add-datasource/references/raw-sql.md
+++ b/.claude/skills/add-datasource/references/raw-sql.md
@@ -2,63 +2,74 @@
 
 For a datasource whose `query` leaf takes raw SQL (postgres, mysql, athena,
 clickhouse and any future dialect). Read this before writing the client's
-request builder or `--limit` handling — both pieces are shared, and hand-rolling
-either is what turns a mechanical PR into three review rounds.
+request builder or `--limit` handling — both pieces are shared.
+
+**Copy postgres or mysql.** Step 1's advice to copy the closest existing client
+needs a caveat here: athena and clickhouse predate the rules below. Neither
+validates `--limit`, and both drop the `capped` flag the shared helper returns
+(`internal/query/athena/types.go`, `internal/query/clickhouse/types.go` both do
+`out, _ :=`), so they truncate silently. Their custom body builders are
+legitimate — see the exception below — but their limit handling is not the model.
 
 ## Request body
 
-Build the unified-query body with
+Build the query body with
 `querysql.BuildRawQueryBody(pluginID, datasourceUID, req)`. Do not write a
 per-dialect body builder: the bodies differ only in plugin ID and are otherwise
-identical, so a copy is dead weight the next dialect copies again.
+identical.
 
-The exception is a plugin that needs more than the shared body models, and there
-are two ways to qualify: a non-string `format` (ClickHouse and Athena both send a
-number), or extra request fields (Athena also carries `connectionArgs` for
-region, catalog and database). Either one earns a dialect builder — check both
-before assuming you can reuse. Say in the PR which case you are in, so a
-reviewer does not have to diff the two to find out.
+However, if a datasource needs a non-string `format` argument (ClickHouse and
+Athena both send a number), or extra request fields (Athena also has
+`connectionArgs`), use a custom query builder. If you do this, point it out in
+the PR description.
 
-The resulting split inside `internal/query/sql` is: response parsing, table
-formatting, LIMIT clamping and the raw-SQL request body shared; schema
-discovery, the dialect's own `bail` rules, and any body the shared builder cannot
-model local. The package doc on `types.go` states the same split — if the two
-ever disagree, the code is right and the doc needs fixing.
+That leaves `internal/query/sql` holding what the dialects share — response
+parsing, table formatting, LIMIT clamping, and the request body — while each
+dialect package keeps its schema discovery, its `bail` rules, and a custom body
+if it needs one. The package doc on `types.go` says the same thing; if the two
+ever disagree, believe the code.
 
 ## Limit enforcement
 
-`--limit` is `querysql.EnforceLimit(sql, limit, maxLimit, bail)` with a
-dialect-local `bail` predicate. Never a hand-rolled clamp, and never a silent
-one:
+Enforce `--limit` with `querysql.EnforceLimit(sql, limit, maxLimit, bail)` and a
+dialect-local `bail` predicate. Two things make that a contract rather than a
+clamp, and `internal/datasources/postgres/query.go` models both:
 
 - Reject a negative `--limit` in `Validate()`, before any query runs.
-- Return the `capped` bool from the dialect wrapper and warn on stderr when an
-  explicit `LIMIT` above `maxLimit` was lowered. Silently truncating a bound the
-  caller wrote themselves is a completeness defect — see
-  `.claude/skills/integrate-with-gcx/references/self-review.md` T3 for the
-  disclosure rule and for why a stderr hint is sufficient here.
+- Take the `capped` bool the helper returns and warn on stderr when it is true.
+  The caller's own `LIMIT` was lowered to `maxLimit`, and they should hear about
+  it from the command that did it.
+
+Handing back fewer rows than asked for without saying so is a completeness
+defect — T3 in `.claude/skills/integrate-with-gcx/references/self-review.md`.
+A stderr warning discharges it here because `docs/design/output.md` §15 is
+PROPOSED and opt-in, not because this shape earns lighter treatment:
+`QueryResponse{columns, rows}` is envelope-shaped, and T3's table would ask an
+envelope for `list_meta` in the payload if §15 were binding.
 
 ## The bail predicate
 
 `bail` decides which statements never get a `LIMIT` suffix. It must return true
-for every shape where appending one changes the statement's meaning instead of
-bounding it. Each trap below has shipped as a review finding on a real PR:
+for every statement where appending one changes what the statement *means*
+rather than bounding what it returns. Each row below has shipped as a review
+finding on a real PR:
 
-| Trap | What breaks |
-|------|-------------|
-| Statement-start allow-list | Allow-list the SELECT-shaped starts rather than bailing on a keyword list. MySQL accepts `LIMIT` on single-table `UPDATE`/`DELETE`, so a leaky allow-list silently restricts a write; and a line-anchored bail entry misfires on formatted queries (`ORDER BY x\nDESC`) |
-| Keyword-vs-function ambiguity | MySQL's `REPLACE` is both a write statement and its most common string function. RE2 has no lookahead, so tell them apart by position — a write's keyword is never followed by `(` |
-| Trailing line comment | A suffix appended after `--`/`#` lands *inside* the comment and is dropped, leaving the query unbounded. Match the dialect's exact comment-start rule, including the degenerate bare `--`: a pattern that is too tight there turns an invalid query into an unbounded scan |
-| Dialect offset syntax | `LIMIT a, b`, `OFFSET n`, `FOR UPDATE`, `INTO OUTFILE` — a second `LIMIT` is a syntax error or a semantic change |
+| Statement shape | Why a LIMIT suffix breaks it |
+|---|---|
+| A write or a metadata statement | MySQL accepts `LIMIT` on single-table `UPDATE`/`DELETE`, so a suffix restricts a write instead of a read. Allow-list the SELECT-shaped starts rather than listing keywords to avoid — a line-anchored keyword bail also misfires on formatted queries, where `DESC` can begin a line of its own |
+| A keyword that is also a function | MySQL's `REPLACE` is both a write statement and its most common string function. RE2 has no lookahead, so separate them by position: a write's `REPLACE` is never followed by `(` |
+| A statement ending in a line comment | The suffix lands inside the `--`/`#` comment and never reaches the server, leaving the query unbounded. Match the dialect's exact comment-start rule, including a bare `--` with nothing after it |
+| A limit the dialect spells another way | `LIMIT a, b`, `OFFSET n`, `FOR UPDATE`, `INTO OUTFILE` — a second `LIMIT` is either a syntax error or a change in meaning |
 
-Test each entry by asserting the SQL that comes out, not just that something
-bailed. A test that only checks "unchanged" passes for the wrong reason when the
-allow-list rejected the statement before `bail` ever ran.
+Test each row by asserting the SQL that comes out, not just that the statement
+came back untouched. "Unchanged" can pass for the wrong reason: if the
+SELECT-shaped allow-list rejected the statement first, `bail` never ran, and the
+test proves nothing about the case it is named after.
 
 ## Keep it proportionate
 
 The row cap is a convenience bound, not a security control — `grafanaquery`'s
-response-size limiting is the real backstop. So a `bail` that fails open on row
-count is acceptable where one that mangles a statement is not, and there is no
-need to grow the regex until it parses SQL. Say which way each entry fails in the
-comment beside it: "fails safe" is true for writes and false for reads.
+response-size limiting is the real backstop. Prefer a `bail` that fails open on
+row count over one that mangles a statement. There is no need to grow the regex
+until it parses SQL. Say which way each entry fails in the comment beside it:
+"fails safe" is true for writes and false for reads.

--- a/.claude/skills/add-datasource/references/raw-sql.md
+++ b/.claude/skills/add-datasource/references/raw-sql.md
@@ -1,0 +1,64 @@
+# Raw SQL dialects
+
+For a datasource whose `query` leaf takes raw SQL (postgres, mysql, athena,
+clickhouse and any future dialect). Read this before writing the client's
+request builder or `--limit` handling — both pieces are shared, and hand-rolling
+either is what turns a mechanical PR into three review rounds.
+
+## Request body
+
+Build the unified-query body with
+`querysql.BuildRawQueryBody(pluginID, datasourceUID, req)`. Do not write a
+per-dialect body builder: the bodies differ only in plugin ID and are otherwise
+identical, so a copy is dead weight the next dialect copies again.
+
+The exception is a plugin that needs more than the shared body models, and there
+are two ways to qualify: a non-string `format` (ClickHouse and Athena both send a
+number), or extra request fields (Athena also carries `connectionArgs` for
+region, catalog and database). Either one earns a dialect builder — check both
+before assuming you can reuse. Say in the PR which case you are in, so a
+reviewer does not have to diff the two to find out.
+
+The resulting split inside `internal/query/sql` is: response parsing, table
+formatting, LIMIT clamping and the raw-SQL request body shared; schema
+discovery, the dialect's own `bail` rules, and any body the shared builder cannot
+model local. The package doc on `types.go` states the same split — if the two
+ever disagree, the code is right and the doc needs fixing.
+
+## Limit enforcement
+
+`--limit` is `querysql.EnforceLimit(sql, limit, maxLimit, bail)` with a
+dialect-local `bail` predicate. Never a hand-rolled clamp, and never a silent
+one:
+
+- Reject a negative `--limit` in `Validate()`, before any query runs.
+- Return the `capped` bool from the dialect wrapper and warn on stderr when an
+  explicit `LIMIT` above `maxLimit` was lowered. Silently truncating a bound the
+  caller wrote themselves is a completeness defect — see
+  `.claude/skills/integrate-with-gcx/references/self-review.md` T3 for the
+  disclosure rule and for why a stderr hint is sufficient here.
+
+## The bail predicate
+
+`bail` decides which statements never get a `LIMIT` suffix. It must return true
+for every shape where appending one changes the statement's meaning instead of
+bounding it. Each trap below has shipped as a review finding on a real PR:
+
+| Trap | What breaks |
+|------|-------------|
+| Statement-start allow-list | Allow-list the SELECT-shaped starts rather than bailing on a keyword list. MySQL accepts `LIMIT` on single-table `UPDATE`/`DELETE`, so a leaky allow-list silently restricts a write; and a line-anchored bail entry misfires on formatted queries (`ORDER BY x\nDESC`) |
+| Keyword-vs-function ambiguity | MySQL's `REPLACE` is both a write statement and its most common string function. RE2 has no lookahead, so tell them apart by position — a write's keyword is never followed by `(` |
+| Trailing line comment | A suffix appended after `--`/`#` lands *inside* the comment and is dropped, leaving the query unbounded. Match the dialect's exact comment-start rule, including the degenerate bare `--`: a pattern that is too tight there turns an invalid query into an unbounded scan |
+| Dialect offset syntax | `LIMIT a, b`, `OFFSET n`, `FOR UPDATE`, `INTO OUTFILE` — a second `LIMIT` is a syntax error or a semantic change |
+
+Test each entry by asserting the SQL that comes out, not just that something
+bailed. A test that only checks "unchanged" passes for the wrong reason when the
+allow-list rejected the statement before `bail` ever ran.
+
+## Keep it proportionate
+
+The row cap is a convenience bound, not a security control — `grafanaquery`'s
+response-size limiting is the real backstop. So a `bail` that fails open on row
+count is acceptable where one that mangles a statement is not, and there is no
+need to grow the regex until it parses SQL. Say which way each entry fails in the
+comment beside it: "fails safe" is true for writes and false for reads.

--- a/internal/query/sql/request.go
+++ b/internal/query/sql/request.go
@@ -7,10 +7,11 @@ import (
 	"time"
 )
 
-// RawQueryRequest is a raw-SQL query request, shared by the dialects (e.g.
-// postgres, mysql) whose Grafana datasource plugin expects a plain string
-// "format" value. ClickHouse's sqlds-based plugin sends a numeric format
-// instead and builds its own body rather than using this helper.
+// RawQueryRequest is a raw-SQL query request, shared by the dialects (postgres,
+// mysql) whose Grafana datasource plugin expects a plain string "format" value.
+// ClickHouse and Athena both send a numeric format instead, and Athena also
+// carries connectionArgs, so both build their own body rather than using this
+// helper.
 type RawQueryRequest struct {
 	RawSQL     string
 	Start      time.Time

--- a/internal/query/sql/types.go
+++ b/internal/query/sql/types.go
@@ -1,6 +1,6 @@
 // Package sql holds the shared building blocks for SQL-style Grafana datasources
-// (ClickHouse, Athena, …) that query via Grafana's unified datasource query API
-// and render row-oriented results. The common response shape, table formatting,
+// (postgres, mysql, ClickHouse, Athena) that query via Grafana's unified
+// datasource query API and render row-oriented results. The common response shape, table formatting,
 // response parsing, LIMIT clamping, and the raw-SQL request body live here.
 // Dialect packages keep their schema discovery and LIMIT bail rules, and build
 // their own request body when the plugin needs more than BuildRawQueryBody

--- a/internal/query/sql/types.go
+++ b/internal/query/sql/types.go
@@ -1,8 +1,11 @@
 // Package sql holds the shared building blocks for SQL-style Grafana datasources
 // (ClickHouse, Athena, …) that query via Grafana's unified datasource query API
-// and render row-oriented results. Dialect packages keep their own request
-// construction, schema discovery, and LIMIT bail rules; the common response
-// shape, table formatting, response parsing, and LIMIT clamping live here.
+// and render row-oriented results. The common response shape, table formatting,
+// response parsing, LIMIT clamping, and the raw-SQL request body live here.
+// Dialect packages keep their schema discovery and LIMIT bail rules, and build
+// their own request body when the plugin needs more than BuildRawQueryBody
+// models: a non-string "format" (ClickHouse, Athena) or extra fields such as
+// Athena's connectionArgs.
 package sql
 
 import (


### PR DESCRIPTION
The `add-datasource` skill named `grafanaquery` and `dataframe` as the shared pieces to reuse, but said nothing about the two things every SQL dialect actually has to get right: building the unified-query request body, and enforcing `--limit`. So both dialects added so far hand-rolled them, and #969 and #970 each spent three review rounds on the same class of bug — `REPLACE(col,'a','b')` read as a write and silently disabling enforcement, a trailing line comment swallowing the appended LIMIT, a line-anchored `DESC` bail firing on a formatted `ORDER BY`. Same defects, same fixes, twice, because there was nothing to reuse from.

This adds `references/raw-sql.md`: the shared body builder and the plugin-`format` exception that keeps ClickHouse on its own builder, the `EnforceLimit` contract including rejecting a negative `--limit` in `Validate()` and the stderr warning that `capped` owes the caller, and the four bail traps with what each one actually breaks. Plus a note on proportionality, since the row cap is a convenience bound with `grafanaquery`'s response-size limiting behind it — failing open on row count is fine, mangling a statement is not, and the regex doesn't need to grow into a SQL parser.

The detail sits in a reference file rather than in SKILL.md because SKILL.md was already 483 lines and inlining this took it to 516, past the 500-line progressive-disclosure guideline. Only SQL dialects need it, which is what `references/` is for — same shape as `add-provider` and `integrate-with-gcx`. Step 1 gets a seven-line pointer. The completeness half points at `integrate-with-gcx` self-review T3 rather than restating the disclosure rule, so there's one home for it and no chance of the two drifting apart.

It also fixes the package doc on `internal/query/sql/types.go`, which is the one code change here. #970 added `BuildRawQueryBody` to that package but left the doc saying "Dialect packages keep their own request construction" — half true now, since postgres and mysql call the shared builder while ClickHouse and Athena legitimately don't. Leaving it points the next author the wrong way, which is the same rot this PR is trying to stop, and it would be strange to assert the split in a skill while the package it describes says something else. The doc now names the real rule: a body of your own when the plugin needs more than the shared one models — a non-string `format`, or extra fields like Athena's `connectionArgs`.

`mise run validate-skills` and `TestSkillsGcxInvocationsMatchCommandTree` both pass. Docs-only, no command or flag changes, so nothing to regenerate.
