### PR TITLE
feat(datasources): support SQL query files and table constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,8 @@ gcx k6 load-tests list                          # list k6 load tests
 # Query more datasources
 gcx logs query '{app="nginx"} |= "error"' --since 1h
 gcx traces query '{.cluster="dev-us-central-0"}' --since 1h
+gcx datasources mysql query -d UID --query-file ./query.sql -o json
+gcx datasources postgres describe-table public.orders --include-constraints -o json
 ```
 
 ## Install Agent Skills

--- a/docs/reference/cli/gcx_datasources_athena_query.md
+++ b/docs/reference/cli/gcx_datasources_athena_query.md
@@ -6,7 +6,8 @@ Execute a SQL query against an Athena datasource
 
 Execute a SQL query against an Amazon Athena datasource.
 
-EXPR is the SQL query to execute, passed as a positional argument or via --expr.
+EXPR is the SQL query to execute, passed as a positional argument, via --expr,
+or via --query-file. Use --query-file - to read SQL from stdin.
 Datasource is resolved from -d flag or datasources.athena in your context.
 Server-side macros ($__timeFilter, $__dateFilter, etc.) are supported.
 Use --share-link to print the equivalent Grafana Explore URL, or --open to
@@ -29,6 +30,9 @@ gcx datasources athena query [EXPR] [flags]
   # With connection overrides
   gcx datasources athena query -d UID 'SELECT 1' --region us-west-2 --database analytics
 
+  # Read a long query from a file
+  gcx datasources athena query -d UID --query-file ./query.sql -o json
+
   # Enable result reuse (Athena engine v3)
   gcx datasources athena query -d UID 'SELECT count(*) FROM events' --result-reuse --ttl-minutes 60
 
@@ -50,6 +54,7 @@ gcx datasources athena query [EXPR] [flags]
       --limit int           Max rows to return (0 disables enforcement) (default 100)
       --open                Open the executed query in Grafana Explore
   -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+      --query-file string   Read the SQL query from FILE (use - for stdin)
       --region string       AWS region override
       --result-reuse        Enable Athena query result reuse (engine v3)
       --share-link          Print the Grafana Explore URL for the executed query to stderr

--- a/docs/reference/cli/gcx_datasources_clickhouse_query.md
+++ b/docs/reference/cli/gcx_datasources_clickhouse_query.md
@@ -6,7 +6,8 @@ Execute a SQL query against a ClickHouse datasource
 
 Execute a SQL query against a ClickHouse datasource.
 
-EXPR is the SQL query to execute, passed as a positional argument or via --expr.
+EXPR is the SQL query to execute, passed as a positional argument, via --expr,
+or via --query-file. Use --query-file - to read SQL from stdin.
 Datasource is resolved from -d flag or datasources.clickhouse in your context.
 Server-side macros ($__timeFilter, $__timeInterval, etc.) are supported.
 Use --share-link to print the equivalent Grafana Explore URL, or --open to
@@ -29,6 +30,9 @@ gcx datasources clickhouse query [EXPR] [flags]
   # Output as JSON
   gcx datasources clickhouse query -d UID 'SELECT 1' -o json
 
+  # Read a long query from a file
+  gcx datasources clickhouse query -d UID --query-file ./query.sql -o json
+
   # Print a Grafana Explore share link for the executed query
   gcx datasources clickhouse query 'SELECT 1' --share-link
 
@@ -48,6 +52,7 @@ gcx datasources clickhouse query [EXPR] [flags]
       --limit int           Max rows to return (0 disables enforcement) (default 100)
       --open                Open the executed query in Grafana Explore
   -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+      --query-file string   Read the SQL query from FILE (use - for stdin)
       --share-link          Print the Grafana Explore URL for the executed query to stderr
       --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')

--- a/docs/reference/cli/gcx_datasources_mysql_describe-table.md
+++ b/docs/reference/cli/gcx_datasources_mysql_describe-table.md
@@ -12,6 +12,10 @@ disambiguate when the same table name exists in multiple databases. TABLE and
 how information_schema itself compares names depending on the server's
 platform and lower_case_table_names setting.
 
+Use --include-constraints with a database-qualified table (or --database) to
+also return a structured table identity, columns, and ordered constraint
+metadata. Constraint metadata requires -o json, -o yaml, or agent mode.
+
 ```
 gcx datasources mysql describe-table TABLE [flags]
 ```
@@ -29,17 +33,21 @@ gcx datasources mysql describe-table TABLE [flags]
 
   # Output as JSON
   gcx datasources mysql describe-table orders -o json
+
+  # Include ordered keys and foreign-key relationships
+  gcx datasources mysql describe-table mydb.orders --include-constraints -o json
 ```
 
 ### Options
 
 ```
-      --database string     Database of the table (exact match, case-sensitive; defaults to all databases)
-  -d, --datasource string   Datasource UID (required unless datasources.mysql is configured)
-  -h, --help                help for describe-table
-      --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
-      --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+      --database string       Database of the table (exact match, case-sensitive; defaults to all databases)
+  -d, --datasource string     Datasource UID (required unless datasources.mysql is configured)
+  -h, --help                  help for describe-table
+      --include-constraints   Include ordered constraint and foreign-key metadata (requires an explicit database and JSON/YAML/agent output)
+      --jq string             jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string         Output format. One of: agents, json, table, wide, yaml (default "table")
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_datasources_mysql_query.md
+++ b/docs/reference/cli/gcx_datasources_mysql_query.md
@@ -6,7 +6,8 @@ Execute a SQL query against a MySQL datasource
 
 Execute a SQL query against a MySQL datasource.
 
-EXPR is the SQL query to execute, passed as a positional argument or via --expr.
+EXPR is the SQL query to execute, passed as a positional argument, via --expr,
+or via --query-file. Use --query-file - to read SQL from stdin.
 Datasource is resolved from -d flag or datasources.mysql in your context.
 Server-side macros ($__timeFilter, $__timeGroup, etc.) are supported.
 
@@ -27,6 +28,9 @@ gcx datasources mysql query [EXPR] [flags]
   # Output as JSON
   gcx datasources mysql query -d UID 'SELECT 1' -o json
 
+  # Read a long query from a file
+  gcx datasources mysql query -d UID --query-file ./query.sql -o json
+
   # Disable limit enforcement
   gcx datasources mysql query 'SELECT * FROM big_table' --limit 0
 ```
@@ -42,6 +46,7 @@ gcx datasources mysql query [EXPR] [flags]
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int           Max rows to return; requests above 1000 are capped, with a warning (0 disables enforcement) (default 100)
   -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+      --query-file string   Read the SQL query from FILE (use - for stdin)
       --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/docs/reference/cli/gcx_datasources_postgres_describe-table.md
+++ b/docs/reference/cli/gcx_datasources_postgres_describe-table.md
@@ -9,6 +9,10 @@ Show the columns of a PostgreSQL table: name, data type, nullability, and defaul
 The table can be schema-qualified (schema.table); otherwise use --schema to
 disambiguate when the same table name exists in multiple schemas.
 
+Use --include-constraints with a schema-qualified table (or --schema) to also
+return a structured table identity, columns, and ordered constraint metadata.
+Constraint metadata requires -o json, -o yaml, or agent mode.
+
 ```
 gcx datasources postgres describe-table TABLE [flags]
 ```
@@ -26,17 +30,21 @@ gcx datasources postgres describe-table TABLE [flags]
 
   # Output as JSON
   gcx datasources postgres describe-table orders -o json
+
+  # Include ordered keys and foreign-key relationships
+  gcx datasources postgres describe-table public.orders --include-constraints -o json
 ```
 
 ### Options
 
 ```
-  -d, --datasource string   Datasource UID (required unless datasources.postgres is configured)
-  -h, --help                help for describe-table
-      --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
-      --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
-  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
-      --schema string       Schema of the table (exact match, case-sensitive; defaults to all schemas)
+  -d, --datasource string     Datasource UID (required unless datasources.postgres is configured)
+  -h, --help                  help for describe-table
+      --include-constraints   Include ordered constraint and foreign-key metadata (requires an explicit schema and JSON/YAML/agent output)
+      --jq string             jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string           Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+  -o, --output string         Output format. One of: agents, json, table, wide, yaml (default "table")
+      --schema string         Schema of the table (exact match, case-sensitive; defaults to all schemas)
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/cli/gcx_datasources_postgres_query.md
+++ b/docs/reference/cli/gcx_datasources_postgres_query.md
@@ -6,7 +6,8 @@ Execute a SQL query against a PostgreSQL datasource
 
 Execute a SQL query against a PostgreSQL datasource.
 
-EXPR is the SQL query to execute, passed as a positional argument or via --expr.
+EXPR is the SQL query to execute, passed as a positional argument, via --expr,
+or via --query-file. Use --query-file - to read SQL from stdin.
 Datasource is resolved from -d flag or datasources.postgres in your context.
 Server-side macros ($__timeFilter, $__timeGroup, etc.) are supported.
 
@@ -27,6 +28,9 @@ gcx datasources postgres query [EXPR] [flags]
   # Output as JSON
   gcx datasources postgres query -d UID 'SELECT 1' -o json
 
