### PR TITLE
fix(ci): correct actions/cache version comment so Renovate can update it

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -52,7 +52,7 @@ jobs:
           persist-credentials: false
 
       - name: Restore go module cache
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # 5.0.5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/go/pkg/mod


### PR DESCRIPTION
`ci.yaml:55` pins `actions/cache` with the trailing comment `# 5.0.5`. Lines 21 and 87 pin the same action, at the same digest, with `# v5.0.5`.

Renovate reads that comment as the `currentValue` for a digest-pinned action. `actions/cache` has no `5.0.5` tag upstream — only `v5.0.5` — so Renovate can't resolve the ref and reports:

```
Could not determine new digest for update (github-tags package actions/cache)
```

The effect is silent: **this one pin has stopped receiving updates**, while the two identical pins around it continue to update normally. Nothing surfaces in CI or on the dependency dashboard.

The digest is correct and unchanged — `27d5ce7f107fe9357f9df03efb73ab90386fccae` is `v5.0.5`. This fixes only the comment, so there is no behavior change.

---

I ran into this while pointing a Renovate-config checker I maintain at this repo — [`renovate-deps`](https://github.com/grafana/flint/blob/main/docs/linters/renovate-deps.md), part of [grafana/flint](https://github.com/grafana/flint). It catches exactly this class of "dependency quietly stops updating" problem, along with package rules that don't cover every resolver of the same upstream package and stale `extractVersion` regexes.

Happy to open a follow-up PR wiring it in if that's interesting — equally happy to leave it at the one-line fix.
