### PR TITLE
chore(release): v1.2.0 changelog

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
       "name": "gcx",
       "source": "./claude-plugin",
       "description": "Debug, explore, and instrument with Grafana using gcx CLI",
-      "version": "1.1.1"
+      "version": "1.2.0"
     }
   ]
 }

--- a/.release-notes.md
+++ b/.release-notes.md
@@ -1,15 +1,14 @@
-```markdown
-- Add Database Observability provider: `gcx dbo11y instances list` and `get` (#1199)
-- Regenerate the CLI reference to cover the new dbo11y commands (#1239)
-- A locked keychain now reports its own clear, fatal error (#1142)
-- New keychain reference docs cover setup and troubleshooting
+**Breaking changes**
+- A locked OS keychain is now its own fatal failure class (`Keychain locked`). gcx stops credential-consuming commands instead of falling back to a plaintext write, and the error explains how to unlock the keychain for the session (#1142)
 - Remove the broken `gcx assistant dashboard` subcommand (#1230)
-- Fix the duplicated `--agent-id` default in assistant help text (#1232)
-- Teach the add-datasource skill the shared raw-SQL contract (#1227)
-- Bump create-github-app-token to 0.3.1 and tune CI review (#1236, #1217)
-```
 
-Two notes on judgement calls:
+**New features**
+- Add the Database Observability provider: `gcx dbo11y instances list` and `gcx dbo11y instances get <name>` (#1199)
 
-- The dbo11y doc regen (#1239) is arguably internal noise for a user-facing changelog — I kept it because it's the only signal that reference docs now exist for the new commands. Drop it if your changelog is strictly behavioural.
-- The keychain docs bullet has no PR number in your list; it comes from the `docs/reference/configuration/keychain.md` + `docs/sources/keychain.md` additions in the diffstat, which look like they rode along with #1142. Worth confirming before publishing.
+**Fixes**
+- Remove the duplicated `--agent-id` default from assistant help text (#1232)
+
+**Other**
+- Add keychain setup and troubleshooting reference docs (#1142)
+- Teach the `add-datasource` skill the shared raw-SQL contract (#1227)
+- Bump `create-github-app-token` to 0.3.1 and tune the CI review process (#1236, #1217)

--- a/.release-notes.md
+++ b/.release-notes.md
@@ -1,30 +1,15 @@
-**Datasources**
-- Add support for the MySQL and Postgres datasources (#970, #969)
-- Add support for the Elasticsearch datasource (#971)
-- Add support for Azure Monitor and Google Cloud Monitoring (#965, #974)
-- Restructure the generic query router to keep it simple (#1141)
-- Add the experimental `gcx traces diff` command (#1165)
+```markdown
+- Add Database Observability provider: `gcx dbo11y instances list` and `get` (#1199)
+- Regenerate the CLI reference to cover the new dbo11y commands (#1239)
+- A locked keychain now reports its own clear, fatal error (#1142)
+- New keychain reference docs cover setup and troubleshooting
+- Remove the broken `gcx assistant dashboard` subcommand (#1230)
+- Fix the duplicated `--agent-id` default in assistant help text (#1232)
+- Teach the add-datasource skill the shared raw-SQL contract (#1227)
+- Bump create-github-app-token to 0.3.1 and tune CI review (#1236, #1217)
+```
 
-**Providers**
-- Add notification commands to the knowledge graph provider (#1077)
-- Add `gcx irm incidents get-pir` for post-incident reviews (#1163)
-- Report `otlpIngestEndpointURL` from frontend applications (#1223)
+Two notes on judgement calls:
 
-**Login and configuration**
-- Add `--oauth-manual` for hosts without a reachable callback (#1136)
-- Let environment credentials override a keychain failure (#1066)
-- Scope `gcx config check` to one explicit context (#1155)
-
-**Fixes**
-- Include `otlp_url` and `otlp_username` in the cluster configuration (#1198)
-- Correct the order of dashboards in the output (#1201)
-
-**Performance**
-- Build the discovery registry one time (#925)
-- Limit the parallel fan-out in resource commands (#925)
-
-**Other**
-- Detect the pi coding agent harness for agent mode (#1208)
-- Report the batch resource volume as size buckets (#1108)
-- Add a Grafana version support policy to the documentation (#1197)
-- Regenerate the command line interface reference (#1224)
+- The dbo11y doc regen (#1239) is arguably internal noise for a user-facing changelog — I kept it because it's the only signal that reference docs now exist for the new commands. Drop it if your changelog is strictly behavioural.
+- The keychain docs bullet has no PR number in your list; it comes from the `docs/reference/configuration/keychain.md` + `docs/sources/keychain.md` additions in the diffstat, which look like they rode along with #1142. Worth confirming before publishing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,20 +1,19 @@
 ## v1.2.0 (2026-08-25)
 
-```markdown
-- Add Database Observability provider: `gcx dbo11y instances list` and `get` (#1199)
-- Regenerate the CLI reference to cover the new dbo11y commands (#1239)
-- A locked keychain now reports its own clear, fatal error (#1142)
-- New keychain reference docs cover setup and troubleshooting
+**Breaking changes**
+- A locked OS keychain is now its own fatal failure class (`Keychain locked`). gcx stops credential-consuming commands instead of falling back to a plaintext write, and the error explains how to unlock the keychain for the session (#1142)
 - Remove the broken `gcx assistant dashboard` subcommand (#1230)
-- Fix the duplicated `--agent-id` default in assistant help text (#1232)
-- Teach the add-datasource skill the shared raw-SQL contract (#1227)
-- Bump create-github-app-token to 0.3.1 and tune CI review (#1236, #1217)
-```
 
-Two notes on judgement calls:
+**New features**
+- Add the Database Observability provider: `gcx dbo11y instances list` and `gcx dbo11y instances get <name>` (#1199)
 
-- The dbo11y doc regen (#1239) is arguably internal noise for a user-facing changelog — I kept it because it's the only signal that reference docs now exist for the new commands. Drop it if your changelog is strictly behavioural.
-- The keychain docs bullet has no PR number in your list; it comes from the `docs/reference/configuration/keychain.md` + `docs/sources/keychain.md` additions in the diffstat, which look like they rode along with #1142. Worth confirming before publishing.
+**Fixes**
+- Remove the duplicated `--agent-id` default from assistant help text (#1232)
+
+**Other**
+- Add keychain setup and troubleshooting reference docs (#1142)
+- Teach the `add-datasource` skill the shared raw-SQL contract (#1227)
+- Bump `create-github-app-token` to 0.3.1 and tune the CI review process (#1236, #1217)
 
 
 ## v1.1.1 (2026-08-24)
@@ -50,20 +49,6 @@ Two notes on judgement calls:
 - Add a Grafana version support policy to the documentation (#1197)
 - Regenerate the command line interface reference (#1224)
 
-
-## Unreleased
-
-### Breaking changes
-
-- credentials: a locked OS keychain is now a separate, fatal failure class (`Keychain locked`). gcx stops credential-consuming commands instead of using or writing a plaintext fallback, and the error explains how to unlock the keychain in the current session. Previously an `org.freedesktop.Secret.Error.IsLocked` response and macOS locked or interaction-disabled statuses counted as an unavailable keychain, which permitted a plaintext write. An unlock failure in a headless Secret Service session was already fatal, but reported only the raw library message.
-
-### New features
-
-- Record the size of batch resource operations (`resources push`, `pull`, `delete`, `validate`) in usage telemetry events, as fixed size categories rather than counts, alongside whether the operation ran in dry-run mode. The first-run telemetry notice is revised to cover this and is shown again on installs that already saw the previous wording. See [Anonymous usage statistics](https://grafana.com/docs/grafana/latest/as-code/observability-as-code/grafana-cli/gcx/anonymous-usage-statistics/).
-
-### Fixes
-
-- instrumentation: app and service writes (`clusters apps configure`/`remove`, `services include`/`exclude`/`clear`) no longer fail with `otlp_url is required`.
 
 ## v1.1.0 (2026-08-14)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## v1.2.0 (2026-08-25)
+
+```markdown
+- Add Database Observability provider: `gcx dbo11y instances list` and `get` (#1199)
+- Regenerate the CLI reference to cover the new dbo11y commands (#1239)
+- A locked keychain now reports its own clear, fatal error (#1142)
+- New keychain reference docs cover setup and troubleshooting
+- Remove the broken `gcx assistant dashboard` subcommand (#1230)
+- Fix the duplicated `--agent-id` default in assistant help text (#1232)
+- Teach the add-datasource skill the shared raw-SQL contract (#1227)
+- Bump create-github-app-token to 0.3.1 and tune CI review (#1236, #1217)
+```
+
+Two notes on judgement calls:
+
+- The dbo11y doc regen (#1239) is arguably internal noise for a user-facing changelog — I kept it because it's the only signal that reference docs now exist for the new commands. Drop it if your changelog is strictly behavioural.
+- The keychain docs bullet has no PR number in your list; it comes from the `docs/reference/configuration/keychain.md` + `docs/sources/keychain.md` additions in the diffstat, which look like they rode along with #1142. Worth confirming before publishing.
+
+
 ## v1.1.1 (2026-08-24)
 
 **Datasources**

--- a/claude-plugin/.claude-plugin/plugin.json
+++ b/claude-plugin/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gcx",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Debug, explore, and instrument with Grafana using gcx CLI",
   "keywords": ["grafana", "observability", "monitoring", "prometheus", "loki", "dashboards"],
   "author": {


### PR DESCRIPTION
Release v1.2.0

## Summary
- v1.2.0 changelog entry and `.release-notes.md` (GoReleaser release body)
- Claude plugin + marketplace version bumped to 1.2.0
- Dropped the stale `## Unreleased` section — its telemetry (#1108) and instrumentation (#1198) bullets already shipped in v1.1.1, and the keychain breaking change (#1142) is now folded into the v1.2.0 entry

Minor bump rather than major, matching v1.1.0 which also shipped a breaking change as a minor.

## How to review this PR
- **`chore(release): v1.2.0 changelog`** — output of `mise run tag -- minor`
- **`chore(release): clean up the generated v1.2.0 changelog entry`** — the generator wrapped its bullets in a ```markdown fence and appended prose about "judgement calls", which would have landed verbatim in the GitHub release body. Rewritten by hand in the grouped style used by v1.1.0/v1.1.1.