### PR TITLE
Update OAuth sign-in configuration instructions

### DIFF
--- a/docs/sources/configuration.md
+++ b/docs/sources/configuration.md
@@ -37,6 +37,17 @@ entries retain expiry, granted scopes, and a coherent OAuth/API endpoint pair.
 
 To authorize a `gcx` CLI connection with OAuth, your Grafana user needs the `grafana-assistant-app.tokens.gcx:access` permission. The **gcx User** role, registered by the Grafana Assistant application, grants this permission and is assigned automatically to users with the basic role Viewer or higher.
 
+{{< admonition type="note" >}}
+For situations where your default role is `None` or you're using custom roles that restrict the default `plugins.app:access` action permissions, you will need to allow access to the `grafana-assistant-app` too:
+
+```json
+{
+  "action": "plugins.app:access",
+  "scope": "plugins:id:grafana-assistant-app"
+}
+```
+{{< /admonition >}}
+
 This permission only lets you create `gcx` tokens for your own user. It doesn't grant access to other users' tokens and it doesn't extend your existing Grafana permissions.
 
 {{< admonition type="note" >}}

--- a/docs/sources/configuration.md
+++ b/docs/sources/configuration.md
@@ -38,7 +38,7 @@ entries retain expiry, granted scopes, and a coherent OAuth/API endpoint pair.
 To authorize a `gcx` CLI connection with OAuth, your Grafana user needs the `grafana-assistant-app.tokens.gcx:access` permission. The **gcx User** role, registered by the Grafana Assistant application, grants this permission and is assigned automatically to users with the basic role Viewer or higher.
 
 {{< admonition type="note" >}}
-For situations where your default role is `None` or you're using custom roles that restrict the default `plugins.app:access` action permissions, you will need to allow access to the `grafana-assistant-app` too:
+If your default role is `None`, or you're using a custom role that doesn't grant the default `plugins.app:access` action, you'll also need to explicitly grant access to `grafana-assistant-app`:
 
 ```json
 {

--- a/docs/sources/configuration.md
+++ b/docs/sources/configuration.md
@@ -48,7 +48,7 @@ If your default role is `None`, or you're using a custom role that doesn't grant
 ```
 {{< /admonition >}}
 
-This permission only lets you create `gcx` tokens for your own user. It doesn't grant access to other users' tokens and it doesn't extend your existing Grafana permissions.
+The `grafana-assistant-app.tokens.gcx:access` permission only lets you create `gcx` tokens for your own user. It doesn't grant access to other users' tokens and it doesn't extend your existing Grafana permissions.
 
 {{< admonition type="note" >}}
 If `gcx login` fails with a `Permission Required` error naming the **gcx User** role, ask your Grafana administrator to assign you the **gcx User** role, or a custom role that includes the `grafana-assistant-app.tokens.gcx:access` permission. If the role doesn't exist on your instance, the Grafana Assistant application needs to be updated to a version that includes it.


### PR DESCRIPTION
Added note about custom roles and access permissions for gcx CLI.

The current documentation doesn't take into account custom roles where the `plugins.app:access` permissions are stripped down. 