### PR TITLE
feat(install): support main branch builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ Downloads the latest release, verifies the SHA-256 checksum, and installs to
 curl -fsSL https://raw.githubusercontent.com/grafana/gcx/main/scripts/install.sh | GCX_INSTALL_DIR=/usr/local/bin sh
 ```
 
+To build and install the latest commit from `main`, use `GCX_VERSION=main`.
+This requires a Go toolchain:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/grafana/gcx/main/scripts/install.sh | GCX_VERSION=main sh
+```
+
 To upgrade, run the same command again, then check `gcx --version`. If the
 version does not change, you have a second `gcx` earlier in your `PATH` — run
 `which -a gcx` and see

--- a/docs/sources/installation.md
+++ b/docs/sources/installation.md
@@ -46,7 +46,7 @@ Use these environment variables to customize the install script:
 | Environment variable | Default | Description |
 |----------------------|---------|-------------|
 | `GCX_INSTALL_DIR` | `$HOME/.local/bin` | Directory to install the binary into |
-| `GCX_VERSION` | latest | Specific version to install (e.g., `0.2.4`) |
+| `GCX_VERSION` | latest | Version to install (e.g., `0.2.4`), or `main` to build the main branch with Go |
 | `GITHUB_TOKEN` | unset | GitHub token for API requests (avoids rate limits) |
 
 The script also accepts `INSTALL_DIR` and `VERSION`. The `GCX_` names take