+  # Read a long query from a file
+  gcx datasources postgres query -d UID --query-file ./query.sql -o json
+
   # Disable limit enforcement
   gcx datasources postgres query 'SELECT * FROM big_table' --limit 0
 ```
@@ -42,6 +46,7 @@ gcx datasources postgres query [EXPR] [flags]
       --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
       --limit int           Max rows to return; requests above 1000 are capped, with a warning (0 disables enforcement) (default 100)
   -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+      --query-file string   Read the SQL query from FILE (use - for stdin)
       --since string        Duration before --to, or now if omitted (e.g., 30m, 6h, 7d); mutually exclusive with --from
       --step string         Query step (e.g., '15s', '1m')
       --to string           End time (RFC3339, Unix timestamp, or relative like 'now')

--- a/internal/datasources/athena/query.go
+++ b/internal/datasources/athena/query.go
@@ -18,7 +18,7 @@ const (
 
 // QueryCmd returns the `query` subcommand for an Athena datasource parent.
 func QueryCmd(loader *providers.ConfigLoader) *cobra.Command {
-	shared := &dsquery.SharedOpts{}
+	shared := &dsquery.SQLQueryOpts{}
 	share := &dsquery.ExploreLinkOpts{}
 	var datasource string
 	var limit int
@@ -31,7 +31,8 @@ func QueryCmd(loader *providers.ConfigLoader) *cobra.Command {
 		Short: "Execute a SQL query against an Athena datasource",
 		Long: `Execute a SQL query against an Amazon Athena datasource.
 
-EXPR is the SQL query to execute, passed as a positional argument or via --expr.
+EXPR is the SQL query to execute, passed as a positional argument, via --expr,
+or via --query-file. Use --query-file - to read SQL from stdin.
 Datasource is resolved from -d flag or datasources.athena in your context.
 Server-side macros ($__timeFilter, $__dateFilter, etc.) are supported.
 Use --share-link to print the equivalent Grafana Explore URL, or --open to
@@ -46,6 +47,9 @@ open it in your browser after the query succeeds.`,
   # With connection overrides
   gcx datasources athena query -d UID 'SELECT 1' --region us-west-2 --database analytics
 
+  # Read a long query from a file
+  gcx datasources athena query -d UID --query-file ./query.sql -o json
+
   # Enable result reuse (Athena engine v3)
   gcx datasources athena query -d UID 'SELECT count(*) FROM events' --result-reuse --ttl-minutes 60
 
@@ -57,7 +61,7 @@ open it in your browser after the query succeeds.`,
 				return err
 			}
 
-			expr, err := shared.ResolveExpr(args, 0)
+			expr, err := shared.ResolveExpr(args, 0, cmd.InOrStdin(), cmd.Flags().Changed("query-file"))
 			if err != nil {
 				return err
 			}