@@ -59,6 +59,12 @@ Install a specific version:
 
 ```sh
 curl -fsSL https://raw.githubusercontent.com/grafana/gcx/main/scripts/install.sh | GCX_VERSION=0.2.4 sh
+```
+
+Install the latest commit from the main branch (requires a Go toolchain):
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/grafana/gcx/main/scripts/install.sh | GCX_VERSION=main sh
 ```
 
 Install to `/usr/local/bin`:
@@ -189,5 +195,4 @@ codesign --sign - --force "$(command -v gcx)"   # required on Apple Silicon
 Next, run `gcx --version` again; subsequent invocations should succeed without the block. 
 
 Note that these steps will no longer be necessary once `gcx` release binaries are Apple-notarised.
-
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,7 +6,8 @@
 #
 # Environment variables:
 #   GCX_INSTALL_DIR  Directory to install into (default: $HOME/.local/bin)
-#   GCX_VERSION      Specific version to install, without v prefix (default: latest)
+#   GCX_VERSION      Version to install, or "main" to build the main branch
+#                    with Go (default: latest release)
 #   GITHUB_TOKEN     GitHub token for API requests (avoids rate limits)
 #
 # INSTALL_DIR and VERSION still work. The GCX_ names take precedence, because
@@ -230,10 +231,21 @@ verify_checksum() {
     fi
 }
 
-main() {
-    need_cmd curl
-    need_cmd tar
+install_main() {
+    output_dir="$1"
 
+    need_cmd go
+    mkdir -p "$output_dir"
+    info "Building ${BINARY_NAME} from the main branch..."
+    GOBIN="$output_dir" go install "github.com/${GITHUB_REPO}/cmd/${BINARY_NAME}@main" ||
+        err "Failed to build ${BINARY_NAME} from the main branch. Check network access and your Go toolchain."
+
+    if [ ! -x "${output_dir}/${BINARY_NAME}" ]; then
+        err "The main branch build did not produce ${output_dir}/${BINARY_NAME}."
+    fi
+}
+
+main() {
     os=$(detect_os)
     arch=$(detect_arch)
 
@@ -248,6 +260,7 @@ main() {
     if [ -n "$requested_version" ]; then
         version="${requested_version#v}"
     else
+        need_cmd curl
         info "Fetching latest release..."
         version=$(get_latest_version)
     fi
@@ -261,26 +274,33 @@ main() {
     tmpdir=$(mktemp -d)
     trap 'rm -rf "$tmpdir"' EXIT
 
-    # Download archive and checksums.
-    info "Downloading ${archive}..."
-    curl -fsSL "${base_url}/${archive}" -o "${tmpdir}/${archive}" ||
-        err "Failed to download ${base_url}/${archive}"
+    if [ "$version" = "main" ]; then
+        install_main "$tmpdir"
+    else
+        need_cmd curl
+        need_cmd tar
 
-    checksums_file="${BINARY_NAME}_${version}_checksums.txt"
-    curl -fsSL "${base_url}/${checksums_file}" -o "${tmpdir}/${checksums_file}" ||
-        err "Failed to download checksums file."
+        # Download archive and checksums.
+        info "Downloading ${archive}..."
+        curl -fsSL "${base_url}/${archive}" -o "${tmpdir}/${archive}" ||
+            err "Failed to download ${base_url}/${archive}"
 
-    # Verify checksum.
-    expected=$(grep "${archive}" "${tmpdir}/${checksums_file}" | cut -d' ' -f1)
-    if [ -z "$expected" ]; then
-        err "Archive ${archive} not found in checksums file."
+        checksums_file="${BINARY_NAME}_${version}_checksums.txt"
+        curl -fsSL "${base_url}/${checksums_file}" -o "${tmpdir}/${checksums_file}" ||
+            err "Failed to download checksums file."
+
+        # Verify checksum.
+        expected=$(grep "${archive}" "${tmpdir}/${checksums_file}" | cut -d' ' -f1)
+        if [ -z "$expected" ]; then
+            err "Archive ${archive} not found in checksums file."
+        fi
+        verify_checksum "${tmpdir}/${archive}" "$expected"
+        info "Checksum verified."
+
+        # Extract binary.
+        tar xzf "${tmpdir}/${archive}" -C "${tmpdir}" "${BINARY_NAME}" ||
+            err "Failed to extract ${BINARY_NAME} from archive."
     fi
-    verify_checksum "${tmpdir}/${archive}" "$expected"
-    info "Checksum verified."
-
-    # Extract binary.
-    tar xzf "${tmpdir}/${archive}" -C "${tmpdir}" "${BINARY_NAME}" ||
-        err "Failed to extract ${BINARY_NAME} from archive."
 
     # Install binary.
     mkdir -p "$install_dir"

--- a/scripts/install_test.sh
+++ b/scripts/install_test.sh
@@ -61,6 +61,20 @@ make_fake_gcx() {
 	chmod +x "$dir/gcx"
 }
 
+# Write a fake go command that records its arguments and produces the binary
+# where go install would place it.
+make_fake_go() {
+	local dir=$1
+	mkdir -p "$dir"
+	cat >"$dir/go" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >"$GO_ARGS_LOG"
+printf '#!/bin/sh\necho "gcx version main"\n' >"$GOBIN/gcx"
+chmod +x "$GOBIN/gcx"
+EOF
+	chmod +x "$dir/go"
+}
+
 # Source the script. GCX_INSTALL_SH_LIB stops it from running main.
 export GCX_INSTALL_SH_LIB=1
 # shellcheck source=install.sh
@@ -125,6 +139,52 @@ test_removal_command_uses_brew() {
 test_removal_command_uses_rm() {
 	assert_eq "rm /usr/local/bin/gcx" "$(removal_command /usr/local/bin/gcx)" \
 		"removal_command names rm for a plain path"
+}
+
+# ── main branch install ───────────────────────────────────────────────────────────────────────────
+
+test_install_main_builds_main_ref() {
+	local tmp args
+	tmp=$(mktemp -d)
+	make_fake_go "$tmp/bin"
+
+	GO_ARGS_LOG="$tmp/go-args" PATH="$tmp/bin:$SYS_PATH" install_main "$tmp/output"
+	args=$(cat "$tmp/go-args")
+
+	assert_eq "install github.com/grafana/gcx/cmd/gcx@main" "$args" \
+		"install_main builds the gcx main branch"
+	if [[ -x "$tmp/output/gcx" ]]; then
+		pass "install_main produces an executable gcx binary"
+	else
+		fail "install_main produces an executable gcx binary"
+	fi
+	rm -rf "$tmp"
+}
+
+test_main_dispatches_main_to_source_build() {
+	local tmp out args
+	tmp=$(mktemp -d)
+	make_fake_go "$tmp/bin"
+
+	out=$(
+		GCX_VERSION=main \
+			GCX_INSTALL_DIR="$tmp/install" \
+			GO_ARGS_LOG="$tmp/go-args" \
+			PATH="$tmp/bin:$SYS_PATH" \
+			main
+	)
+	args=$(cat "$tmp/go-args")
+
+	assert_eq "install github.com/grafana/gcx/cmd/gcx@main" "$args" \
+		"GCX_VERSION=main selects the source build"
+	assert_contains "$out" "Installed: gcx version main" \
+		"the main branch build is installed and verified"
+	if [[ -x "$tmp/install/gcx" ]]; then
+		pass "GCX_VERSION=main installs gcx in GCX_INSTALL_DIR"
+	else
+		fail "GCX_VERSION=main installs gcx in GCX_INSTALL_DIR"
+	fi
+	rm -rf "$tmp"
 }
 
 # ── report_resolution ────────────────────────────────────────────────────────
@@ -228,6 +288,8 @@ test_resolve_skips_non_executable
 test_resolve_reports_absence
 test_removal_command_uses_brew
 test_removal_command_uses_rm
+test_install_main_builds_main_ref
+test_main_dispatches_main_to_source_build
 test_report_warns_on_shadow
 test_report_is_quiet_when_install_dir_wins
 test_report_is_quiet_on_a_plain_reinstall


### PR DESCRIPTION
## Summary

- support `GCX_VERSION=main` by building `github.com/grafana/gcx/cmd/gcx@main` with Go
- preserve checksum-verified release downloads for tagged versions
- add installer coverage and document the new install option

## Verification

- real `GCX_VERSION=main` smoke install
- `mise run tests`
- `GOLANGCI_LINT_CACHE=<isolated-cache> mise run lint`
- `GCX_AGENT_MODE=false mise run docs`