--- a/internal/datasources/athena/query_test.go
+++ b/internal/datasources/athena/query_test.go
@@ -1,44 +1,15 @@
-package postgres_test
+package athena_test
 
 import (
 	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/grafana/gcx/internal/datasources/postgres"
+	"github.com/grafana/gcx/internal/datasources/athena"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestQueryCmd_ValidationErrors(t *testing.T) {
-	tests := []struct {
-		name    string
-		args    []string
-		wantErr string
-	}{
-		{
-			name:    "negative limit rejected before any config/datasource I/O",
-			args:    []string{"--limit=-5", "SELECT 1"},
-			wantErr: "--limit must be >= 0",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// A zero-value loader has no context/config wired up, so any code
-			// path that reaches config loading or datasource resolution fails
-			// with an unrelated error. Asserting on the specific validation
-			// message proves validation ran first.
-			loader := &providers.ConfigLoader{}
-			cmd := postgres.QueryCmd(loader)
-			cmd.SetArgs(tt.args)
-			err := cmd.Execute()
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), tt.wantErr)
-		})
-	}
-}
 
 func TestQueryCmd_QueryFileValidationBeforeIO(t *testing.T) {
 	emptyFile := filepath.Join(t.TempDir(), "empty.sql")
@@ -67,7 +38,7 @@ func TestQueryCmd_QueryFileValidationBeforeIO(t *testing.T) {
 			// query-file error proves input validation completed before config or
 			// datasource I/O.
 			loader := &providers.ConfigLoader{}
-			cmd := postgres.QueryCmd(loader)
+			cmd := athena.QueryCmd(loader)
 			cmd.SetArgs([]string{"--query-file", tt.queryFile})
 			err := cmd.Execute()
 			require.Error(t, err)

--- a/internal/datasources/clickhouse/query.go
+++ b/internal/datasources/clickhouse/query.go
@@ -18,7 +18,7 @@ const (
 
 // QueryCmd returns the `query` subcommand for a ClickHouse datasource parent.
 func QueryCmd(loader *providers.ConfigLoader) *cobra.Command {
-	shared := &dsquery.SharedOpts{}
+	shared := &dsquery.SQLQueryOpts{}
 	share := &dsquery.ExploreLinkOpts{}
 	var datasource string
 	var limit int
@@ -28,7 +28,8 @@ func QueryCmd(loader *providers.ConfigLoader) *cobra.Command {
 		Short: "Execute a SQL query against a ClickHouse datasource",
 		Long: `Execute a SQL query against a ClickHouse datasource.
 
-EXPR is the SQL query to execute, passed as a positional argument or via --expr.
+EXPR is the SQL query to execute, passed as a positional argument, via --expr,
+or via --query-file. Use --query-file - to read SQL from stdin.
 Datasource is resolved from -d flag or datasources.clickhouse in your context.
 Server-side macros ($__timeFilter, $__timeInterval, etc.) are supported.
 Use --share-link to print the equivalent Grafana Explore URL, or --open to
@@ -43,6 +44,9 @@ open it in your browser after the query succeeds.`,
   # Output as JSON
   gcx datasources clickhouse query -d UID 'SELECT 1' -o json
 
+  # Read a long query from a file
+  gcx datasources clickhouse query -d UID --query-file ./query.sql -o json
+
   # Print a Grafana Explore share link for the executed query
   gcx datasources clickhouse query 'SELECT 1' --share-link
 
@@ -54,7 +58,7 @@ open it in your browser after the query succeeds.`,
 				return err
 			}
 
-			expr, err := shared.ResolveExpr(args, 0)
+			expr, err := shared.ResolveExpr(args, 0, cmd.InOrStdin(), cmd.Flags().Changed("query-file"))
 			if err != nil {
 				return err
 			}

--- a/internal/datasources/clickhouse/query_test.go
+++ b/internal/datasources/clickhouse/query_test.go
@@ -1,44 +1,15 @@
-package postgres_test
+package clickhouse_test
 
 import (
 	"os"
 	"path/filepath"
 	"testing"
 
-	"github.com/grafana/gcx/internal/datasources/postgres"
+	"github.com/grafana/gcx/internal/datasources/clickhouse"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestQueryCmd_ValidationErrors(t *testing.T) {
-	tests := []struct {
-		name    string
-		args    []string
-		wantErr string
-	}{
-		{
-			name:    "negative limit rejected before any config/datasource I/O",
-			args:    []string{"--limit=-5", "SELECT 1"},
-			wantErr: "--limit must be >= 0",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// A zero-value loader has no context/config wired up, so any code
-			// path that reaches config loading or datasource resolution fails
-			// with an unrelated error. Asserting on the specific validation
-			// message proves validation ran first.
-			loader := &providers.ConfigLoader{}
-			cmd := postgres.QueryCmd(loader)
-			cmd.SetArgs(tt.args)
-			err := cmd.Execute()
-			require.Error(t, err)
-			assert.Contains(t, err.Error(), tt.wantErr)
-		})
-	}
-}
 
 func TestQueryCmd_QueryFileValidationBeforeIO(t *testing.T) {
 	emptyFile := filepath.Join(t.TempDir(), "empty.sql")
@@ -67,7 +38,7 @@ func TestQueryCmd_QueryFileValidationBeforeIO(t *testing.T) {
 			// query-file error proves input validation completed before config or
 			// datasource I/O.
 			loader := &providers.ConfigLoader{}
-			cmd := postgres.QueryCmd(loader)
+			cmd := clickhouse.QueryCmd(loader)
 			cmd.SetArgs([]string{"--query-file", tt.queryFile})
 			err := cmd.Execute()
 			require.Error(t, err)

--- a/internal/datasources/mysql/describe_table.go
+++ b/internal/datasources/mysql/describe_table.go
@@ -45,7 +45,7 @@ func (opts *describeTableOpts) setup(flags *pflag.FlagSet) {
 	opts.IO.BindFlags(flags)
 	flags.StringVarP(&opts.Datasource, "datasource", "d", "", "Datasource UID (required unless datasources.mysql is configured)")
 	flags.StringVar(&opts.Database, "database", "", "Database of the table (exact match, case-sensitive; defaults to all databases)")
-	flags.BoolVar(&opts.IncludeConstraints, "include-constraints", false, "Include ordered constraint and foreign-key metadata (requires an explicit database and JSON/YAML output)")
+	flags.BoolVar(&opts.IncludeConstraints, "include-constraints", false, "Include ordered constraint and foreign-key metadata (requires an explicit database and JSON/YAML/agent output)")
 }
 
 func (opts *describeTableOpts) Validate() error {
@@ -69,7 +69,7 @@ platform and lower_case_table_names setting.
 
 Use --include-constraints with a database-qualified table (or --database) to
 also return a structured table identity, columns, and ordered constraint
-metadata. Constraint metadata requires -o json or -o yaml.`,
+metadata. Constraint metadata requires -o json, -o yaml, or agent mode.`,
 		Example: `
   # Describe a table
   gcx datasources mysql describe-table orders -d UID
@@ -78,11 +78,11 @@ metadata. Constraint metadata requires -o json or -o yaml.`,
   gcx datasources mysql describe-table mydb.orders
   gcx datasources mysql describe-table orders --database mydb
 
-	  # Output as JSON
-	  gcx datasources mysql describe-table orders -o json
+  # Output as JSON
+  gcx datasources mysql describe-table orders -o json
 
-	  # Include ordered keys and foreign-key relationships
-	  gcx datasources mysql describe-table mydb.orders --include-constraints -o json`,
+  # Include ordered keys and foreign-key relationships
+  gcx datasources mysql describe-table mydb.orders --include-constraints -o json`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.Validate(); err != nil {
@@ -108,7 +108,7 @@ metadata. Constraint metadata requires -o json or -o yaml.`,
 					return errors.New("--include-constraints requires an explicit database (use DATABASE.TABLE or --database)")
 				}
 				if opts.IO.OutputFormat != "json" && opts.IO.OutputFormat != "yaml" && opts.IO.OutputFormat != "agents" {
-					return errors.New("--include-constraints requires JSON or YAML output (use -o json or -o yaml)")
+					return errors.New("--include-constraints requires JSON, YAML, or agent output (use -o json or -o yaml)")
 				}
 			}
 

--- a/internal/datasources/mysql/describe_table.go
+++ b/internal/datasources/mysql/describe_table.go
@@ -10,14 +10,16 @@ import (
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/mysql"
+	querysql "github.com/grafana/gcx/internal/query/sql"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
 type describeTableOpts struct {
-	IO         cmdio.Options
-	Datasource string
-	Database   string
+	IO                 cmdio.Options
+	Datasource         string
+	Database           string
+	IncludeConstraints bool
 }
 
 // splitTableArg resolves a possibly database-qualified TABLE argument
@@ -43,6 +45,7 @@ func (opts *describeTableOpts) setup(flags *pflag.FlagSet) {
 	opts.IO.BindFlags(flags)
 	flags.StringVarP(&opts.Datasource, "datasource", "d", "", "Datasource UID (required unless datasources.mysql is configured)")
 	flags.StringVar(&opts.Database, "database", "", "Database of the table (exact match, case-sensitive; defaults to all databases)")
+	flags.BoolVar(&opts.IncludeConstraints, "include-constraints", false, "Include ordered constraint and foreign-key metadata (requires an explicit database and JSON/YAML output)")
 }
 
 func (opts *describeTableOpts) Validate() error {
@@ -62,7 +65,11 @@ The table can be database-qualified (db.table); otherwise use --database to
 disambiguate when the same table name exists in multiple databases. TABLE and
 --database both match exactly and are case-sensitive, which can differ from
 how information_schema itself compares names depending on the server's
-platform and lower_case_table_names setting.`,
+platform and lower_case_table_names setting.
+
+Use --include-constraints with a database-qualified table (or --database) to
+also return a structured table identity, columns, and ordered constraint
+metadata. Constraint metadata requires -o json or -o yaml.`,
 		Example: `
   # Describe a table
   gcx datasources mysql describe-table orders -d UID
@@ -71,8 +78,11 @@ platform and lower_case_table_names setting.`,
   gcx datasources mysql describe-table mydb.orders
   gcx datasources mysql describe-table orders --database mydb
 
-  # Output as JSON
-  gcx datasources mysql describe-table orders -o json`,
+	  # Output as JSON
+	  gcx datasources mysql describe-table orders -o json
+
+	  # Include ordered keys and foreign-key relationships
+	  gcx datasources mysql describe-table mydb.orders --include-constraints -o json`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.Validate(); err != nil {
@@ -92,6 +102,14 @@ platform and lower_case_table_names setting.`,
 			}
 			if err := mysql.ValidateIdentifier(database, "database"); err != nil {
 				return err
+			}
+			if opts.IncludeConstraints {
+				if database == "" {
+					return errors.New("--include-constraints requires an explicit database (use DATABASE.TABLE or --database)")
+				}
+				if opts.IO.OutputFormat != "json" && opts.IO.OutputFormat != "yaml" && opts.IO.OutputFormat != "agents" {
+					return errors.New("--include-constraints requires JSON or YAML output (use -o json or -o yaml)")
+				}
 			}
 
 			ctx := cmd.Context()
@@ -134,6 +152,18 @@ platform and lower_case_table_names setting.`,
 					return fmt.Errorf("table %q not found in database %q", table, database)
 				}
 				return fmt.Errorf("table %q not found", table)
+			}
+
+			if opts.IncludeConstraints {
+				constraintsResp, err := client.Query(ctx, datasourceUID, mysql.QueryRequest{RawSQL: mysql.BuildDescribeConstraintsQuery(database, table)})
+				if err != nil {
+					return fmt.Errorf("query constraints failed: %w", err)
+				}
+				description, err := querysql.ParseTableDescription(database, table, resp, constraintsResp)
+				if err != nil {
+					return fmt.Errorf("parse table description: %w", err)
+				}
+				return opts.IO.Encode(cmd.OutOrStdout(), description)
 			}
 
 			return opts.IO.Encode(cmd.OutOrStdout(), resp)

--- a/internal/datasources/mysql/describe_table_test.go
+++ b/internal/datasources/mysql/describe_table_test.go
@@ -28,7 +28,7 @@ func TestDescribeTableCmd_ValidationErrors(t *testing.T) {
 		{
 			name:    "constraint metadata rejects table output before config I/O",
 			args:    []string{"mydb.orders", "--include-constraints"},
-			wantErr: "requires JSON or YAML output",
+			wantErr: "requires JSON, YAML, or agent output",
 		},
 	}
 

--- a/internal/datasources/mysql/describe_table_test.go
+++ b/internal/datasources/mysql/describe_table_test.go
@@ -20,6 +20,16 @@ func TestDescribeTableCmd_ValidationErrors(t *testing.T) {
 			args:    []string{"orders", "--database="},
 			wantErr: "--database must not be empty",
 		},
+		{
+			name:    "constraint metadata requires explicit database before config I/O",
+			args:    []string{"orders", "--include-constraints", "-o", "json"},
+			wantErr: "--include-constraints requires an explicit database",
+		},
+		{
+			name:    "constraint metadata rejects table output before config I/O",
+			args:    []string{"mydb.orders", "--include-constraints"},
+			wantErr: "requires JSON or YAML output",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/datasources/mysql/query.go
+++ b/internal/datasources/mysql/query.go
@@ -19,7 +19,7 @@ const (
 )
 
 type queryOpts struct {
-	dsquery.SharedOpts
+	dsquery.SQLQueryOpts
 
 	Datasource string
 	Limit      int
@@ -35,7 +35,7 @@ func (opts *queryOpts) Validate() error {
 	if opts.Limit < 0 {
 		return fmt.Errorf("--limit must be >= 0, got %d", opts.Limit)
 	}
-	return opts.SharedOpts.Validate()
+	return opts.SQLQueryOpts.Validate()
 }
 
 // QueryCmd returns the `query` subcommand for a MySQL datasource parent.
@@ -47,7 +47,8 @@ func QueryCmd(loader *providers.ConfigLoader) *cobra.Command {
 		Short: "Execute a SQL query against a MySQL datasource",
 		Long: `Execute a SQL query against a MySQL datasource.
 
-EXPR is the SQL query to execute, passed as a positional argument or via --expr.
+EXPR is the SQL query to execute, passed as a positional argument, via --expr,
+or via --query-file. Use --query-file - to read SQL from stdin.
 Datasource is resolved from -d flag or datasources.mysql in your context.
 Server-side macros ($__timeFilter, $__timeGroup, etc.) are supported.`,
 		Example: `
@@ -60,6 +61,9 @@ Server-side macros ($__timeFilter, $__timeGroup, etc.) are supported.`,
   # Output as JSON
   gcx datasources mysql query -d UID 'SELECT 1' -o json
 
+  # Read a long query from a file
+  gcx datasources mysql query -d UID --query-file ./query.sql -o json
+
   # Disable limit enforcement
   gcx datasources mysql query 'SELECT * FROM big_table' --limit 0`,
 		Args: cobra.RangeArgs(0, 1),
@@ -68,7 +72,7 @@ Server-side macros ($__timeFilter, $__timeGroup, etc.) are supported.`,
 				return err
 			}
 
-			expr, err := opts.ResolveExpr(args, 0)
+			expr, err := opts.ResolveExpr(args, 0, cmd.InOrStdin(), cmd.Flags().Changed("query-file"))
 			if err != nil {
 				return err
 			}

--- a/internal/datasources/mysql/query_test.go
+++ b/internal/datasources/mysql/query_test.go
@@ -1,6 +1,8 @@
 package mysql_test
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/grafana/gcx/internal/datasources/mysql"
@@ -31,6 +33,42 @@ func TestQueryCmd_ValidationErrors(t *testing.T) {
 			loader := &providers.ConfigLoader{}
 			cmd := mysql.QueryCmd(loader)
 			cmd.SetArgs(tt.args)
+			err := cmd.Execute()
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestQueryCmd_QueryFileValidationBeforeIO(t *testing.T) {
+	emptyFile := filepath.Join(t.TempDir(), "empty.sql")
+	require.NoError(t, os.WriteFile(emptyFile, []byte(" \n\t"), 0o600))
+
+	tests := []struct {
+		name      string
+		queryFile string
+		wantErr   string
+	}{
+		{
+			name:      "missing file",
+			queryFile: filepath.Join(t.TempDir(), "missing.sql"),
+			wantErr:   "failed to read --query-file",
+		},
+		{
+			name:      "empty file",
+			queryFile: emptyFile,
+			wantErr:   "is empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// A zero-value loader has no context/config wired up. Seeing the
+			// query-file error proves input validation completed before config or
+			// datasource I/O.
+			loader := &providers.ConfigLoader{}
+			cmd := mysql.QueryCmd(loader)
+			cmd.SetArgs([]string{"--query-file", tt.queryFile})
 			err := cmd.Execute()
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantErr)

--- a/internal/datasources/postgres/describe_table.go
+++ b/internal/datasources/postgres/describe_table.go
@@ -10,14 +10,16 @@ import (
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/query/postgres"
+	querysql "github.com/grafana/gcx/internal/query/sql"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
 type describeTableOpts struct {
-	IO         cmdio.Options
-	Datasource string
-	Schema     string
+	IO                 cmdio.Options
+	Datasource         string
+	Schema             string
+	IncludeConstraints bool
 }
 
 // splitTableArg resolves a possibly schema-qualified TABLE argument
@@ -43,6 +45,7 @@ func (opts *describeTableOpts) setup(flags *pflag.FlagSet) {
 	opts.IO.BindFlags(flags)
 	flags.StringVarP(&opts.Datasource, "datasource", "d", "", "Datasource UID (required unless datasources.postgres is configured)")
 	flags.StringVar(&opts.Schema, "schema", "", "Schema of the table (exact match, case-sensitive; defaults to all schemas)")
+	flags.BoolVar(&opts.IncludeConstraints, "include-constraints", false, "Include ordered constraint and foreign-key metadata (requires an explicit schema and JSON/YAML output)")
 }
 
 func (opts *describeTableOpts) Validate() error {
@@ -59,7 +62,11 @@ func DescribeTableCmd(loader *providers.ConfigLoader) *cobra.Command {
 		Long: `Show the columns of a PostgreSQL table: name, data type, nullability, and default.
 
 The table can be schema-qualified (schema.table); otherwise use --schema to
-disambiguate when the same table name exists in multiple schemas.`,
+disambiguate when the same table name exists in multiple schemas.
+
+Use --include-constraints with a schema-qualified table (or --schema) to also
+return a structured table identity, columns, and ordered constraint metadata.
+Constraint metadata requires -o json or -o yaml.`,
 		Example: `
   # Describe a table
   gcx datasources postgres describe-table orders -d UID
@@ -69,7 +76,10 @@ disambiguate when the same table name exists in multiple schemas.`,
   gcx datasources postgres describe-table orders --schema public
 
   # Output as JSON
-  gcx datasources postgres describe-table orders -o json`,
+  gcx datasources postgres describe-table orders -o json
+
+  # Include ordered keys and foreign-key relationships
+  gcx datasources postgres describe-table public.orders --include-constraints -o json`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := opts.Validate(); err != nil {
@@ -89,6 +99,14 @@ disambiguate when the same table name exists in multiple schemas.`,
 			}
 			if err := postgres.ValidateIdentifier(schema, "schema"); err != nil {
 				return err
+			}
+			if opts.IncludeConstraints {
+				if schema == "" {
+					return errors.New("--include-constraints requires an explicit schema (use SCHEMA.TABLE or --schema)")
+				}
+				if opts.IO.OutputFormat != "json" && opts.IO.OutputFormat != "yaml" && opts.IO.OutputFormat != "agents" {
+					return errors.New("--include-constraints requires JSON or YAML output (use -o json or -o yaml)")
+				}
 			}
 
 			ctx := cmd.Context()
@@ -131,6 +149,18 @@ disambiguate when the same table name exists in multiple schemas.`,
 					return fmt.Errorf("table %q not found in schema %q", table, schema)
 				}
 				return fmt.Errorf("table %q not found", table)
+			}
+
+			if opts.IncludeConstraints {
+				constraintsResp, err := client.Query(ctx, datasourceUID, postgres.QueryRequest{RawSQL: postgres.BuildDescribeConstraintsQuery(schema, table)})
+				if err != nil {
+					return fmt.Errorf("query constraints failed: %w", err)
+				}
+				description, err := querysql.ParseTableDescription(schema, table, resp, constraintsResp)
+				if err != nil {
+					return fmt.Errorf("parse table description: %w", err)
+				}
+				return opts.IO.Encode(cmd.OutOrStdout(), description)
 			}
 
 			return opts.IO.Encode(cmd.OutOrStdout(), resp)

--- a/internal/datasources/postgres/describe_table.go
+++ b/internal/datasources/postgres/describe_table.go
@@ -45,7 +45,7 @@ func (opts *describeTableOpts) setup(flags *pflag.FlagSet) {
 	opts.IO.BindFlags(flags)
 	flags.StringVarP(&opts.Datasource, "datasource", "d", "", "Datasource UID (required unless datasources.postgres is configured)")
 	flags.StringVar(&opts.Schema, "schema", "", "Schema of the table (exact match, case-sensitive; defaults to all schemas)")
-	flags.BoolVar(&opts.IncludeConstraints, "include-constraints", false, "Include ordered constraint and foreign-key metadata (requires an explicit schema and JSON/YAML output)")
+	flags.BoolVar(&opts.IncludeConstraints, "include-constraints", false, "Include ordered constraint and foreign-key metadata (requires an explicit schema and JSON/YAML/agent output)")
 }
 
 func (opts *describeTableOpts) Validate() error {
@@ -66,7 +66,7 @@ disambiguate when the same table name exists in multiple schemas.
 
 Use --include-constraints with a schema-qualified table (or --schema) to also
 return a structured table identity, columns, and ordered constraint metadata.
-Constraint metadata requires -o json or -o yaml.`,
+Constraint metadata requires -o json, -o yaml, or agent mode.`,
 		Example: `
   # Describe a table
   gcx datasources postgres describe-table orders -d UID
@@ -105,7 +105,7 @@ Constraint metadata requires -o json or -o yaml.`,
 					return errors.New("--include-constraints requires an explicit schema (use SCHEMA.TABLE or --schema)")
 				}
 				if opts.IO.OutputFormat != "json" && opts.IO.OutputFormat != "yaml" && opts.IO.OutputFormat != "agents" {
-					return errors.New("--include-constraints requires JSON or YAML output (use -o json or -o yaml)")
+					return errors.New("--include-constraints requires JSON, YAML, or agent output (use -o json or -o yaml)")
 				}
 			}
 

--- a/internal/datasources/postgres/describe_table_test.go
+++ b/internal/datasources/postgres/describe_table_test.go
@@ -20,6 +20,16 @@ func TestDescribeTableCmd_ValidationErrors(t *testing.T) {
 			args:    []string{"orders", "--schema="},
 			wantErr: "--schema must not be empty",
 		},
+		{
+			name:    "constraint metadata requires explicit schema before config I/O",
+			args:    []string{"orders", "--include-constraints", "-o", "json"},
+			wantErr: "--include-constraints requires an explicit schema",
+		},
+		{
+			name:    "constraint metadata rejects table output before config I/O",
+			args:    []string{"public.orders", "--include-constraints"},
+			wantErr: "requires JSON or YAML output",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/datasources/postgres/describe_table_test.go
+++ b/internal/datasources/postgres/describe_table_test.go
@@ -28,7 +28,7 @@ func TestDescribeTableCmd_ValidationErrors(t *testing.T) {
 		{
 			name:    "constraint metadata rejects table output before config I/O",
 			args:    []string{"public.orders", "--include-constraints"},
-			wantErr: "requires JSON or YAML output",
+			wantErr: "requires JSON, YAML, or agent output",
 		},
 	}
 

--- a/internal/datasources/postgres/query.go
+++ b/internal/datasources/postgres/query.go
@@ -19,7 +19,7 @@ const (
 )
 
 type queryOpts struct {
-	dsquery.SharedOpts
+	dsquery.SQLQueryOpts
 
 	Datasource string
 	Limit      int
@@ -35,7 +35,7 @@ func (opts *queryOpts) Validate() error {
 	if opts.Limit < 0 {
 		return fmt.Errorf("--limit must be >= 0, got %d", opts.Limit)
 	}
-	return opts.SharedOpts.Validate()
+	return opts.SQLQueryOpts.Validate()
 }
 
 // QueryCmd returns the `query` subcommand for a PostgreSQL datasource parent.
@@ -47,7 +47,8 @@ func QueryCmd(loader *providers.ConfigLoader) *cobra.Command {
 		Short: "Execute a SQL query against a PostgreSQL datasource",
 		Long: `Execute a SQL query against a PostgreSQL datasource.
 
-EXPR is the SQL query to execute, passed as a positional argument or via --expr.
+EXPR is the SQL query to execute, passed as a positional argument, via --expr,
+or via --query-file. Use --query-file - to read SQL from stdin.
 Datasource is resolved from -d flag or datasources.postgres in your context.
 Server-side macros ($__timeFilter, $__timeGroup, etc.) are supported.`,
 		Example: `
@@ -60,6 +61,9 @@ Server-side macros ($__timeFilter, $__timeGroup, etc.) are supported.`,
   # Output as JSON
   gcx datasources postgres query -d UID 'SELECT 1' -o json
 
+  # Read a long query from a file
+  gcx datasources postgres query -d UID --query-file ./query.sql -o json
+
   # Disable limit enforcement
   gcx datasources postgres query 'SELECT * FROM big_table' --limit 0`,
 		Args: cobra.RangeArgs(0, 1),
@@ -68,7 +72,7 @@ Server-side macros ($__timeFilter, $__timeGroup, etc.) are supported.`,
 				return err
 			}
 
-			expr, err := opts.ResolveExpr(args, 0)
+			expr, err := opts.ResolveExpr(args, 0, cmd.InOrStdin(), cmd.Flags().Changed("query-file"))
 			if err != nil {
 				return err
 			}

--- a/internal/datasources/query/sql_opts.go
+++ b/internal/datasources/query/sql_opts.go
@@ -1,0 +1,90 @@
+package query
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/pflag"
+)
+
+// SQLQueryOpts holds flags and expression resolution shared by typed SQL
+// datasource commands. It deliberately wraps SharedOpts instead of adding the
+// --query-file flag to SharedOpts.Setup, so non-SQL query commands do not
+// advertise an input mode they do not support.
+type SQLQueryOpts struct {
+	SharedOpts
+	QueryFile string
+}
+
+// Setup registers the common query flags and the SQL-only --query-file flag.
+func (opts *SQLQueryOpts) Setup(flags *pflag.FlagSet, enableGraph bool) {
+	opts.SharedOpts.Setup(flags, enableGraph)
+	flags.StringVar(&opts.QueryFile, "query-file", "", "Read the SQL query from FILE (use - for stdin)")
+}
+
+// ResolveExpr resolves a SQL expression from exactly one of a positional
+// argument, --expr, or --query-file. queryFileChanged must be supplied by the
+// command so an explicitly empty --query-file value cannot silently fall back
+// to another source.
+func (opts *SQLQueryOpts) ResolveExpr(args []string, exprArgIndex int, stdin io.Reader, queryFileChanged bool) (string, error) {
+	haveFlag := opts.Expr != ""
+	haveArg := exprArgIndex < len(args)
+	haveFile := queryFileChanged || opts.QueryFile != ""
+	if !haveFile {
+		// Keep the established positional/--expr contract and its error text
+		// unchanged when --query-file is not in use.
+		return opts.SharedOpts.ResolveExpr(args, exprArgIndex)
+	}
+
+	sources := 0
+	if haveFlag {
+		sources++
+	}
+	if haveArg {
+		sources++
+	}
+	if haveFile {
+		sources++
+	}
+	if sources > 1 {
+		return "", errors.New("provide the SQL query as a positional argument, via --expr, or via --query-file, not multiple sources")
+	}
+	if sources == 0 {
+		return "", errors.New("SQL query is required: provide it as a positional argument, via --expr, or via --query-file")
+	}
+
+	if haveFlag {
+		return opts.Expr, nil
+	}
+	if haveArg {
+		return args[exprArgIndex], nil
+	}
+	if opts.QueryFile == "" {
+		return "", errors.New("--query-file requires a file path (use - to read from stdin)")
+	}
+
+	data, err := readSQLQueryFile(opts.QueryFile, stdin)
+	if err != nil {
+		return "", fmt.Errorf("failed to read --query-file %q: %w", opts.QueryFile, err)
+	}
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return "", fmt.Errorf("--query-file %q is empty", opts.QueryFile)
+	}
+
+	// Keep the file bytes unchanged. In particular, do not trim a trailing
+	// newline or normalize whitespace before the datasource receives the SQL.
+	return string(data), nil
+}
+
+func readSQLQueryFile(path string, stdin io.Reader) ([]byte, error) {
+	if path == "-" {
+		if stdin == nil {
+			stdin = os.Stdin
+		}
+		return io.ReadAll(stdin)
+	}
+	return os.ReadFile(path)
+}

--- a/internal/datasources/query/sql_opts_test.go
+++ b/internal/datasources/query/sql_opts_test.go
@@ -1,0 +1,128 @@
+package query_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	dsquery "github.com/grafana/gcx/internal/datasources/query"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSQLQueryOptsResolveExpr(t *testing.T) {
+	queryFile := filepath.Join(t.TempDir(), "query.sql")
+	const fileSQL = "SELECT 1\n-- preserve this newline\n"
+	require.NoError(t, os.WriteFile(queryFile, []byte(fileSQL), 0o600))
+
+	tests := []struct {
+		name             string
+		expr             string
+		queryFile        string
+		queryFileChanged bool
+		args             []string
+		stdin            string
+		want             string
+		wantErr          string
+	}{
+		{
+			name: "positional argument",
+			args: []string{"SELECT 1"},
+			want: "SELECT 1",
+		},
+		{
+			name: "expr flag",
+			expr: "SELECT 1",
+			want: "SELECT 1",
+		},
+		{
+			name:      "file preserves bytes",
+			queryFile: queryFile,
+			want:      fileSQL,
+		},
+		{
+			name:      "stdin",
+			queryFile: "-",
+			stdin:     "SELECT 2\n",
+			want:      "SELECT 2\n",
+		},
+		{
+			name:    "no source",
+			wantErr: "expression is required",
+		},
+		{
+			name:    "positional and expr",
+			expr:    "SELECT 1",
+			args:    []string{"SELECT 2"},
+			wantErr: "not both",
+		},
+		{
+			name:      "positional and file",
+			queryFile: queryFile,
+			args:      []string{"SELECT 2"},
+			wantErr:   "not multiple sources",
+		},
+		{
+			name:      "expr and file",
+			expr:      "SELECT 1",
+			queryFile: queryFile,
+			wantErr:   "not multiple sources",
+		},
+		{
+			name:             "explicit empty file path",
+			queryFileChanged: true,
+			wantErr:          "requires a file path",
+		},
+		{
+			name:      "missing file",
+			queryFile: filepath.Join(t.TempDir(), "missing.sql"),
+			wantErr:   "failed to read --query-file",
+		},
+		{
+			name:      "empty file",
+			queryFile: emptyQueryFile(t),
+			wantErr:   "is empty",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := &dsquery.SQLQueryOpts{SharedOpts: dsquery.SharedOpts{Expr: tt.expr}, QueryFile: tt.queryFile}
+			got, err := opts.ResolveExpr(tt.args, 0, strings.NewReader(tt.stdin), tt.queryFileChanged)
+			if tt.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestSQLQueryOptsSetup_DoesNotLeakIntoSharedOpts(t *testing.T) {
+	shared := &dsquery.SharedOpts{}
+	sharedFlags := newTestFlagSet()
+	shared.Setup(sharedFlags, false)
+	assert.Nil(t, sharedFlags.Lookup("query-file"))
+
+	sql := &dsquery.SQLQueryOpts{}
+	sqlFlags := newTestFlagSet()
+	sql.Setup(sqlFlags, false)
+	require.NotNil(t, sqlFlags.Lookup("query-file"))
+	require.NoError(t, sqlFlags.Parse([]string{"--query-file", "query.sql"}))
+	assert.Equal(t, "query.sql", sql.QueryFile)
+}
+
+func newTestFlagSet() *pflag.FlagSet {
+	return pflag.NewFlagSet("test", pflag.ContinueOnError)
+}
+
+func emptyQueryFile(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "empty.sql")
+	require.NoError(t, os.WriteFile(path, []byte(" \n\t"), 0o600))
+	return path
+}

--- a/internal/query/mysql/constraints.go
+++ b/internal/query/mysql/constraints.go
@@ -1,0 +1,30 @@
+package mysql
+
+import "fmt"
+
+// BuildDescribeConstraintsQuery returns the information_schema query used by
+// describe-table --include-constraints. The left joins retain CHECK and other
+// constraints which do not expose a KEY_COLUMN_USAGE row; foreign-key target
+// columns and referential actions are populated when available.
+func BuildDescribeConstraintsQuery(database, table string) string {
+	return fmt.Sprintf(`SELECT tc.CONSTRAINT_NAME AS constraint_name,
+       tc.CONSTRAINT_TYPE AS constraint_type,
+       kcu.ORDINAL_POSITION AS ordinal_position,
+       kcu.COLUMN_NAME AS column_name,
+       kcu.REFERENCED_TABLE_SCHEMA AS referenced_namespace,
+       kcu.REFERENCED_TABLE_NAME AS referenced_table,
+       kcu.REFERENCED_COLUMN_NAME AS referenced_column,
+       rc.DELETE_RULE AS on_delete,
+       rc.UPDATE_RULE AS on_update
+FROM information_schema.TABLE_CONSTRAINTS tc
+LEFT JOIN information_schema.KEY_COLUMN_USAGE kcu
+  ON tc.CONSTRAINT_SCHEMA = kcu.CONSTRAINT_SCHEMA
+ AND tc.TABLE_NAME = kcu.TABLE_NAME
+ AND tc.CONSTRAINT_NAME = kcu.CONSTRAINT_NAME
+LEFT JOIN information_schema.REFERENTIAL_CONSTRAINTS rc
+  ON tc.CONSTRAINT_SCHEMA = rc.CONSTRAINT_SCHEMA
+ AND tc.CONSTRAINT_NAME = rc.CONSTRAINT_NAME
+WHERE tc.TABLE_SCHEMA = '%s'
+  AND tc.TABLE_NAME = '%s'
+ORDER BY tc.CONSTRAINT_NAME, kcu.ORDINAL_POSITION`, EscapeSQLString(database), EscapeSQLString(table))
+}

--- a/internal/query/mysql/constraints_test.go
+++ b/internal/query/mysql/constraints_test.go
@@ -1,0 +1,24 @@
+package mysql_test
+
+import (
+	"testing"
+
+	"github.com/grafana/gcx/internal/query/mysql"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildDescribeConstraintsQuery(t *testing.T) {
+	query := mysql.BuildDescribeConstraintsQuery("sales", "order_items")
+	assert.Contains(t, query, "information_schema.TABLE_CONSTRAINTS")
+	assert.Contains(t, query, "KEY_COLUMN_USAGE")
+	assert.Contains(t, query, "REFERENTIAL_CONSTRAINTS")
+	assert.Contains(t, query, "tc.TABLE_SCHEMA = 'sales'")
+	assert.Contains(t, query, "tc.TABLE_NAME = 'order_items'")
+	assert.Contains(t, query, "ORDER BY tc.CONSTRAINT_NAME, kcu.ORDINAL_POSITION")
+}
+
+func TestBuildDescribeConstraintsQueryEscapesLiterals(t *testing.T) {
+	query := mysql.BuildDescribeConstraintsQuery("sales'archive", "order'items")
+	assert.Contains(t, query, "tc.TABLE_SCHEMA = 'sales''archive'")
+	assert.Contains(t, query, "tc.TABLE_NAME = 'order''items'")
+}

--- a/internal/query/postgres/constraints.go
+++ b/internal/query/postgres/constraints.go
@@ -1,0 +1,58 @@
+package postgres
+
+import "fmt"
+
+// BuildDescribeConstraintsQuery returns a PostgreSQL catalog query for
+// describe-table --include-constraints. pg_constraint's conkey/confkey
+// arrays, unnested with ordinality, preserve the local and referenced column
+// order for composite keys. The left lateral joins retain CHECK constraints,
+// whose conkey is NULL.
+func BuildDescribeConstraintsQuery(schema, table string) string {
+	return fmt.Sprintf(`SELECT c.conname AS constraint_name,
+       CASE c.contype
+         WHEN 'p' THEN 'PRIMARY KEY'
+         WHEN 'u' THEN 'UNIQUE'
+         WHEN 'f' THEN 'FOREIGN KEY'
+         WHEN 'c' THEN 'CHECK'
+         WHEN 'x' THEN 'EXCLUDE'
+         ELSE c.contype::text
+       END AS constraint_type,
+       cols.ordinality AS ordinal_position,
+       src_att.attname AS column_name,
+       ref_ns.nspname AS referenced_namespace,
+       ref_cls.relname AS referenced_table,
+       ref_att.attname AS referenced_column,
+       CASE c.confdeltype
+         WHEN 'a' THEN 'NO ACTION'
+         WHEN 'r' THEN 'RESTRICT'
+         WHEN 'c' THEN 'CASCADE'
+         WHEN 'n' THEN 'SET NULL'
+         WHEN 'd' THEN 'SET DEFAULT'
+         ELSE NULL
+       END AS on_delete,
+       CASE c.confupdtype
+         WHEN 'a' THEN 'NO ACTION'
+         WHEN 'r' THEN 'RESTRICT'
+         WHEN 'c' THEN 'CASCADE'
+         WHEN 'n' THEN 'SET NULL'
+         WHEN 'd' THEN 'SET DEFAULT'
+         ELSE NULL
+       END AS on_update
+FROM pg_constraint c
+JOIN pg_class src_cls ON src_cls.oid = c.conrelid
+JOIN pg_namespace src_ns ON src_ns.oid = src_cls.relnamespace
+LEFT JOIN LATERAL unnest(c.conkey) WITH ORDINALITY AS cols(attnum, ordinality) ON TRUE
+LEFT JOIN pg_attribute src_att
+  ON src_att.attrelid = c.conrelid
+ AND src_att.attnum = cols.attnum
+LEFT JOIN pg_class ref_cls ON ref_cls.oid = c.confrelid
+LEFT JOIN pg_namespace ref_ns ON ref_ns.oid = ref_cls.relnamespace
+LEFT JOIN LATERAL unnest(c.confkey) WITH ORDINALITY AS ref_cols(attnum, ordinality)
+  ON ref_cols.ordinality = cols.ordinality
+LEFT JOIN pg_attribute ref_att
+  ON ref_att.attrelid = c.confrelid
+ AND ref_att.attnum = ref_cols.attnum
+WHERE src_ns.nspname = '%s'
+  AND src_cls.relname = '%s'
+ORDER BY c.conname, cols.ordinality`, EscapeSQLString(schema), EscapeSQLString(table))
+}

--- a/internal/query/postgres/constraints_test.go
+++ b/internal/query/postgres/constraints_test.go
@@ -1,0 +1,24 @@
+package postgres_test
+
+import (
+	"testing"
+
+	"github.com/grafana/gcx/internal/query/postgres"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildDescribeConstraintsQuery(t *testing.T) {
+	query := postgres.BuildDescribeConstraintsQuery("public", "orders")
+	assert.Contains(t, query, "FROM pg_constraint")
+	assert.Contains(t, query, "unnest(c.conkey) WITH ORDINALITY")
+	assert.Contains(t, query, "unnest(c.confkey) WITH ORDINALITY")
+	assert.Contains(t, query, "src_ns.nspname = 'public'")
+	assert.Contains(t, query, "src_cls.relname = 'orders'")
+	assert.Contains(t, query, "ORDER BY c.conname, cols.ordinality")
+}
+
+func TestBuildDescribeConstraintsQueryEscapesLiterals(t *testing.T) {
+	query := postgres.BuildDescribeConstraintsQuery("public'archive", "order'items")
+	assert.Contains(t, query, "src_ns.nspname = 'public''archive'")
+	assert.Contains(t, query, "src_cls.relname = 'order''items'")
+}

--- a/internal/query/sql/constraints.go
+++ b/internal/query/sql/constraints.go
@@ -67,7 +67,8 @@ func ParseTableDescription(namespace, table string, columnsResp, constraintsResp
 	}
 
 	desc := &TableDescription{
-		Table: TableIdentity{Namespace: namespace, Name: table},
+		Table:       TableIdentity{Namespace: namespace, Name: table},
+		Constraints: make([]TableConstraint, 0),
 	}
 	for _, row := range columnsResp.Rows {
 		name, err := valueAsString(rowValue(columnsResp, row, "name"))
@@ -109,6 +110,14 @@ type constraintAccumulator struct {
 }
 
 func parseConstraints(desc *TableDescription, resp *QueryResponse) (*TableDescription, error) {
+	// Grafana's MySQL plugin returns an empty frame as {columns:null,rows:null}
+	// when information_schema has no matching constraints. Treat that as a
+	// valid table with no declared constraints; there are no rows whose aliases
+	// need validation.
+	if len(resp.Rows) == 0 {
+		return desc, nil
+	}
+
 	// Validate the aliases once, before touching any row. A malformed or
 	// changed provider query should fail clearly instead of silently returning
 	// incomplete relationship metadata.

--- a/internal/query/sql/constraints.go
+++ b/internal/query/sql/constraints.go
@@ -1,0 +1,323 @@
+package sql
+
+import (
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// TableDescription is the structured response returned by describe-table
+// when constraint metadata is requested. Namespace is the database for MySQL
+// and the schema for PostgreSQL. The shape intentionally differs from the
+// legacy QueryResponse so the opt-in response can carry table identity and
+// relationships without changing the default output contract.
+type TableDescription struct {
+	Table       TableIdentity     `json:"table"`
+	Columns     []TableColumn     `json:"columns"`
+	Constraints []TableConstraint `json:"constraints"`
+}
+
+// TableIdentity identifies a table in a datasource namespace.
+type TableIdentity struct {
+	Namespace string `json:"namespace"`
+	Name      string `json:"name"`
+}
+
+// TableColumn describes a column in a TableDescription.
+type TableColumn struct {
+	Name     string `json:"name"`
+	Type     string `json:"type"`
+	Nullable string `json:"nullable"`
+	Default  any    `json:"default"`
+}
+
+// TableConstraint describes one table constraint. Referenced is populated
+// only for foreign-key constraints. Columns and Referenced.Columns retain the
+// ordinal order reported by the database, including for composite keys.
+type TableConstraint struct {
+	Name       string          `json:"name"`
+	Type       string          `json:"type"`
+	Columns    []string        `json:"columns"`
+	Referenced *TableReference `json:"referencedTable,omitempty"`
+	OnDelete   string          `json:"onDelete,omitempty"`
+	OnUpdate   string          `json:"onUpdate,omitempty"`
+}
+
+// TableReference identifies the target of a foreign-key constraint.
+type TableReference struct {
+	Namespace string   `json:"namespace"`
+	Name      string   `json:"name"`
+	Columns   []string `json:"columns"`
+}
+
+// ParseTableDescription combines the column response and a normalized
+// constraint response into the stable describe-table envelope. The
+// constraint query used by each SQL dialect must expose these column aliases:
+// constraint_name, constraint_type, ordinal_position, column_name,
+// referenced_namespace, referenced_table, referenced_column, on_delete, and
+// on_update. Parsing by aliases rather than positional indexes keeps the
+// response resilient to harmless SELECT-list changes.
+func ParseTableDescription(namespace, table string, columnsResp, constraintsResp *QueryResponse) (*TableDescription, error) {
+	if columnsResp == nil {
+		return nil, fmt.Errorf("columns response is nil")
+	}
+	if constraintsResp == nil {
+		return nil, fmt.Errorf("constraints response is nil")
+	}
+
+	desc := &TableDescription{
+		Table: TableIdentity{Namespace: namespace, Name: table},
+	}
+	for _, row := range columnsResp.Rows {
+		name, err := valueAsString(rowValue(columnsResp, row, "name"))
+		if err != nil {
+			return nil, fmt.Errorf("parse column name: %w", err)
+		}
+		typ, err := valueAsString(rowValue(columnsResp, row, "type"))
+		if err != nil {
+			return nil, fmt.Errorf("parse column type: %w", err)
+		}
+		nullable, err := valueAsString(rowValue(columnsResp, row, "nullable"))
+		if err != nil {
+			return nil, fmt.Errorf("parse column nullable: %w", err)
+		}
+		if name == "" {
+			return nil, fmt.Errorf("column name is empty")
+		}
+		desc.Columns = append(desc.Columns, TableColumn{
+			Name:     name,
+			Type:     typ,
+			Nullable: nullable,
+			Default:  rowValue(columnsResp, row, "default"),
+		})
+	}
+
+	return parseConstraints(desc, constraintsResp)
+}
+
+type constraintColumn struct {
+	ordinal int
+	seen    int
+	name    string
+}
+
+type constraintAccumulator struct {
+	constraint        TableConstraint
+	columns           []constraintColumn
+	referencedColumns []constraintColumn
+}
+
+func parseConstraints(desc *TableDescription, resp *QueryResponse) (*TableDescription, error) {
+	// Validate the aliases once, before touching any row. A malformed or
+	// changed provider query should fail clearly instead of silently returning
+	// incomplete relationship metadata.
+	for _, alias := range []string{"constraint_name", "constraint_type", "ordinal_position", "column_name", "referenced_namespace", "referenced_table", "referenced_column", "on_delete", "on_update"} {
+		if findColumn(resp, alias) < 0 {
+			return nil, fmt.Errorf("constraints response is missing column %q", alias)
+		}
+	}
+
+	byName := make(map[string]*constraintAccumulator)
+	order := make([]string, 0)
+	for rowIndex, row := range resp.Rows {
+		name, err := valueAsString(rowValue(resp, row, "constraint_name"))
+		if err != nil {
+			return nil, fmt.Errorf("parse constraint name: %w", err)
+		}
+		typ, err := valueAsString(rowValue(resp, row, "constraint_type"))
+		if err != nil {
+			return nil, fmt.Errorf("parse constraint type: %w", err)
+		}
+		if name == "" || typ == "" {
+			return nil, fmt.Errorf("constraint name and type must not be empty")
+		}
+
+		acc := byName[name]
+		if acc == nil {
+			acc = &constraintAccumulator{
+				constraint: TableConstraint{Name: name, Type: typ},
+			}
+			byName[name] = acc
+			order = append(order, name)
+		} else if acc.constraint.Type != typ {
+			return nil, fmt.Errorf("constraint %q has inconsistent types %q and %q", name, acc.constraint.Type, typ)
+		}
+
+		ordinal, err := valueAsInt(rowValue(resp, row, "ordinal_position"))
+		if err != nil {
+			return nil, fmt.Errorf("parse constraint %q ordinal position: %w", name, err)
+		}
+		columnName, err := valueAsString(rowValue(resp, row, "column_name"))
+		if err != nil {
+			return nil, fmt.Errorf("parse constraint %q column: %w", name, err)
+		}
+		if columnName != "" {
+			acc.columns = append(acc.columns, constraintColumn{ordinal: ordinal, seen: rowIndex, name: columnName})
+		}
+
+		refNamespace, err := valueAsString(rowValue(resp, row, "referenced_namespace"))
+		if err != nil {
+			return nil, fmt.Errorf("parse constraint %q referenced namespace: %w", name, err)
+		}
+		refTable, err := valueAsString(rowValue(resp, row, "referenced_table"))
+		if err != nil {
+			return nil, fmt.Errorf("parse constraint %q referenced table: %w", name, err)
+		}
+		refColumn, err := valueAsString(rowValue(resp, row, "referenced_column"))
+		if err != nil {
+			return nil, fmt.Errorf("parse constraint %q referenced column: %w", name, err)
+		}
+		if refNamespace != "" || refTable != "" || refColumn != "" {
+			if acc.constraint.Referenced == nil {
+				acc.constraint.Referenced = &TableReference{Namespace: refNamespace, Name: refTable}
+			} else if acc.constraint.Referenced.Namespace != refNamespace || acc.constraint.Referenced.Name != refTable {
+				return nil, fmt.Errorf("constraint %q has inconsistent referenced table", name)
+			}
+			if refColumn != "" {
+				acc.referencedColumns = append(acc.referencedColumns, constraintColumn{ordinal: ordinal, seen: rowIndex, name: refColumn})
+			}
+		}
+
+		deleteRule, err := valueAsString(rowValue(resp, row, "on_delete"))
+		if err != nil {
+			return nil, fmt.Errorf("parse constraint %q delete action: %w", name, err)
+		}
+		updateRule, err := valueAsString(rowValue(resp, row, "on_update"))
+		if err != nil {
+			return nil, fmt.Errorf("parse constraint %q update action: %w", name, err)
+		}
+		if deleteRule != "" {
+			if acc.constraint.OnDelete != "" && acc.constraint.OnDelete != deleteRule {
+				return nil, fmt.Errorf("constraint %q has inconsistent delete actions", name)
+			}
+			acc.constraint.OnDelete = deleteRule
+		}
+		if updateRule != "" {
+			if acc.constraint.OnUpdate != "" && acc.constraint.OnUpdate != updateRule {
+				return nil, fmt.Errorf("constraint %q has inconsistent update actions", name)
+			}
+			acc.constraint.OnUpdate = updateRule
+		}
+	}
+
+	for _, name := range order {
+		acc := byName[name]
+		sort.SliceStable(acc.columns, func(i, j int) bool {
+			if acc.columns[i].ordinal == acc.columns[j].ordinal {
+				return acc.columns[i].seen < acc.columns[j].seen
+			}
+			// A nil ordinal is represented as zero. Keep it after real
+			// ordinals while preserving source order among nils.
+			if acc.columns[i].ordinal == 0 {
+				return false
+			}
+			if acc.columns[j].ordinal == 0 {
+				return true
+			}
+			return acc.columns[i].ordinal < acc.columns[j].ordinal
+		})
+		acc.constraint.Columns = make([]string, 0, len(acc.columns))
+		for _, col := range acc.columns {
+			acc.constraint.Columns = append(acc.constraint.Columns, col.name)
+		}
+		if acc.constraint.Referenced != nil {
+			sort.SliceStable(acc.referencedColumns, func(i, j int) bool {
+				if acc.referencedColumns[i].ordinal == acc.referencedColumns[j].ordinal {
+					return acc.referencedColumns[i].seen < acc.referencedColumns[j].seen
+				}
+				if acc.referencedColumns[i].ordinal == 0 {
+					return false
+				}
+				if acc.referencedColumns[j].ordinal == 0 {
+					return true
+				}
+				return acc.referencedColumns[i].ordinal < acc.referencedColumns[j].ordinal
+			})
+			acc.constraint.Referenced.Columns = make([]string, 0, len(acc.referencedColumns))
+			for _, col := range acc.referencedColumns {
+				acc.constraint.Referenced.Columns = append(acc.constraint.Referenced.Columns, col.name)
+			}
+		}
+		desc.Constraints = append(desc.Constraints, acc.constraint)
+	}
+
+	return desc, nil
+}
+
+func findColumn(resp *QueryResponse, name string) int {
+	for i, col := range resp.Columns {
+		if strings.EqualFold(col.Name, name) {
+			return i
+		}
+	}
+	return -1
+}
+
+func rowValue(resp *QueryResponse, row []any, name string) any {
+	idx := findColumn(resp, name)
+	if idx < 0 || idx >= len(row) {
+		return nil
+	}
+	return row[idx]
+}
+
+func valueAsString(value any) (string, error) {
+	if value == nil {
+		return "", nil
+	}
+	switch v := value.(type) {
+	case string:
+		return v, nil
+	case []byte:
+		return string(v), nil
+	case fmt.Stringer:
+		return v.String(), nil
+	default:
+		return fmt.Sprint(v), nil
+	}
+}
+
+func valueAsInt(value any) (int, error) {
+	if value == nil {
+		return 0, nil
+	}
+	switch v := value.(type) {
+	case int:
+		return v, nil
+	case int8:
+		return int(v), nil
+	case int16:
+		return int(v), nil
+	case int32:
+		return int(v), nil
+	case int64:
+		return int(v), nil
+	case uint:
+		return int(v), nil
+	case uint8:
+		return int(v), nil
+	case uint16:
+		return int(v), nil
+	case uint32:
+		return int(v), nil
+	case uint64:
+		return int(v), nil
+	case float32:
+		return int(v), nil
+	case float64:
+		return int(v), nil
+	case string:
+		n, err := strconv.Atoi(strings.TrimSpace(v))
+		if err != nil {
+			return 0, err
+		}
+		return n, nil
+	default:
+		n, err := strconv.Atoi(strings.TrimSpace(fmt.Sprint(v)))
+		if err != nil {
+			return 0, err
+		}
+		return n, nil
+	}
+}

--- a/internal/query/sql/constraints_test.go
+++ b/internal/query/sql/constraints_test.go
@@ -66,7 +66,26 @@ func TestParseTableDescriptionPreservesCompositeConstraintOrder(t *testing.T) {
 
 func TestParseTableDescriptionRejectsMalformedConstraintResponse(t *testing.T) {
 	columns := &querysql.QueryResponse{Columns: []querysql.Column{{Name: "name"}, {Name: "type"}, {Name: "nullable"}, {Name: "default"}}, Rows: [][]any{{"id", "integer", "NO", nil}}}
-	_, err := querysql.ParseTableDescription("public", "orders", columns, &querysql.QueryResponse{})
+	malformed := &querysql.QueryResponse{
+		Columns: []querysql.Column{{Name: "unexpected"}},
+		Rows:    [][]any{{"value"}},
+	}
+	_, err := querysql.ParseTableDescription("public", "orders", columns, malformed)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `missing column "constraint_name"`)
+}
+
+func TestParseTableDescriptionAcceptsNoDeclaredConstraints(t *testing.T) {
+	columns := &querysql.QueryResponse{
+		Columns: []querysql.Column{{Name: "name"}, {Name: "type"}, {Name: "nullable"}, {Name: "default"}},
+		Rows:    [][]any{{"id", "bigint", "NO", nil}},
+	}
+
+	desc, err := querysql.ParseTableDescription("dw_hacking_tracking", "discount_invoke", columns, &querysql.QueryResponse{})
+	require.NoError(t, err)
+	assert.Empty(t, desc.Constraints)
+
+	encoded, err := json.Marshal(desc)
+	require.NoError(t, err)
+	assert.Contains(t, string(encoded), `"constraints":[]`)
 }

--- a/internal/query/sql/constraints_test.go
+++ b/internal/query/sql/constraints_test.go
@@ -1,0 +1,72 @@
+package sql_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	querysql "github.com/grafana/gcx/internal/query/sql"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseTableDescriptionPreservesCompositeConstraintOrder(t *testing.T) {
+	columns := &querysql.QueryResponse{
+		Columns: []querysql.Column{
+			{Name: "name"}, {Name: "type"}, {Name: "nullable"}, {Name: "default"},
+		},
+		Rows: [][]any{
+			{"id", "bigint", "NO", nil},
+			{"tenant_id", "bigint", "NO", "0"},
+		},
+	}
+	constraints := &querysql.QueryResponse{
+		Columns: []querysql.Column{
+			{Name: "constraint_name"},
+			{Name: "constraint_type"},
+			{Name: "ordinal_position"},
+			{Name: "column_name"},
+			{Name: "referenced_namespace"},
+			{Name: "referenced_table"},
+			{Name: "referenced_column"},
+			{Name: "on_delete"},
+			{Name: "on_update"},
+		},
+		// Deliberately return the second key position first. The parser must
+		// use ordinal_position for both local and referenced columns.
+		Rows: [][]any{
+			{"fk_orders_customer", "FOREIGN KEY", float64(2), "region_id", "crm", "customers", "region", "CASCADE", "NO ACTION"},
+			{"fk_orders_customer", "FOREIGN KEY", float64(1), "customer_id", "crm", "customers", "id", "CASCADE", "NO ACTION"},
+			{"orders_pkey", "PRIMARY KEY", float64(1), "id", nil, nil, nil, nil, nil},
+		},
+	}
+
+	desc, err := querysql.ParseTableDescription("sales", "orders", columns, constraints)
+	require.NoError(t, err)
+	assert.Equal(t, querysql.TableIdentity{Namespace: "sales", Name: "orders"}, desc.Table)
+	require.Len(t, desc.Columns, 2)
+	assert.Equal(t, "tenant_id", desc.Columns[1].Name)
+	require.Len(t, desc.Constraints, 2)
+
+	fk := desc.Constraints[0]
+	assert.Equal(t, "fk_orders_customer", fk.Name)
+	assert.Equal(t, []string{"customer_id", "region_id"}, fk.Columns)
+	require.NotNil(t, fk.Referenced)
+	assert.Equal(t, "crm", fk.Referenced.Namespace)
+	assert.Equal(t, "customers", fk.Referenced.Name)
+	assert.Equal(t, []string{"id", "region"}, fk.Referenced.Columns)
+	assert.Equal(t, "CASCADE", fk.OnDelete)
+	assert.Equal(t, "NO ACTION", fk.OnUpdate)
+
+	// Pin the JSON field names because this is an agent-facing opt-in
+	// contract, not an implementation detail of the Go structs.
+	encoded, err := json.Marshal(desc)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{"table":{"namespace":"sales","name":"orders"},"columns":[{"name":"id","type":"bigint","nullable":"NO","default":null},{"name":"tenant_id","type":"bigint","nullable":"NO","default":"0"}],"constraints":[{"name":"fk_orders_customer","type":"FOREIGN KEY","columns":["customer_id","region_id"],"referencedTable":{"namespace":"crm","name":"customers","columns":["id","region"]},"onDelete":"CASCADE","onUpdate":"NO ACTION"},{"name":"orders_pkey","type":"PRIMARY KEY","columns":["id"]}]}`, string(encoded))
+}
+
+func TestParseTableDescriptionRejectsMalformedConstraintResponse(t *testing.T) {
+	columns := &querysql.QueryResponse{Columns: []querysql.Column{{Name: "name"}, {Name: "type"}, {Name: "nullable"}, {Name: "default"}}, Rows: [][]any{{"id", "integer", "NO", nil}}}
+	_, err := querysql.ParseTableDescription("public", "orders", columns, &querysql.QueryResponse{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `missing column "constraint_name"`)
+}


### PR DESCRIPTION
Closes #1246

## Summary

- add SQL-only `--query-file FILE` support to the typed MySQL, PostgreSQL, ClickHouse, and Athena query commands, including `-` for stdin
- keep positional SQL, `--expr`, and `--query-file` mutually exclusive, and validate unreadable or empty files before config/datasource I/O
- add opt-in `describe-table --include-constraints` metadata for MySQL and PostgreSQL
- preserve default `describe-table` output while returning ordered declared constraints, referenced tables/columns, and referential actions in structured output
- handle Grafana's empty-frame response for tables with no declared constraints as `"constraints": []`

## Scope and compatibility

- `--query-file` is registered only by SQL typed commands; query commands for PromQL, LogQL, and other non-SQL languages are unchanged
- `--include-constraints` requires an explicit database/schema to avoid ambiguous same-named tables
- no relationship inference is performed from same-named columns or sampled values; only database-declared metadata is returned
- ClickHouse and Athena `describe-table` behavior is unchanged because their relationship metadata does not share relational constraint semantics

## Validation

- `go test ./...`
- focused datasource/query tests, including validation-before-I/O and composite foreign-key ordering
- `go vet` on changed packages
- `go build -buildvcs=false ./cmd/gcx`
- regenerated CLI reference docs with agent mode disabled
- exercised `--query-file` against a real MySQL datasource
- exercised `--include-constraints` against a real table with no declared constraints, which exposed and verified the empty-frame fix

`mise` was not available in the local environment, so the equivalent local Go, reference-generation, and build commands above were run directly; CI will run the repository's full `mise run all` gate.
