### PR TITLE
feat(fleet): move Fleet Management to the collector app plugin proxy

### DIFF
--- a/.claude/skills/migrate-provider/SKILL.md
+++ b/.claude/skills/migrate-provider/SKILL.md
@@ -144,8 +144,9 @@ as the recording template.
 ### 0.3: Identify Pattern Reference
 
 Identify and read the closest existing gcx provider as a pattern reference:
-- **Cloud APIs with separate URLs** → `fleet`
+- **Cloud APIs with separate URLs** → `k6` (fleet no longer applies: it uses the plugin proxy)
 - **Plugin APIs (standard Grafana SA token)** → `slo`
+- **gRPC-style POST APIs behind a plugin proxy** → `fleet`
 - **gRPC-style POST APIs** → `incidents`
 - **Token exchange auth** → `k6`
 - **Multi-resource providers** → `oncall`

--- a/.claude/skills/migrate-provider/SKILL.md
+++ b/.claude/skills/migrate-provider/SKILL.md
@@ -144,11 +144,10 @@ as the recording template.
 ### 0.3: Identify Pattern Reference
 
 Identify and read the closest existing gcx provider as a pattern reference:
-- **Cloud APIs with separate URLs** → `k6` (fleet no longer applies: it uses the plugin proxy)
 - **Plugin APIs (standard Grafana SA token)** → `slo`
 - **gRPC-style POST APIs behind a plugin proxy** → `fleet`
 - **gRPC-style POST APIs** → `incidents`
-- **Token exchange auth** → `k6`
+- **Cloud APIs on a separate URL, with token exchange** → `k6`
 - **Multi-resource providers** → `oncall`
 - **Plugin proxy APIs** → `kg`
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -128,7 +128,7 @@ Action-verb command tree for Grafana Cloud's Instrumentation Hub. Backed by flee
 - **`instrumentation clusters [list|get|configure|remove|wait]`** + nested **`apps`** — Declared-state read/write with tri-state flag semantics on `configure` and a per-namespace optimistic-lock guard
 - **`instrumentation services [list|get|include|exclude|clear]`** — Observed-state fleet sweep via `RunK8sDiscovery` with DWIM single-workload mutation
 
-Uses `internal/providers/instrumentation/` (provider, types, output codecs, RMW helper, helm formatter, enumeration helper) and `internal/fleet/` (shared base HTTP client, also used by the fleet provider). `check` and `explain` are thin cmd/-only wrappers around the upstream `github.com/grafana/otel-checker/checks` and `.../checks/explain` packages — no provider glue. `check --fix-plan=assistant` embeds Grafana Assistant via `internal/providers/assistant.ResolveClientOptions` + `RequireGrafanaCloud` (reused from the same auth resolution used by `gcx assistant prompt`), then calls `ChatWithApproval` directly; the two-mode dispatch (local vs. assistant, no cross-mode fallback) lives in `cmd/gcx/instrumentation/check/fixplan/`. See ADR-018 for the design.
+Uses `internal/providers/instrumentation/` (provider, types, output codecs, RMW helper, helm formatter, enumeration helper) and `internal/fleet/` (shared base HTTP client, also used by the fleet provider; it reaches Fleet Management through the `grafana-collector-app` plugin proxy on the stack — see ADR-023). `check` and `explain` are thin cmd/-only wrappers around the upstream `github.com/grafana/otel-checker/checks` and `.../checks/explain` packages — no provider glue. `check --fix-plan=assistant` embeds Grafana Assistant via `internal/providers/assistant.ResolveClientOptions` + `RequireGrafanaCloud` (reused from the same auth resolution used by `gcx assistant prompt`), then calls `ChatWithApproval` directly; the two-mode dispatch (local vs. assistant, no cross-mode fallback) lives in `cmd/gcx/instrumentation/check/fixplan/`. See ADR-018 for the design.
 
 ### 7. Configuration
 
@@ -223,6 +223,7 @@ can otherwise inject Grafana auth into the wrong request.
 | [020](docs/adrs/sm-datasource-proxy/001-dual-mode-transport.md) | Synthetic Monitoring dual-mode transport: datasource proxy primary, direct SM API fallback | accepted |
 | [021](docs/adrs/assistant-provider/001-assistant-provider-and-mcp-servers-as-resources.md) | Assistant provider + MCP servers as resources | proposed |
 | [022](docs/adrs/config-v1/001-versioned-split-config-and-secret-trust.md) | Versioned Split Config and Source-Bound Secret Trust | proposed |
+| [023](docs/adrs/fleet-plugin-proxy/001-fleet-via-collector-app-proxy.md) | Fleet Management through the collector app plugin proxy | accepted |
 
 See [docs/adrs/](docs/adrs/) for all ADRs.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 **Breaking changes**
 
-- Fleet Management and Instrumentation now use the `grafana-collector-app` plugin proxy instead of direct Cloud Access Policy authentication. A Cloud Access Policy token with `fleet-management` scopes is no longer sufficient. Use a Grafana stack login and ensure that the plugin is enabled. Older stack tokens can require a new `gcx login` to obtain `grafana-api:write`. Named plugin routes need `grafana-collector-app:read`; wildcard routes need `grafana-collector-app:admin`, including some read-only commands.
+- Fleet Management and Instrumentation now use the `grafana-collector-app` plugin proxy instead of direct Cloud Access Policy authentication. A Cloud Access Policy token with `fleet-management` scopes is no longer sufficient. Use a Grafana stack login and ensure that the plugin is enabled. Older stack tokens can require a new `gcx login` to obtain `grafana-api:write`. Named plugin routes need `grafana-collector-app:read`. Wildcard routes need `grafana-collector-app:admin`, including some read-only commands. The default `gcx cloud login --scope` list no longer includes `fleet-management:read` or `fleet-management:write`.
+- Fleet collector resource manifests now include `spec.id`. Collector creation requires this field. Existing numeric-ID manifests continue to work for update and delete. Add `spec.id` before you reuse an older manifest to create a collector.
+- `gcx setup status` now adds `fleet-management` as the first item in `products`. Select entries by `.product` instead of their array position. The command returns exit code 1 when the plugin is missing or disabled. It returns exit code 4 when the Instrumentation check fails. In both cases, it emits the status document before it exits.
 
 **New Features**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+**Breaking changes**
+
+- Fleet Management and Instrumentation now use the `grafana-collector-app` plugin proxy instead of direct Cloud Access Policy authentication. A Cloud Access Policy token with `fleet-management` scopes is no longer sufficient. Use a Grafana stack login and ensure that the plugin is enabled. Older stack tokens can require a new `gcx login` to obtain `grafana-api:write`. Named plugin routes need `grafana-collector-app:read`; wildcard routes need `grafana-collector-app:admin`, including some read-only commands.
+
 **New Features**
 
 - Added `--fix-plan` to `gcx instrumentation check`, with two explicit modes: `--fix-plan=local` produces a deterministic aggregation of the explanation docs' "How to fix" sections (offline, no billing, works on OSS/Enterprise), and `--fix-plan=assistant` synthesizes a prioritized plan with Grafana Assistant (BILLABLE, requires a Grafana Cloud context — see the Assistant pricing docs). The two modes are disjoint: assistant mode returns a clear error when preconditions aren't met rather than silently falling back to local. `--fix-plan` alone is rejected; users must specify a mode.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - traces: add experimental `gcx traces baseline <trace-id>` to retrieve same-operation candidate traces (root identity, operation success, and topology fingerprint) to feed into `gcx traces diff`, with optional raw TraceQL filters when the unfiltered candidates are not valid comparisons.
 - traces: include Tempo `serviceStats` metadata (per-service span and error counts) in structured trace search output.
 
+**Fixes**
+
+- Correct Fleet resource examples, preserve string collector IDs in resource manifests, and include the collector name and ID in successful create output.
+
 ## v1.2.0 (2026-08-25)
 
 **Breaking changes**

--- a/CONSTITUTION.md
+++ b/CONSTITUTION.md
@@ -193,13 +193,21 @@ agent mode detection, behavior changes, and opt-out mechanisms.
   credentials independently — this ensures consistent env var precedence,
   secret handling, and auth behavior across all providers.
 - **`httputils.NewDefaultClient(ctx)` for external APIs.** Provider clients
-  calling APIs outside the Grafana server (k6 Cloud, OnCall, Fleet —
+  calling APIs outside the Grafana server (k6 Cloud, OnCall —
   any domain other than `cfg.Host`) must use `httputils.NewDefaultClient(ctx)`,
   never `rest.HTTPClientFor()`. The k8s transport round-tripper injects the
   Grafana bearer token on every outgoing request, which conflicts with the
   product's own auth mechanism. `NewDefaultClient(ctx)` returns an `*http.Client`
   with `LoggingRoundTripper` and no auth injection — providers set their own
   auth headers per request.
+- **Fleet Management runs through the plugin proxy.** Fleet Management and the
+  Instrumentation Hub reach their API at `cfg.Host`, through the
+  `grafana-collector-app` plugin proxy
+  (`/api/plugin-proxy/grafana-collector-app/fleet-management-api/…`). The plugin
+  adds the Fleet Management credentials and the tenant headers server-side, so
+  the client carries the caller's Grafana credential only and uses
+  `rest.HTTPClientFor()`, the same as Faro. Fleet Management needs no
+  grafana.com token and no `fleet-management` access policy scope. See ADR-023.
 - **Synth is dual-mode (carve-out).** Synthetic Monitoring reaches its API two
   ways: (1) primary — Grafana's datasource proxy at `cfg.Host`
   (`/api/datasources/proxy/uid/<sm-uid>/sm/…`) via `rest.HTTPClientFor()` in

--- a/claude-plugin/skills/gcx-demo/SKILL.md
+++ b/claude-plugin/skills/gcx-demo/SKILL.md
@@ -201,7 +201,8 @@ the create commands for checks, schedules, and pipelines currently don't.)
 |-----------|--------|
 | `config check` fails | Stop. Ask user to fix the context before continuing. |
 | Signal datasource not found | Skip that signal type, note it. |
-| Cloud auth or stack slug missing | Skip k6 and fleet, note what's needed. |
+| Cloud auth or stack slug missing | Skip k6, note what's needed. Fleet needs the stack login only. |
+| Collector app plugin absent (fleet 404) | Skip fleet, run `gcx setup status` to name the cause. |
 | Assistant unavailable (self-hosted, OAuth missing, 403) | Skip assistant section, note Cloud + OAuth requirement. |
 | Auth scope missing (403) | Note the missing scope, skip, continue. |
 | Empty list (0 resources) | Report "none found" — not an error; continue. |

--- a/cmd/gcx/cloud/command_test.go
+++ b/cmd/gcx/cloud/command_test.go
@@ -512,12 +512,12 @@ func TestCloudEntryFromOAuthResultPreservesMetadata(t *testing.T) {
 	}, &auth.GCOMResult{
 		AccessToken: "oauth-token",
 		ExpiresAt:   "2030-01-01T00:00:00Z",
-		Scope:       "stacks:read fleet-management:read",
+		Scope:       "stacks:read metrics:write",
 	})
 
 	assert.Equal(t, "oauth-token", entry.OAuthToken)
 	assert.Equal(t, "2030-01-01T00:00:00Z", entry.OAuthTokenExpiresAt)
-	assert.Equal(t, []string{"stacks:read", "fleet-management:read"}, entry.OAuthScopes)
+	assert.Equal(t, []string{"stacks:read", "metrics:write"}, entry.OAuthScopes)
 	assert.Equal(t, "https://grafana-ops.com", entry.OAuthUrl)
 	assert.Equal(t, "https://grafana-ops.com", entry.APIUrl)
 }

--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -1171,8 +1171,8 @@ func convertFleetHTTPErrors(err error) (*gcxerrors.DetailedError, bool) {
 	if httpErr.Status == http.StatusNotFound && fleet.IsPluginMissingBody(httpErr.Body) {
 		return &gcxerrors.DetailedError{
 			Parent:  err,
-			Summary: "Fleet Management plugin not available",
-			Details: "The grafana-collector-app plugin is not installed or not enabled on this stack",
+			Summary: "Endpoint not available",
+			Details: "The " + fleet.CollectorAppID + " plugin is not installed or not enabled on this stack",
 			Suggestions: []string{
 				"Check the plugin and your permissions: gcx setup status",
 				"Install or enable the Collector app in Grafana: Administration > Plugins",
@@ -1201,8 +1201,8 @@ func convertFleetHTTPErrors(err error) (*gcxerrors.DetailedError, bool) {
 			Summary: "Authorization failed",
 			Details: "HTTP 403 from " + httpErr.Path,
 			Suggestions: []string{
-				"Read commands need the grafana-collector-app:read action on this stack",
-				"Write commands need the Admin role, or the grafana-collector-app:admin action",
+				"Named read routes need the " + fleet.CollectorAppReadAction + " action on this stack",
+				"Wildcard routes need the Admin role, or the " + fleet.CollectorAppAdminAction + " action; some read-only commands use these routes",
 				"Check what your login holds: gcx setup status",
 			},
 			DocsLink: docs.RolesAndPermissions,

--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -1168,7 +1168,7 @@ func convertFleetHTTPErrors(err error) (*gcxerrors.DetailedError, bool) {
 	// Grafana returns this when the collector app plugin is absent or disabled.
 	// It arrives as a 404, the same status Fleet Management uses for an absent
 	// resource, so the body decides.
-	if strings.Contains(httpErr.Body, fleet.PluginRouteMissingMarker) {
+	if httpErr.Status == http.StatusNotFound && fleet.IsPluginMissingBody(httpErr.Body) {
 		return &gcxerrors.DetailedError{
 			Parent:  err,
 			Summary: "Fleet Management plugin not available",

--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -1105,34 +1105,6 @@ func convertCloudConfigErrors(err error) (*gcxerrors.DetailedError, bool) {
 		}, true
 	}
 
-	// Fleet API scope error on read operations.
-	if strings.Contains(msg, "fleet:") && strings.Contains(msg, "invalid scope") &&
-		(strings.Contains(msg, "list ") || strings.Contains(msg, "get ")) {
-		return &gcxerrors.DetailedError{
-			Parent:  err,
-			Summary: "Fleet Management: permission denied",
-			Suggestions: []string{
-				"Ensure your cloud token's access policy includes the fleet-management:read scope",
-			},
-			DocsLink: docs.AccessPolicies,
-			ExitCode: new(gcxerrors.ExitAuthFailure),
-		}, true
-	}
-
-	// Fleet API scope error on write operations.
-	if strings.Contains(msg, "fleet:") && strings.Contains(msg, "invalid scope") &&
-		(strings.Contains(msg, "create ") || strings.Contains(msg, "update ") || strings.Contains(msg, "delete ")) {
-		return &gcxerrors.DetailedError{
-			Parent:  err,
-			Summary: "Fleet Management: permission denied",
-			Suggestions: []string{
-				"Ensure your cloud token's access policy includes the fleet-management:write scope",
-			},
-			DocsLink: docs.AccessPolicies,
-			ExitCode: new(gcxerrors.ExitAuthFailure),
-		}, true
-	}
-
 	// Adaptive Traces scope errors.
 	if strings.Contains(msg, "adaptive-traces:") && strings.Contains(msg, "invalid scope") {
 		return &gcxerrors.DetailedError{
@@ -1162,21 +1134,6 @@ func convertCloudConfigErrors(err error) (*gcxerrors.DetailedError, bool) {
 		}, true
 	}
 
-	// Fleet management not available.
-	if strings.Contains(msg, "fleet management endpoint is not available") ||
-		strings.Contains(msg, "fleet management instance ID is not available") {
-		return &gcxerrors.DetailedError{
-			Summary: "Fleet Management not available",
-			Details: msg,
-			Parent:  err,
-			Suggestions: []string{
-				"Fleet Management may not be enabled for this stack",
-				"Contact Grafana Cloud support to enable Fleet Management",
-			},
-			DocsLink: docs.FleetManagement,
-		}, true
-	}
-
 	// Stack info lookup forbidden — access policy missing stacks:read scope.
 	if strings.Contains(msg, "failed to get stack info for") && strings.Contains(msg, "status 403") {
 		suggestions := []string{
@@ -1198,12 +1155,31 @@ func convertCloudConfigErrors(err error) (*gcxerrors.DetailedError, bool) {
 }
 
 // convertFleetHTTPErrors converts fleet.HTTPError values (non-2xx HTTP
-// responses from the Fleet Management API) into structured DetailedErrors with
-// actionable auth suggestions for 401 and 403 responses.
+// responses from the Fleet Management plugin proxy) into structured
+// DetailedErrors. Fleet Management runs behind the grafana-collector-app plugin
+// proxy on the stack, so an absent plugin and an absent permission are the two
+// common causes.
 func convertFleetHTTPErrors(err error) (*gcxerrors.DetailedError, bool) {
 	var httpErr *fleet.HTTPError
 	if !errors.As(err, &httpErr) {
 		return nil, false
+	}
+
+	// Grafana returns this when the collector app plugin is absent or disabled.
+	// It arrives as a 404, the same status Fleet Management uses for an absent
+	// resource, so the body decides.
+	if strings.Contains(httpErr.Body, fleet.PluginRouteMissingMarker) {
+		return &gcxerrors.DetailedError{
+			Parent:  err,
+			Summary: "Fleet Management plugin not available",
+			Details: "The grafana-collector-app plugin is not installed or not enabled on this stack",
+			Suggestions: []string{
+				"Check the plugin and your permissions: gcx setup status",
+				"Install or enable the Collector app in Grafana: Administration > Plugins",
+				"Fleet Management is a Grafana Cloud product and is not available on self-hosted Grafana",
+			},
+			DocsLink: docs.FleetManagement,
+		}, true
 	}
 
 	switch httpErr.Status {
@@ -1213,11 +1189,10 @@ func convertFleetHTTPErrors(err error) (*gcxerrors.DetailedError, bool) {
 			Summary: "Authentication failed",
 			Details: "HTTP 401 from " + httpErr.Path,
 			Suggestions: []string{
-				"Ensure cloud auth is configured: gcx cloud login",
 				"Verify the token has not expired: gcx config view",
 				reauthSuggestion,
 			},
-			DocsLink: docs.AccessPolicies,
+			DocsLink: docs.ServiceAccounts,
 			ExitCode: new(gcxerrors.ExitAuthFailure),
 		}, true
 	case http.StatusForbidden:
@@ -1226,11 +1201,11 @@ func convertFleetHTTPErrors(err error) (*gcxerrors.DetailedError, bool) {
 			Summary: "Authorization failed",
 			Details: "HTTP 403 from " + httpErr.Path,
 			Suggestions: []string{
-				"Ensure your Cloud Access Policy includes the fleet-management:read scope",
-				"Ensure your Cloud Access Policy includes the fleet-management:write scope for mutation commands",
-				reauthSuggestion,
+				"Read commands need the grafana-collector-app:read action on this stack",
+				"Write commands need the Admin role, or the grafana-collector-app:admin action",
+				"Check what your login holds: gcx setup status",
 			},
-			DocsLink: docs.AccessPolicies,
+			DocsLink: docs.RolesAndPermissions,
 			ExitCode: new(gcxerrors.ExitAuthFailure),
 		}, true
 	}

--- a/cmd/gcx/fail/convert_test.go
+++ b/cmd/gcx/fail/convert_test.go
@@ -436,7 +436,7 @@ func TestErrorToDetailedError_FleetPluginMissing(t *testing.T) {
 	got := fail.ErrorToDetailedError(err)
 
 	require.NotNil(t, got)
-	assert.Equal(t, "Fleet Management plugin not available", got.Summary)
+	assert.Equal(t, "Endpoint not available", got.Summary)
 	assert.Contains(t, got.Details, "grafana-collector-app")
 	require.NotEmpty(t, got.Suggestions)
 	assert.Contains(t, got.Suggestions[0], "gcx setup status")
@@ -455,7 +455,10 @@ func TestErrorToDetailedError_FleetForbiddenNamesTheAction(t *testing.T) {
 	assert.Equal(t, "Authorization failed", got.Summary)
 	require.NotNil(t, got.ExitCode)
 	assert.Equal(t, gcxerrors.ExitAuthFailure, *got.ExitCode)
-	assert.Contains(t, strings.Join(got.Suggestions, "\n"), "grafana-collector-app:admin")
+	suggestions := strings.Join(got.Suggestions, "\n")
+	assert.Contains(t, suggestions, fleet.CollectorAppReadAction)
+	assert.Contains(t, suggestions, fleet.CollectorAppAdminAction)
+	assert.Contains(t, suggestions, "read-only commands")
 }
 
 func TestErrorToDetailedError_StacksReadAdaptiveContext(t *testing.T) {
@@ -956,7 +959,7 @@ func TestConvertFleetHTTPErrors(t *testing.T) {
 		{
 			name:        "404 for a missing plugin route reports the plugin",
 			err:         &fleet.HTTPError{Status: 404, Path: "/foo", Body: `{"message":"plugin route match not found"}`},
-			wantSummary: "Fleet Management plugin not available",
+			wantSummary: "Endpoint not available",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/gcx/fail/convert_test.go
+++ b/cmd/gcx/fail/convert_test.go
@@ -423,70 +423,39 @@ func TestErrorToDetailedError_CloudStackLookupForbidden(t *testing.T) {
 	}
 }
 
-func TestErrorToDetailedError_FleetScopeError(t *testing.T) {
-	tests := []struct {
-		name      string
-		err       error
-		wantScope string
-	}{
-		{
-			name:      "list pipelines invalid scope suggests fleet-management:read",
-			err:       errors.New(`fleet: list pipelines: status 401: {"status":"error","error":"authentication error: invalid scope requested"}`),
-			wantScope: "fleet-management:read",
-		},
-		{
-			name:      "list collectors invalid scope suggests fleet-management:read",
-			err:       errors.New(`fleet: list collectors: status 401: {"status":"error","error":"authentication error: invalid scope requested"}`),
-			wantScope: "fleet-management:read",
-		},
-		{
-			name:      "get pipeline invalid scope suggests fleet-management:read",
-			err:       errors.New(`fleet: get pipeline abc123: status 401: {"status":"error","error":"authentication error: invalid scope requested"}`),
-			wantScope: "fleet-management:read",
-		},
-		{
-			name:      "create pipeline invalid scope suggests fleet-management:write",
-			err:       errors.New(`fleet: create pipeline: status 401: {"status":"error","error":"authentication error: invalid scope requested"}`),
-			wantScope: "fleet-management:write",
-		},
-		{
-			name:      "update pipeline invalid scope suggests fleet-management:write",
-			err:       errors.New(`fleet: update pipeline abc123: status 401: {"status":"error","error":"authentication error: invalid scope requested"}`),
-			wantScope: "fleet-management:write",
-		},
-		{
-			name:      "create collector invalid scope suggests fleet-management:write",
-			err:       errors.New(`fleet: create collector: status 401: {"status":"error","error":"authentication error: invalid scope requested"}`),
-			wantScope: "fleet-management:write",
-		},
-		{
-			name:      "update collector invalid scope suggests fleet-management:write",
-			err:       errors.New(`fleet: update collector abc123: status 401: {"status":"error","error":"authentication error: invalid scope requested"}`),
-			wantScope: "fleet-management:write",
-		},
-		{
-			name:      "delete pipeline invalid scope suggests fleet-management:write",
-			err:       errors.New(`fleet: delete pipeline abc123: status 401: {"status":"error","error":"authentication error: invalid scope requested"}`),
-			wantScope: "fleet-management:write",
-		},
-	}
+func TestErrorToDetailedError_FleetPluginMissing(t *testing.T) {
+	// Grafana answers with this body when the collector app plugin is absent or
+	// disabled. It arrives as a 404, the same status Fleet Management returns for
+	// an absent resource, so the message must not mention a missing resource.
+	err := fmt.Errorf("fleet: list pipelines: %w", &fleet.HTTPError{
+		Status: 404,
+		Path:   "/pipeline.v1.PipelineService/ListPipelines",
+		Body:   `{"message":"plugin route match not found"}`,
+	})
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := fail.ErrorToDetailedError(tc.err)
+	got := fail.ErrorToDetailedError(err)
 
-			if tc.wantScope == "" {
-				assert.Equal(t, "Unexpected error", got.Summary)
-				return
-			}
+	require.NotNil(t, got)
+	assert.Equal(t, "Fleet Management plugin not available", got.Summary)
+	assert.Contains(t, got.Details, "grafana-collector-app")
+	require.NotEmpty(t, got.Suggestions)
+	assert.Contains(t, got.Suggestions[0], "gcx setup status")
+}
 
-			assert.Equal(t, "Fleet Management: permission denied", got.Summary)
-			require.NotNil(t, got.ExitCode)
-			assert.Equal(t, gcxerrors.ExitAuthFailure, *got.ExitCode)
-			require.Len(t, got.Suggestions, 1)
-			assert.Contains(t, got.Suggestions[0], tc.wantScope)
-		})
-	}
+func TestErrorToDetailedError_FleetForbiddenNamesTheAction(t *testing.T) {
+	err := fmt.Errorf("fleet: create pipeline: %w", &fleet.HTTPError{
+		Status: 403,
+		Path:   "/pipeline.v1.PipelineService/CreatePipeline",
+		Body:   `{"message":"forbidden"}`,
+	})
+
+	got := fail.ErrorToDetailedError(err)
+
+	require.NotNil(t, got)
+	assert.Equal(t, "Authorization failed", got.Summary)
+	require.NotNil(t, got.ExitCode)
+	assert.Equal(t, gcxerrors.ExitAuthFailure, *got.ExitCode)
+	assert.Contains(t, strings.Join(got.Suggestions, "\n"), "grafana-collector-app:admin")
 }
 
 func TestErrorToDetailedError_StacksReadAdaptiveContext(t *testing.T) {
@@ -981,8 +950,13 @@ func TestConvertFleetHTTPErrors(t *testing.T) {
 			wantAuthExit: true,
 		},
 		{
-			name: "404 not handled by this converter",
-			err:  &fleet.HTTPError{Status: 404, Path: "/foo"},
+			name: "404 for a missing resource is not handled by this converter",
+			err:  &fleet.HTTPError{Status: 404, Path: "/foo", Body: `{"code":"not_found","message":"pipeline not found"}`},
+		},
+		{
+			name:        "404 for a missing plugin route reports the plugin",
+			err:         &fleet.HTTPError{Status: 404, Path: "/foo", Body: `{"message":"plugin route match not found"}`},
+			wantSummary: "Fleet Management plugin not available",
 		},
 	}
 	for _, tc := range tests {

--- a/cmd/gcx/fail/convert_test.go
+++ b/cmd/gcx/fail/convert_test.go
@@ -939,13 +939,13 @@ func TestConvertFleetHTTPErrors(t *testing.T) {
 	}{
 		{
 			name:         "401 from fleet management",
-			err:          fmt.Errorf("clusters list: %w", &fleet.HTTPError{Status: 401, Path: "/instrumentation.v1.InstrumentationService/GetK8SInstrumentation"}),
+			err:          fmt.Errorf("clusters list: %w", &fleet.HTTPError{Status: 401, Path: "/instrumentation.v1.InstrumentationService/GetK8SInstrumentation", Body: `{"message":"Plugin not found"}`}),
 			wantSummary:  "Authentication failed",
 			wantAuthExit: true,
 		},
 		{
 			name:         "403 from fleet management",
-			err:          fmt.Errorf("clusters list: %w", &fleet.HTTPError{Status: 403, Path: "/instrumentation.v1.InstrumentationService/GetK8SInstrumentation"}),
+			err:          fmt.Errorf("clusters list: %w", &fleet.HTTPError{Status: 403, Path: "/instrumentation.v1.InstrumentationService/GetK8SInstrumentation", Body: `{"message":"Plugin is not enabled"}`}),
 			wantSummary:  "Authorization failed",
 			wantAuthExit: true,
 		},

--- a/cmd/gcx/instrumentation/services/include_test.go
+++ b/cmd/gcx/instrumentation/services/include_test.go
@@ -67,7 +67,7 @@ func (s *includeTestServer) start(t *testing.T) *httptest.Server {
 
 func makeIncludeClient(t *testing.T, serverURL string) *instrumentation.Client {
 	t.Helper()
-	f := fleet.NewClient(context.Background(), serverURL, "inst-id", "api-token", true, nil)
+	f := fleet.NewClient(context.Background(), serverURL, nil)
 	return instrumentation.NewClient(f)
 }
 

--- a/cmd/gcx/instrumentation/services/list_test.go
+++ b/cmd/gcx/instrumentation/services/list_test.go
@@ -10,10 +10,10 @@ import (
 	"testing"
 
 	"github.com/grafana/gcx/cmd/gcx/instrumentation/services"
+	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/fleet"
 	gcxerrors "github.com/grafana/gcx/internal/gcxerrors"
 	cmdio "github.com/grafana/gcx/internal/output"
-	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/providers/instrumentation"
 	instrumout "github.com/grafana/gcx/internal/providers/instrumentation/output"
 	"github.com/spf13/pflag"
@@ -42,7 +42,7 @@ func (s *discoveryTestServer) start(t *testing.T) *httptest.Server {
 
 func makeDiscoveryClient(t *testing.T, serverURL string) *instrumentation.Client {
 	t.Helper()
-	f := fleet.NewClient(context.Background(), serverURL, "inst-id", "api-token", true, nil)
+	f := fleet.NewClient(context.Background(), serverURL, nil)
 	return instrumentation.NewClient(f)
 }
 
@@ -354,8 +354,8 @@ func TestRunList_JSONFieldSelection_Unknown(t *testing.T) {
 // Used for tests that only exercise cobra.Args validation without RunE.
 type noopConfigLoader struct{}
 
-func (noopConfigLoader) LoadCloudConfig(_ context.Context) (providers.CloudRESTConfig, error) {
-	return providers.CloudRESTConfig{}, errors.New("noop loader: not connected")
+func (noopConfigLoader) LoadGrafanaConfig(_ context.Context) (config.NamespacedRESTConfig, error) {
+	return config.NamespacedRESTConfig{}, errors.New("noop loader: not connected")
 }
 
 // TestListCmd_RejectsPositionalArgs verifies that cobra.NoArgs enforcement

--- a/cmd/gcx/login/command_test.go
+++ b/cmd/gcx/login/command_test.go
@@ -237,7 +237,7 @@ func TestUseExistingCloudEntryPreservesCredentialKindAndMetadata(t *testing.T) {
 			entry: &config.CloudEntry{
 				OAuthToken:          "oauth-token",
 				OAuthTokenExpiresAt: future,
-				OAuthScopes:         []string{"stacks:read", "fleet-management:read"},
+				OAuthScopes:         []string{"stacks:read", "metrics:write"},
 				OAuthUrl:            "https://grafana-dev.com",
 				APIUrl:              "https://grafana-dev.com",
 			},
@@ -290,7 +290,7 @@ func TestRunCloudOAuthPersistsResponseMetadataAndEndpointIntent(t *testing.T) {
 				gotFlowOpts = flowOpts
 				return &stubCloudAuthFlow{result: &internalauth.GCOMResult{
 					AccessToken: "oauth-token",
-					Scope:       "stacks:read fleet-management:read",
+					Scope:       "stacks:read metrics:write",
 					ExpiresAt:   "2030-01-01T00:00:00Z",
 				}}
 			},
@@ -304,7 +304,7 @@ func TestRunCloudOAuthPersistsResponseMetadataAndEndpointIntent(t *testing.T) {
 	assert.Equal(t, internallogin.CloudCredentialOAuth, opts.CloudCredentialKind)
 	assert.True(t, opts.CloudTokenTrusted)
 	assert.Equal(t, "2030-01-01T00:00:00Z", opts.CloudOAuthTokenExpiresAt)
-	assert.Equal(t, []string{"stacks:read", "fleet-management:read"}, opts.CloudOAuthScopes)
+	assert.Equal(t, []string{"stacks:read", "metrics:write"}, opts.CloudOAuthScopes)
 }
 
 func TestUseExistingCloudEntryEndpointChangeFailsClosed(t *testing.T) {

--- a/cmd/gcx/setup/command.go
+++ b/cmd/gcx/setup/command.go
@@ -1,12 +1,14 @@
 package setup
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
 
 	fleetbase "github.com/grafana/gcx/internal/fleet"
 	"github.com/grafana/gcx/internal/format"
+	"github.com/grafana/gcx/internal/gcxerrors"
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers"
 	instrum "github.com/grafana/gcx/internal/providers/instrumentation"
@@ -117,7 +119,7 @@ func newStatusCommand(loader *providers.ConfigLoader) *cobra.Command {
 
 			products := []setupProductStatus{state.row()}
 
-			if !state.available() {
+			if !state.mayServe() {
 				products = append(products, setupProductStatus{
 					Product: "instrumentation",
 					Enabled: false,
@@ -127,29 +129,56 @@ func newStatusCommand(loader *providers.ConfigLoader) *cobra.Command {
 				return opts.IO.Encode(cmd.OutOrStdout(), newSetupStatus(products))
 			}
 
-			r, err := fleetbase.LoadClientWithStack(ctx, loader)
-			if err != nil {
-				return fmt.Errorf("setup: %w", err)
+			// A failed instrumentation call must not discard the Fleet
+			// Management row: that row names the cause. The command reports
+			// the failure in the instrumentation row, then carries the exit
+			// code with EmittedError, so stdout holds exactly one document.
+			row, statusErr := instrumentationRow(ctx, loader)
+			products = append(products, row)
+			if err := opts.IO.Encode(cmd.OutOrStdout(), newSetupStatus(products)); err != nil {
+				return err
 			}
-			client := instrum.NewClient(r.Client)
-			promHdrs := instrum.PromHeadersFromStack(r.Stack)
-
-			monResp, err := client.RunK8sMonitoring(ctx, promHdrs)
-			if err != nil {
-				return fmt.Errorf("setup: %w", err)
+			if statusErr != nil {
+				return gcxerrors.NewEmittedError(gcxerrors.ExitPartialFailure, statusErr)
 			}
-
-			products = append(products, setupProductStatus{
-				Product: "instrumentation",
-				Enabled: len(monResp.Clusters) > 0,
-				Health:  "healthy",
-				Details: fmt.Sprintf("%d clusters", len(monResp.Clusters)),
-			})
-			return opts.IO.Encode(cmd.OutOrStdout(), newSetupStatus(products))
+			return nil
 		},
 	}
 	opts.setup(cmd.Flags())
 	return cmd
+}
+
+// instrumentationRow reads the Instrumentation Hub state through the collector
+// app plugin proxy. It returns a product row in every case: the row carries the
+// reason when the call fails, together with the error for the exit code.
+func instrumentationRow(ctx context.Context, loader *providers.ConfigLoader) (setupProductStatus, error) {
+	r, err := fleetbase.LoadClientWithStack(ctx, loader)
+	if err != nil {
+		return unknownInstrumentationRow(err), fmt.Errorf("setup: %w", err)
+	}
+
+	monResp, err := instrum.NewClient(r.Client).RunK8sMonitoring(ctx, instrum.PromHeadersFromStack(r.Stack))
+	if err != nil {
+		return unknownInstrumentationRow(err), fmt.Errorf("setup: %w", err)
+	}
+
+	return setupProductStatus{
+		Product: "instrumentation",
+		Enabled: len(monResp.Clusters) > 0,
+		Health:  "healthy",
+		Details: fmt.Sprintf("%d clusters", len(monResp.Clusters)),
+	}, nil
+}
+
+// unknownInstrumentationRow renders a failed instrumentation check as a product
+// row, so the user sees the cause next to the Fleet Management row.
+func unknownInstrumentationRow(err error) setupProductStatus {
+	return setupProductStatus{
+		Product: "instrumentation",
+		Enabled: false,
+		Health:  "unknown",
+		Details: "the check failed: " + err.Error(),
+	}
 }
 
 // setupStatusTextCodec is the human "text" codec for setupStatus values: it

--- a/cmd/gcx/setup/command.go
+++ b/cmd/gcx/setup/command.go
@@ -112,21 +112,27 @@ func newStatusCommand(loader *providers.ConfigLoader) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("setup: %w", err)
 			}
-			state, err := checkCollectorApp(ctx, cfg, httpClient)
+			state, err := fleetbase.CheckCollectorApp(ctx, cfg.Host, httpClient)
 			if err != nil {
 				return fmt.Errorf("setup: %w", err)
 			}
 
-			products := []setupProductStatus{state.row()}
+			products := []setupProductStatus{collectorAppRow(state)}
 
-			if !state.mayServe() {
+			if !state.MayServe() {
 				products = append(products, setupProductStatus{
 					Product: "instrumentation",
 					Enabled: false,
 					Health:  "unknown",
-					Details: "needs the " + collectorAppID + " plugin",
+					Details: "needs the " + fleetbase.CollectorAppID + " plugin",
 				})
-				return opts.IO.Encode(cmd.OutOrStdout(), newSetupStatus(products))
+				if err := opts.IO.Encode(cmd.OutOrStdout(), newSetupStatus(products)); err != nil {
+					return err
+				}
+				return gcxerrors.NewEmittedError(
+					gcxerrors.ExitGeneralError,
+					fmt.Errorf("setup: %s plugin is not available", fleetbase.CollectorAppID),
+				)
 			}
 
 			// A failed instrumentation call must not discard the Fleet

--- a/cmd/gcx/setup/command.go
+++ b/cmd/gcx/setup/command.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/gcx/internal/style"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"k8s.io/client-go/rest"
 )
 
 // Command returns the setup command area for onboarding and configuring
@@ -98,6 +99,34 @@ func newStatusCommand(loader *providers.ConfigLoader) *cobra.Command {
 
 			ctx := cmd.Context()
 
+			// Fleet Management reaches its API through the collector app plugin
+			// proxy. Report the plugin and the permissions first, so a user
+			// learns the cause without a failed RPC.
+			cfg, err := loader.LoadGrafanaConfig(ctx)
+			if err != nil {
+				return fmt.Errorf("setup: %w", err)
+			}
+			httpClient, err := rest.HTTPClientFor(&cfg.Config)
+			if err != nil {
+				return fmt.Errorf("setup: %w", err)
+			}
+			state, err := checkCollectorApp(ctx, cfg, httpClient)
+			if err != nil {
+				return fmt.Errorf("setup: %w", err)
+			}
+
+			products := []setupProductStatus{state.row()}
+
+			if !state.available() {
+				products = append(products, setupProductStatus{
+					Product: "instrumentation",
+					Enabled: false,
+					Health:  "unknown",
+					Details: "needs the " + collectorAppID + " plugin",
+				})
+				return opts.IO.Encode(cmd.OutOrStdout(), newSetupStatus(products))
+			}
+
 			r, err := fleetbase.LoadClientWithStack(ctx, loader)
 			if err != nil {
 				return fmt.Errorf("setup: %w", err)
@@ -110,15 +139,13 @@ func newStatusCommand(loader *providers.ConfigLoader) *cobra.Command {
 				return fmt.Errorf("setup: %w", err)
 			}
 
-			status := newSetupStatus([]setupProductStatus{
-				{
-					Product: "instrumentation",
-					Enabled: len(monResp.Clusters) > 0,
-					Health:  "healthy",
-					Details: fmt.Sprintf("%d clusters", len(monResp.Clusters)),
-				},
+			products = append(products, setupProductStatus{
+				Product: "instrumentation",
+				Enabled: len(monResp.Clusters) > 0,
+				Health:  "healthy",
+				Details: fmt.Sprintf("%d clusters", len(monResp.Clusters)),
 			})
-			return opts.IO.Encode(cmd.OutOrStdout(), status)
+			return opts.IO.Encode(cmd.OutOrStdout(), newSetupStatus(products))
 		},
 	}
 	opts.setup(cmd.Flags())

--- a/cmd/gcx/setup/command_test.go
+++ b/cmd/gcx/setup/command_test.go
@@ -5,11 +5,17 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/grafana/gcx/cmd/gcx/setup"
 	"github.com/grafana/gcx/internal/agent"
+	"github.com/grafana/gcx/internal/gcxerrors"
+	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
@@ -170,4 +176,193 @@ func decodeSingleJSONValue(t *testing.T, raw string) map[string]any {
 		t.Fatalf("document is %T, want object", first)
 	}
 	return doc
+}
+
+// runStatus mounts the setup command under a bare root and runs `setup status`
+// against the given handler. It returns the stdout of the command and the error
+// of the run.
+func runStatus(t *testing.T, handler http.HandlerFunc) (string, error) {
+	t.Helper()
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	cfgFile := filepath.Join(t.TempDir(), "config.yaml")
+	cfg := "version: 1\n" +
+		"stacks:\n" +
+		"  test:\n" +
+		"    grafana:\n" +
+		"      server: " + server.URL + "\n" +
+		"      token: test-token\n" +
+		"      org-id: 1\n" +
+		"contexts:\n" +
+		"  test:\n" +
+		"    stack: test\n" +
+		"current-context: test\n"
+	if err := os.WriteFile(cfgFile, []byte(cfg), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	root := &cobra.Command{Use: "gcx", SilenceUsage: true, SilenceErrors: true}
+	root.AddCommand(setup.Command())
+
+	var stdout bytes.Buffer
+	root.SetOut(&stdout)
+	root.SetErr(io.Discard)
+	root.SetArgs([]string{"setup", "status", "--config", cfgFile, "-o", "json"})
+
+	err := root.Execute()
+	return stdout.String(), err
+}
+
+// The Fleet Management preflight row is the reason the preflight exists. A
+// failed instrumentation check must not discard it.
+func TestSetupStatus_KeepsPreflightRowWhenInstrumentationFails(t *testing.T) {
+	tests := []struct {
+		name    string
+		handler http.HandlerFunc
+	}{
+		{
+			name: "stack lookup fails",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/plugins/grafana-collector-app/settings":
+					writeJSON(w, map[string]any{"id": "grafana-collector-app", "enabled": true})
+				case "/api/access-control/user/actions":
+					writeJSON(w, map[string]bool{
+						"grafana-collector-app:read":  true,
+						"grafana-collector-app:admin": true,
+					})
+				default:
+					w.WriteHeader(http.StatusForbidden)
+				}
+			},
+		},
+		{
+			name: "monitoring request fails",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/plugins/grafana-collector-app/settings":
+					writeJSON(w, map[string]any{"id": "grafana-collector-app", "enabled": true})
+				case "/api/access-control/user/actions":
+					writeJSON(w, map[string]bool{
+						"grafana-collector-app:read":  true,
+						"grafana-collector-app:admin": true,
+					})
+				case "/api/plugin-proxy/grafana-collector-app/grafanacom-api/instances/":
+					writeJSON(w, map[string]any{
+						"hmInstancePromId":        123,
+						"hmInstancePromClusterId": 42,
+					})
+				case "/api/plugin-proxy/grafana-collector-app/fleet-management-api/discovery.v1.DiscoveryService/RunK8sMonitoring":
+					w.WriteHeader(http.StatusInternalServerError)
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stdout, err := runStatus(t, tt.handler)
+			if err == nil {
+				t.Fatal("Execute() = nil, want the failure of the instrumentation check")
+			}
+
+			var emitted *gcxerrors.EmittedError
+			if !errors.As(err, &emitted) {
+				t.Fatalf("error = %T (%v), want *gcxerrors.EmittedError", err, err)
+			}
+			if emitted.Code != gcxerrors.ExitPartialFailure {
+				t.Fatalf("exit code = %d, want %d", emitted.Code, gcxerrors.ExitPartialFailure)
+			}
+
+			doc := decodeSingleJSONValue(t, stdout)
+			products, ok := doc["products"].([]any)
+			if !ok || len(products) != 2 {
+				t.Fatalf("products = %v, want two entries", doc["products"])
+			}
+			plugin, ok := products[0].(map[string]any)
+			if !ok {
+				t.Fatalf("products[0] is %T, want object", products[0])
+			}
+			if plugin["product"] != "fleet-management" || plugin["health"] != "healthy" {
+				t.Fatalf("the preflight row is lost: %v", plugin)
+			}
+			instrumentation, ok := products[1].(map[string]any)
+			if !ok {
+				t.Fatalf("products[1] is %T, want object", products[1])
+			}
+			if instrumentation["product"] != "instrumentation" || instrumentation["health"] != "unknown" {
+				t.Fatalf("unexpected instrumentation row: %v", instrumentation)
+			}
+			details, _ := instrumentation["details"].(string)
+			if !strings.Contains(details, "the check failed") {
+				t.Fatalf("details = %q, want the reason of the failure", details)
+			}
+		})
+	}
+}
+
+// An absent plugin ends the run early with one document and no error.
+func TestSetupStatus_PluginAbsentEndsEarly(t *testing.T) {
+	stdout, err := runStatus(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/access-control/user/actions":
+			writeJSON(w, map[string]bool{})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+	if err != nil {
+		t.Fatalf("Execute() = %v, want nil", err)
+	}
+
+	doc := decodeSingleJSONValue(t, stdout)
+	products, ok := doc["products"].([]any)
+	if !ok || len(products) != 2 {
+		t.Fatalf("products = %v, want two entries", doc["products"])
+	}
+	plugin, _ := products[0].(map[string]any)
+	if plugin["product"] != "fleet-management" || plugin["health"] != "unhealthy" {
+		t.Fatalf("unexpected plugin row: %v", plugin)
+	}
+	instrumentation, _ := products[1].(map[string]any)
+	if instrumentation["health"] != "unknown" {
+		t.Fatalf("unexpected instrumentation row: %v", instrumentation)
+	}
+}
+
+// A 403 on the plugin settings route must not read as "not installed". The
+// command still tries the instrumentation check, so the real error reaches the
+// user.
+func TestSetupStatus_UnknownPluginStateStillTriesTheCheck(t *testing.T) {
+	stdout, err := runStatus(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/plugins/grafana-collector-app/settings":
+			w.WriteHeader(http.StatusForbidden)
+		case "/api/access-control/user/actions":
+			writeJSON(w, map[string]bool{})
+		default:
+			w.WriteHeader(http.StatusForbidden)
+		}
+	})
+	if err == nil {
+		t.Fatal("Execute() = nil, want the failure of the instrumentation check")
+	}
+
+	doc := decodeSingleJSONValue(t, stdout)
+	products, _ := doc["products"].([]any)
+	if len(products) != 2 {
+		t.Fatalf("products = %v, want two entries", doc["products"])
+	}
+	plugin, _ := products[0].(map[string]any)
+	if plugin["health"] != "unknown" {
+		t.Fatalf("plugin health = %v, want unknown", plugin["health"])
+	}
+	details, _ := plugin["details"].(string)
+	if !strings.Contains(details, "HTTP 403") {
+		t.Fatalf("details = %q, want the status in the text", details)
+	}
 }

--- a/cmd/gcx/setup/command_test.go
+++ b/cmd/gcx/setup/command_test.go
@@ -21,14 +21,16 @@ import (
 // -o json/yaml always win.
 
 // statusTableEnabled is the byte-exact human table for an enabled
-// instrumentation product with 3 clusters, pinned against the pre-migration
-// writeSetupStatusTable output.
-const statusTableEnabled = "PRODUCT          ENABLED  HEALTH   DETAILS\n" +
-	"instrumentation  yes      healthy  3 clusters\n"
+// instrumentation product with 3 clusters, behind a healthy collector app
+// plugin.
+const statusTableEnabled = "PRODUCT           ENABLED  HEALTH   DETAILS\n" +
+	"fleet-management  yes      healthy  read and write\n" +
+	"instrumentation   yes      healthy  3 clusters\n"
 
 // statusTableDisabled is the byte-exact human table when no clusters exist.
-const statusTableDisabled = "PRODUCT          ENABLED  HEALTH   DETAILS\n" +
-	"instrumentation  no       healthy  0 clusters\n"
+const statusTableDisabled = "PRODUCT           ENABLED  HEALTH   DETAILS\n" +
+	"fleet-management  yes      healthy  read and write\n" +
+	"instrumentation   no       healthy  0 clusters\n"
 
 func TestSetupStatus_OutputContract(t *testing.T) {
 	tests := []struct {
@@ -67,12 +69,19 @@ func TestSetupStatus_OutputContract(t *testing.T) {
 					t.Fatalf("schema_version = %v, want 1", doc["schema_version"])
 				}
 				products, ok := doc["products"].([]any)
-				if !ok || len(products) != 1 {
-					t.Fatalf("products = %v, want one entry", doc["products"])
+				if !ok || len(products) != 2 {
+					t.Fatalf("products = %v, want two entries", doc["products"])
 				}
-				product, ok := products[0].(map[string]any)
+				plugin, ok := products[0].(map[string]any)
 				if !ok {
 					t.Fatalf("products[0] is %T, want object", products[0])
+				}
+				if plugin["product"] != "fleet-management" || plugin["health"] != "healthy" {
+					t.Fatalf("unexpected plugin row: %v", plugin)
+				}
+				product, ok := products[1].(map[string]any)
+				if !ok {
+					t.Fatalf("products[1] is %T, want object", products[1])
 				}
 				if product["product"] != "instrumentation" || product["enabled"] != true {
 					t.Fatalf("unexpected product row: %v", product)

--- a/cmd/gcx/setup/command_test.go
+++ b/cmd/gcx/setup/command_test.go
@@ -30,12 +30,12 @@ import (
 // instrumentation product with 3 clusters, behind a healthy collector app
 // plugin.
 const statusTableEnabled = "PRODUCT           ENABLED  HEALTH   DETAILS\n" +
-	"fleet-management  yes      healthy  read and write\n" +
+	"fleet-management  yes      healthy  read and admin routes\n" +
 	"instrumentation   yes      healthy  3 clusters\n"
 
 // statusTableDisabled is the byte-exact human table when no clusters exist.
 const statusTableDisabled = "PRODUCT           ENABLED  HEALTH   DETAILS\n" +
-	"fleet-management  yes      healthy  read and write\n" +
+	"fleet-management  yes      healthy  read and admin routes\n" +
 	"instrumentation   no       healthy  0 clusters\n"
 
 func TestSetupStatus_OutputContract(t *testing.T) {
@@ -305,32 +305,67 @@ func TestSetupStatus_KeepsPreflightRowWhenInstrumentationFails(t *testing.T) {
 	}
 }
 
-// An absent plugin ends the run early with one document and no error.
-func TestSetupStatus_PluginAbsentEndsEarly(t *testing.T) {
-	stdout, err := runStatus(t, func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/api/access-control/user/actions":
-			writeJSON(w, map[string]bool{})
-		default:
-			w.WriteHeader(http.StatusNotFound)
-		}
-	})
-	if err != nil {
-		t.Fatalf("Execute() = %v, want nil", err)
+// An unavailable plugin emits one complete status document and returns a
+// general error. The action check must not hide the known plugin state.
+func TestSetupStatus_UnavailablePluginEndsWithGeneralError(t *testing.T) {
+	tests := []struct {
+		name     string
+		settings func(http.ResponseWriter)
+	}{
+		{
+			name: "plugin is absent",
+			settings: func(w http.ResponseWriter) {
+				w.WriteHeader(http.StatusNotFound)
+			},
+		},
+		{
+			name: "plugin is disabled",
+			settings: func(w http.ResponseWriter) {
+				writeJSON(w, map[string]any{"id": "grafana-collector-app", "enabled": false})
+			},
+		},
 	}
 
-	doc := decodeSingleJSONValue(t, stdout)
-	products, ok := doc["products"].([]any)
-	if !ok || len(products) != 2 {
-		t.Fatalf("products = %v, want two entries", doc["products"])
-	}
-	plugin, _ := products[0].(map[string]any)
-	if plugin["product"] != "fleet-management" || plugin["health"] != "unhealthy" {
-		t.Fatalf("unexpected plugin row: %v", plugin)
-	}
-	instrumentation, _ := products[1].(map[string]any)
-	if instrumentation["health"] != "unknown" {
-		t.Fatalf("unexpected instrumentation row: %v", instrumentation)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actionsCalled := false
+			stdout, err := runStatus(t, func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/plugins/grafana-collector-app/settings":
+					tt.settings(w)
+				case "/api/access-control/user/actions":
+					actionsCalled = true
+					w.WriteHeader(http.StatusInternalServerError)
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			})
+
+			var emitted *gcxerrors.EmittedError
+			if !errors.As(err, &emitted) {
+				t.Fatalf("error = %T (%v), want *gcxerrors.EmittedError", err, err)
+			}
+			if emitted.Code != gcxerrors.ExitGeneralError {
+				t.Fatalf("exit code = %d, want %d", emitted.Code, gcxerrors.ExitGeneralError)
+			}
+			if actionsCalled {
+				t.Fatal("the action endpoint was called for an unavailable plugin")
+			}
+
+			doc := decodeSingleJSONValue(t, stdout)
+			products, ok := doc["products"].([]any)
+			if !ok || len(products) != 2 {
+				t.Fatalf("products = %v, want two entries", doc["products"])
+			}
+			plugin, _ := products[0].(map[string]any)
+			if plugin["product"] != "fleet-management" || plugin["health"] != "unhealthy" {
+				t.Fatalf("unexpected plugin row: %v", plugin)
+			}
+			instrumentation, _ := products[1].(map[string]any)
+			if instrumentation["health"] != "unknown" {
+				t.Fatalf("unexpected instrumentation row: %v", instrumentation)
+			}
+		})
 	}
 }
 
@@ -364,5 +399,12 @@ func TestSetupStatus_UnknownPluginStateStillTriesTheCheck(t *testing.T) {
 	details, _ := plugin["details"].(string)
 	if !strings.Contains(details, "HTTP 403") {
 		t.Fatalf("details = %q, want the status in the text", details)
+	}
+}
+
+func writeJSON(w http.ResponseWriter, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }

--- a/cmd/gcx/setup/export_test.go
+++ b/cmd/gcx/setup/export_test.go
@@ -1,11 +1,9 @@
 package setup
 
 import (
-	"context"
 	"fmt"
-	"net/http"
 
-	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/fleet"
 	"github.com/spf13/pflag"
 )
 
@@ -38,37 +36,25 @@ func StatusDocForTest(enabled bool, clusters int) setupStatus {
 // CollectorRowForTest builds the Fleet Management preflight row for the given
 // plugin and permission state.
 func CollectorRowForTest(installed, pluginEnabled, actionsKnown, canRead, canAdmin bool) setupProductStatus {
-	return collectorAppState{
+	return collectorAppRow(fleet.CollectorAppState{
 		PluginKnown:  true,
 		Installed:    installed,
 		Enabled:      pluginEnabled,
 		ActionsKnown: actionsKnown,
 		CanRead:      canRead,
 		CanAdmin:     canAdmin,
-	}.row()
+	})
 }
 
 // UnknownPluginRowForTest builds the Fleet Management row for the case where
 // Grafana answers the plugin settings endpoint with the given status, so the
 // plugin state stays unknown.
 func UnknownPluginRowForTest(status int) setupProductStatus {
-	return collectorAppState{PluginStatus: status}.row()
+	return collectorAppRow(fleet.CollectorAppState{PluginStatus: status})
 }
 
 // StatusRowFieldsForTest exposes a product row's fields to external tests, in
 // the order product, enabled, health, details.
 func StatusRowFieldsForTest(row setupProductStatus) (string, bool, string, string) {
 	return row.Product, row.Enabled, row.Health, row.Details
-}
-
-// CheckCollectorAppForTest runs the Fleet Management preflight against a test
-// server and returns the resulting product row.
-func CheckCollectorAppForTest(ctx context.Context, host string) (setupProductStatus, error) {
-	cfg := config.NamespacedRESTConfig{}
-	cfg.Host = host
-	state, err := checkCollectorApp(ctx, cfg, http.DefaultClient)
-	if err != nil {
-		return setupProductStatus{}, err
-	}
-	return state.row(), nil
 }

--- a/cmd/gcx/setup/export_test.go
+++ b/cmd/gcx/setup/export_test.go
@@ -1,8 +1,11 @@
 package setup
 
 import (
+	"context"
 	"fmt"
+	"net/http"
 
+	"github.com/grafana/gcx/internal/config"
 	"github.com/spf13/pflag"
 )
 
@@ -18,10 +21,11 @@ func NewStatusOptsForTest(flags *pflag.FlagSet) *setupStatusOpts {
 	return opts
 }
 
-// StatusDocForTest builds the setupStatus document with a single
-// instrumentation row, mirroring exactly what the status RunE encodes.
+// StatusDocForTest builds the setupStatus document that the status RunE encodes
+// when the collector app plugin is enabled and the login holds both actions.
 func StatusDocForTest(enabled bool, clusters int) setupStatus {
 	return newSetupStatus([]setupProductStatus{
+		CollectorRowForTest(true, true, true, true, true),
 		{
 			Product: "instrumentation",
 			Enabled: enabled,
@@ -29,4 +33,34 @@ func StatusDocForTest(enabled bool, clusters int) setupStatus {
 			Details: fmt.Sprintf("%d clusters", clusters),
 		},
 	})
+}
+
+// CollectorRowForTest builds the Fleet Management preflight row for the given
+// plugin and permission state.
+func CollectorRowForTest(installed, pluginEnabled, actionsKnown, canRead, canAdmin bool) setupProductStatus {
+	return collectorAppState{
+		Installed:    installed,
+		Enabled:      pluginEnabled,
+		ActionsKnown: actionsKnown,
+		CanRead:      canRead,
+		CanAdmin:     canAdmin,
+	}.row()
+}
+
+// StatusRowFieldsForTest exposes a product row's fields to external tests, in
+// the order product, enabled, health, details.
+func StatusRowFieldsForTest(row setupProductStatus) (string, bool, string, string) {
+	return row.Product, row.Enabled, row.Health, row.Details
+}
+
+// CheckCollectorAppForTest runs the Fleet Management preflight against a test
+// server and returns the resulting product row.
+func CheckCollectorAppForTest(ctx context.Context, host string) (setupProductStatus, error) {
+	cfg := config.NamespacedRESTConfig{}
+	cfg.Host = host
+	state, err := checkCollectorApp(ctx, cfg, http.DefaultClient)
+	if err != nil {
+		return setupProductStatus{}, err
+	}
+	return state.row(), nil
 }

--- a/cmd/gcx/setup/export_test.go
+++ b/cmd/gcx/setup/export_test.go
@@ -39,12 +39,20 @@ func StatusDocForTest(enabled bool, clusters int) setupStatus {
 // plugin and permission state.
 func CollectorRowForTest(installed, pluginEnabled, actionsKnown, canRead, canAdmin bool) setupProductStatus {
 	return collectorAppState{
+		PluginKnown:  true,
 		Installed:    installed,
 		Enabled:      pluginEnabled,
 		ActionsKnown: actionsKnown,
 		CanRead:      canRead,
 		CanAdmin:     canAdmin,
 	}.row()
+}
+
+// UnknownPluginRowForTest builds the Fleet Management row for the case where
+// Grafana answers the plugin settings endpoint with the given status, so the
+// plugin state stays unknown.
+func UnknownPluginRowForTest(status int) setupProductStatus {
+	return collectorAppState{PluginStatus: status}.row()
 }
 
 // StatusRowFieldsForTest exposes a product row's fields to external tests, in

--- a/cmd/gcx/setup/preflight.go
+++ b/cmd/gcx/setup/preflight.go
@@ -1,0 +1,155 @@
+package setup
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/grafana/gcx/internal/config"
+)
+
+const (
+	// collectorAppID is the Grafana app plugin that proxies Fleet Management.
+	collectorAppID = "grafana-collector-app"
+
+	pluginSettingsPath = "/api/plugins/" + collectorAppID + "/settings"
+	userActionsPath    = "/api/access-control/user/actions"
+
+	// actionRead is the action a read command needs. actionAdmin is the action
+	// every write command needs, because a write matches the wildcard route of
+	// the plugin.
+	actionRead  = collectorAppID + ":read"
+	actionAdmin = collectorAppID + ":admin"
+
+	// maxPreflightBody caps the response bodies the preflight reads.
+	maxPreflightBody = 1 << 20
+)
+
+// collectorAppState is the result of the Fleet Management preflight: whether
+// the plugin serves the proxy routes, and which actions the login holds.
+type collectorAppState struct {
+	Installed bool
+	Enabled   bool
+	// ActionsKnown is false when Grafana does not answer the actions endpoint.
+	ActionsKnown bool
+	CanRead      bool
+	CanAdmin     bool
+}
+
+// checkCollectorApp reads the plugin state and the actions of the current
+// login. It returns an error only when the requests themselves fail.
+func checkCollectorApp(ctx context.Context, cfg config.NamespacedRESTConfig, httpClient *http.Client) (collectorAppState, error) {
+	var state collectorAppState
+
+	var settings struct {
+		ID      string `json:"id"`
+		Enabled bool   `json:"enabled"`
+	}
+	status, err := getJSON(ctx, httpClient, cfg.Host+pluginSettingsPath, &settings)
+	if err != nil {
+		return state, err
+	}
+	if status == http.StatusOK {
+		state.Installed = true
+		state.Enabled = settings.Enabled
+	}
+
+	actions := map[string]bool{}
+	status, err = getJSON(ctx, httpClient, cfg.Host+userActionsPath, &actions)
+	if err != nil {
+		return state, err
+	}
+	if status == http.StatusOK {
+		state.ActionsKnown = true
+		state.CanRead = actions[actionRead]
+		state.CanAdmin = actions[actionAdmin]
+	}
+
+	return state, nil
+}
+
+// getJSON performs a GET and decodes a 2xx body into out. A non-2xx response
+// returns its status code without an error, so callers can treat a 404 as
+// "absent" rather than as a failure.
+func getJSON(ctx context.Context, httpClient *http.Client, url string, out any) (int, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, fmt.Errorf("preflight: create request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("preflight: request %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return resp.StatusCode, nil
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxPreflightBody))
+	if err != nil {
+		return resp.StatusCode, fmt.Errorf("preflight: read %s: %w", url, err)
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return resp.StatusCode, fmt.Errorf("preflight: decode %s: %w", url, err)
+	}
+	return resp.StatusCode, nil
+}
+
+// available reports whether the plugin can serve the Fleet Management proxy
+// routes at all.
+func (s collectorAppState) available() bool {
+	return s.Installed && s.Enabled
+}
+
+// row renders the preflight as a product row of the status document.
+func (s collectorAppState) row() setupProductStatus {
+	switch {
+	case !s.Installed:
+		return setupProductStatus{
+			Product: "fleet-management",
+			Enabled: false,
+			Health:  "unhealthy",
+			Details: "the " + collectorAppID + " plugin is not installed",
+		}
+	case !s.Enabled:
+		return setupProductStatus{
+			Product: "fleet-management",
+			Enabled: false,
+			Health:  "unhealthy",
+			Details: "the " + collectorAppID + " plugin is installed but not enabled",
+		}
+	case s.ActionsKnown && !s.CanRead:
+		return setupProductStatus{
+			Product: "fleet-management",
+			Enabled: true,
+			Health:  "unhealthy",
+			Details: "your login is missing the " + actionRead + " action",
+		}
+	case s.ActionsKnown && !s.CanAdmin:
+		return setupProductStatus{
+			Product: "fleet-management",
+			Enabled: true,
+			Health:  "degraded",
+			Details: "read only; write commands need the " + actionAdmin + " action",
+		}
+	case !s.ActionsKnown:
+		return setupProductStatus{
+			Product: "fleet-management",
+			Enabled: true,
+			Health:  "healthy",
+			Details: "plugin enabled; permissions unknown",
+		}
+	default:
+		return setupProductStatus{
+			Product: "fleet-management",
+			Enabled: true,
+			Health:  "healthy",
+			Details: "read and write",
+		}
+	}
+}

--- a/cmd/gcx/setup/preflight.go
+++ b/cmd/gcx/setup/preflight.go
@@ -30,8 +30,14 @@ const (
 // collectorAppState is the result of the Fleet Management preflight: whether
 // the plugin serves the proxy routes, and which actions the login holds.
 type collectorAppState struct {
-	Installed bool
-	Enabled   bool
+	// PluginKnown is false when Grafana answers the plugin settings endpoint
+	// with a status other than 200 or 404. A 403 or a 500 says nothing about
+	// the plugin, so the preflight must not report the plugin as absent.
+	PluginKnown bool
+	// PluginStatus is the HTTP status that left the plugin state unknown.
+	PluginStatus int
+	Installed    bool
+	Enabled      bool
 	// ActionsKnown is false when Grafana does not answer the actions endpoint.
 	ActionsKnown bool
 	CanRead      bool
@@ -51,9 +57,16 @@ func checkCollectorApp(ctx context.Context, cfg config.NamespacedRESTConfig, htt
 	if err != nil {
 		return state, err
 	}
-	if status == http.StatusOK {
+	switch status {
+	case http.StatusOK:
+		state.PluginKnown = true
 		state.Installed = true
 		state.Enabled = settings.Enabled
+	case http.StatusNotFound:
+		// Only a 404 means that the plugin is absent.
+		state.PluginKnown = true
+	default:
+		state.PluginStatus = status
 	}
 
 	actions := map[string]bool{}
@@ -71,8 +84,8 @@ func checkCollectorApp(ctx context.Context, cfg config.NamespacedRESTConfig, htt
 }
 
 // getJSON performs a GET and decodes a 2xx body into out. A non-2xx response
-// returns its status code without an error, so callers can treat a 404 as
-// "absent" rather than as a failure.
+// returns its status code without an error. The caller decides which status
+// means "absent" and which status means "unknown".
 func getJSON(ctx context.Context, httpClient *http.Client, url string, out any) (int, error) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
@@ -100,15 +113,26 @@ func getJSON(ctx context.Context, httpClient *http.Client, url string, out any) 
 	return resp.StatusCode, nil
 }
 
-// available reports whether the plugin can serve the Fleet Management proxy
-// routes at all.
-func (s collectorAppState) available() bool {
+// mayServe reports whether a Fleet Management call through the plugin proxy is
+// worth an attempt. An unknown plugin state counts as worth an attempt, so the
+// real error of the call reaches the user in place of a guess.
+func (s collectorAppState) mayServe() bool {
+	if !s.PluginKnown {
+		return true
+	}
 	return s.Installed && s.Enabled
 }
 
 // row renders the preflight as a product row of the status document.
 func (s collectorAppState) row() setupProductStatus {
 	switch {
+	case !s.PluginKnown:
+		return setupProductStatus{
+			Product: "fleet-management",
+			Enabled: false,
+			Health:  "unknown",
+			Details: fmt.Sprintf("HTTP %d from %s; the plugin state is unknown", s.PluginStatus, pluginSettingsPath),
+		}
 	case !s.Installed:
 		return setupProductStatus{
 			Product: "fleet-management",

--- a/cmd/gcx/setup/preflight.go
+++ b/cmd/gcx/setup/preflight.go
@@ -1,179 +1,69 @@
 package setup
 
 import (
-	"context"
-	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
 
-	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/fleet"
 )
 
-const (
-	// collectorAppID is the Grafana app plugin that proxies Fleet Management.
-	collectorAppID = "grafana-collector-app"
-
-	pluginSettingsPath = "/api/plugins/" + collectorAppID + "/settings"
-	userActionsPath    = "/api/access-control/user/actions"
-
-	// actionRead is the action a read command needs. actionAdmin is the action
-	// every write command needs, because a write matches the wildcard route of
-	// the plugin.
-	actionRead  = collectorAppID + ":read"
-	actionAdmin = collectorAppID + ":admin"
-
-	// maxPreflightBody caps the response bodies the preflight reads.
-	maxPreflightBody = 1 << 20
-)
-
-// collectorAppState is the result of the Fleet Management preflight: whether
-// the plugin serves the proxy routes, and which actions the login holds.
-type collectorAppState struct {
-	// PluginKnown is false when Grafana answers the plugin settings endpoint
-	// with a status other than 200 or 404. A 403 or a 500 says nothing about
-	// the plugin, so the preflight must not report the plugin as absent.
-	PluginKnown bool
-	// PluginStatus is the HTTP status that left the plugin state unknown.
-	PluginStatus int
-	Installed    bool
-	Enabled      bool
-	// ActionsKnown is false when Grafana does not answer the actions endpoint.
-	ActionsKnown bool
-	CanRead      bool
-	CanAdmin     bool
-}
-
-// checkCollectorApp reads the plugin state and the actions of the current
-// login. It returns an error only when the requests themselves fail.
-func checkCollectorApp(ctx context.Context, cfg config.NamespacedRESTConfig, httpClient *http.Client) (collectorAppState, error) {
-	var state collectorAppState
-
-	var settings struct {
-		ID      string `json:"id"`
-		Enabled bool   `json:"enabled"`
-	}
-	status, err := getJSON(ctx, httpClient, cfg.Host+pluginSettingsPath, &settings)
-	if err != nil {
-		return state, err
-	}
-	switch status {
-	case http.StatusOK:
-		state.PluginKnown = true
-		state.Installed = true
-		state.Enabled = settings.Enabled
-	case http.StatusNotFound:
-		// Only a 404 means that the plugin is absent.
-		state.PluginKnown = true
-	default:
-		state.PluginStatus = status
-	}
-
-	actions := map[string]bool{}
-	status, err = getJSON(ctx, httpClient, cfg.Host+userActionsPath, &actions)
-	if err != nil {
-		return state, err
-	}
-	if status == http.StatusOK {
-		state.ActionsKnown = true
-		state.CanRead = actions[actionRead]
-		state.CanAdmin = actions[actionAdmin]
-	}
-
-	return state, nil
-}
-
-// getJSON performs a GET and decodes a 2xx body into out. A non-2xx response
-// returns its status code without an error. The caller decides which status
-// means "absent" and which status means "unknown".
-func getJSON(ctx context.Context, httpClient *http.Client, url string, out any) (int, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return 0, fmt.Errorf("preflight: create request: %w", err)
-	}
-	req.Header.Set("Accept", "application/json")
-
-	resp, err := httpClient.Do(req)
-	if err != nil {
-		return 0, fmt.Errorf("preflight: request %s: %w", url, err)
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode < 200 || resp.StatusCode > 299 {
-		return resp.StatusCode, nil
-	}
-
-	body, err := io.ReadAll(io.LimitReader(resp.Body, maxPreflightBody))
-	if err != nil {
-		return resp.StatusCode, fmt.Errorf("preflight: read %s: %w", url, err)
-	}
-	if err := json.Unmarshal(body, out); err != nil {
-		return resp.StatusCode, fmt.Errorf("preflight: decode %s: %w", url, err)
-	}
-	return resp.StatusCode, nil
-}
-
-// mayServe reports whether a Fleet Management call through the plugin proxy is
-// worth an attempt. An unknown plugin state counts as worth an attempt, so the
-// real error of the call reaches the user in place of a guess.
-func (s collectorAppState) mayServe() bool {
-	if !s.PluginKnown {
-		return true
-	}
-	return s.Installed && s.Enabled
-}
-
-// row renders the preflight as a product row of the status document.
-func (s collectorAppState) row() setupProductStatus {
+// collectorAppRow renders the Fleet preflight as a setup status row.
+func collectorAppRow(state fleet.CollectorAppState) setupProductStatus {
 	switch {
-	case !s.PluginKnown:
+	case !state.PluginKnown:
 		return setupProductStatus{
 			Product: "fleet-management",
 			Enabled: false,
 			Health:  "unknown",
-			Details: fmt.Sprintf("HTTP %d from %s; the plugin state is unknown", s.PluginStatus, pluginSettingsPath),
+			Details: fmt.Sprintf("HTTP %d from %s; the plugin state is unknown", state.PluginStatus, fleet.CollectorAppSettingsPath),
 		}
-	case !s.Installed:
+	case !state.Installed:
 		return setupProductStatus{
 			Product: "fleet-management",
 			Enabled: false,
 			Health:  "unhealthy",
-			Details: "the " + collectorAppID + " plugin is not installed",
+			Details: "the " + fleet.CollectorAppID + " plugin is not installed",
 		}
-	case !s.Enabled:
+	case !state.Enabled:
 		return setupProductStatus{
 			Product: "fleet-management",
 			Enabled: false,
 			Health:  "unhealthy",
-			Details: "the " + collectorAppID + " plugin is installed but not enabled",
+			Details: "the " + fleet.CollectorAppID + " plugin is installed but not enabled",
 		}
-	case s.ActionsKnown && !s.CanRead:
+	case !state.ActionsKnown:
 		return setupProductStatus{
 			Product: "fleet-management",
 			Enabled: true,
-			Health:  "unhealthy",
-			Details: "your login is missing the " + actionRead + " action",
+			Health:  "unknown",
+			Details: "plugin enabled; route permissions unknown",
 		}
-	case s.ActionsKnown && !s.CanAdmin:
-		return setupProductStatus{
-			Product: "fleet-management",
-			Enabled: true,
-			Health:  "degraded",
-			Details: "read only; write commands need the " + actionAdmin + " action",
-		}
-	case !s.ActionsKnown:
+	case state.CanRead && state.CanAdmin:
 		return setupProductStatus{
 			Product: "fleet-management",
 			Enabled: true,
 			Health:  "healthy",
-			Details: "plugin enabled; permissions unknown",
+			Details: "read and admin routes",
+		}
+	case state.CanRead:
+		return setupProductStatus{
+			Product: "fleet-management",
+			Enabled: true,
+			Health:  "degraded",
+			Details: "limited access; some commands, including read-only commands, need the " + fleet.CollectorAppAdminAction + " action",
+		}
+	case state.CanAdmin:
+		return setupProductStatus{
+			Product: "fleet-management",
+			Enabled: true,
+			Health:  "degraded",
+			Details: "limited access; named read routes need the " + fleet.CollectorAppReadAction + " action",
 		}
 	default:
 		return setupProductStatus{
 			Product: "fleet-management",
 			Enabled: true,
-			Health:  "healthy",
-			Details: "read and write",
+			Health:  "unhealthy",
+			Details: "your login has neither the " + fleet.CollectorAppReadAction + " nor the " + fleet.CollectorAppAdminAction + " action",
 		}
 	}
 }

--- a/cmd/gcx/setup/preflight_test.go
+++ b/cmd/gcx/setup/preflight_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/grafana/gcx/cmd/gcx/setup"
@@ -139,6 +140,36 @@ func TestCheckCollectorApp(t *testing.T) {
 			wantDetails: "read and write",
 		},
 		{
+			name: "plugin settings forbidden leaves the plugin state unknown",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/plugins/grafana-collector-app/settings":
+					w.WriteHeader(http.StatusForbidden)
+				case "/api/access-control/user/actions":
+					writeJSON(w, map[string]bool{})
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			},
+			wantHealth:  "unknown",
+			wantDetails: "HTTP 403 from /api/plugins/grafana-collector-app/settings; the plugin state is unknown",
+		},
+		{
+			name: "plugin settings server error leaves the plugin state unknown",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/plugins/grafana-collector-app/settings":
+					w.WriteHeader(http.StatusInternalServerError)
+				case "/api/access-control/user/actions":
+					writeJSON(w, map[string]bool{})
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			},
+			wantHealth:  "unknown",
+			wantDetails: "HTTP 500 from /api/plugins/grafana-collector-app/settings; the plugin state is unknown",
+		},
+		{
 			name: "actions endpoint forbidden leaves permissions unknown",
 			handler: func(w http.ResponseWriter, r *http.Request) {
 				switch r.URL.Path {
@@ -177,5 +208,25 @@ func writeJSON(w http.ResponseWriter, v any) {
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(v); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}
+
+// An unknown plugin state must not read as "not installed": a 403 says nothing
+// about the plugin.
+func TestUnknownPluginRow(t *testing.T) {
+	row := setup.UnknownPluginRowForTest(http.StatusForbidden)
+	product, enabled, health, details := setup.StatusRowFieldsForTest(row)
+
+	if product != "fleet-management" {
+		t.Fatalf("product = %q, want fleet-management", product)
+	}
+	if enabled {
+		t.Fatal("enabled = true, want false")
+	}
+	if health != "unknown" {
+		t.Fatalf("health = %q, want unknown", health)
+	}
+	if !strings.Contains(details, "HTTP 403") {
+		t.Fatalf("details = %q, want the status in the text", details)
 	}
 }

--- a/cmd/gcx/setup/preflight_test.go
+++ b/cmd/gcx/setup/preflight_test.go
@@ -1,0 +1,181 @@
+package setup_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/grafana/gcx/cmd/gcx/setup"
+)
+
+// The Fleet Management row must name the exact cause, because a user cannot
+// act on "unhealthy" alone.
+func TestCollectorAppRow(t *testing.T) {
+	tests := []struct {
+		name         string
+		installed    bool
+		enabled      bool
+		actionsKnown bool
+		canRead      bool
+		canAdmin     bool
+		wantEnabled  bool
+		wantHealth   string
+		wantDetails  string
+	}{
+		{
+			name:        "plugin absent",
+			wantHealth:  "unhealthy",
+			wantDetails: "the grafana-collector-app plugin is not installed",
+		},
+		{
+			name:        "plugin installed but disabled",
+			installed:   true,
+			wantHealth:  "unhealthy",
+			wantDetails: "the grafana-collector-app plugin is installed but not enabled",
+		},
+		{
+			name:         "read action missing",
+			installed:    true,
+			enabled:      true,
+			actionsKnown: true,
+			wantEnabled:  true,
+			wantHealth:   "unhealthy",
+			wantDetails:  "your login is missing the grafana-collector-app:read action",
+		},
+		{
+			name:         "admin action missing means read only",
+			installed:    true,
+			enabled:      true,
+			actionsKnown: true,
+			canRead:      true,
+			wantEnabled:  true,
+			wantHealth:   "degraded",
+			wantDetails:  "read only; write commands need the grafana-collector-app:admin action",
+		},
+		{
+			name:        "actions endpoint unavailable",
+			installed:   true,
+			enabled:     true,
+			wantEnabled: true,
+			wantHealth:  "healthy",
+			wantDetails: "plugin enabled; permissions unknown",
+		},
+		{
+			name:         "both actions present",
+			installed:    true,
+			enabled:      true,
+			actionsKnown: true,
+			canRead:      true,
+			canAdmin:     true,
+			wantEnabled:  true,
+			wantHealth:   "healthy",
+			wantDetails:  "read and write",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			row := setup.CollectorRowForTest(tt.installed, tt.enabled, tt.actionsKnown, tt.canRead, tt.canAdmin)
+			product, enabled, health, details := setup.StatusRowFieldsForTest(row)
+
+			if product != "fleet-management" {
+				t.Fatalf("product = %q, want fleet-management", product)
+			}
+			if enabled != tt.wantEnabled {
+				t.Fatalf("enabled = %v, want %v", enabled, tt.wantEnabled)
+			}
+			if health != tt.wantHealth {
+				t.Fatalf("health = %q, want %q", health, tt.wantHealth)
+			}
+			if details != tt.wantDetails {
+				t.Fatalf("details = %q, want %q", details, tt.wantDetails)
+			}
+		})
+	}
+}
+
+// The preflight must treat a 404 from the plugin settings route as "not
+// installed", not as a request failure.
+func TestCheckCollectorApp(t *testing.T) {
+	tests := []struct {
+		name        string
+		handler     http.HandlerFunc
+		wantHealth  string
+		wantDetails string
+	}{
+		{
+			name: "plugin absent",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/plugins/grafana-collector-app/settings":
+					w.WriteHeader(http.StatusNotFound)
+				case "/api/access-control/user/actions":
+					writeJSON(w, map[string]bool{})
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			},
+			wantHealth:  "unhealthy",
+			wantDetails: "the grafana-collector-app plugin is not installed",
+		},
+		{
+			name: "plugin enabled with both actions",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/plugins/grafana-collector-app/settings":
+					writeJSON(w, map[string]any{"id": "grafana-collector-app", "enabled": true})
+				case "/api/access-control/user/actions":
+					writeJSON(w, map[string]bool{
+						"grafana-collector-app:read":  true,
+						"grafana-collector-app:admin": true,
+					})
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			},
+			wantHealth:  "healthy",
+			wantDetails: "read and write",
+		},
+		{
+			name: "actions endpoint forbidden leaves permissions unknown",
+			handler: func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/plugins/grafana-collector-app/settings":
+					writeJSON(w, map[string]any{"id": "grafana-collector-app", "enabled": true})
+				default:
+					w.WriteHeader(http.StatusForbidden)
+				}
+			},
+			wantHealth:  "healthy",
+			wantDetails: "plugin enabled; permissions unknown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(tt.handler)
+			defer server.Close()
+
+			row, err := setup.CheckCollectorAppForTest(context.Background(), server.URL)
+			if err != nil {
+				t.Fatalf("CheckCollectorAppForTest() = %v", err)
+			}
+			_, _, health, details := setup.StatusRowFieldsForTest(row)
+			if health != tt.wantHealth {
+				t.Fatalf("health = %q, want %q", health, tt.wantHealth)
+			}
+			if details != tt.wantDetails {
+				t.Fatalf("details = %q, want %q", details, tt.wantDetails)
+			}
+		})
+	}
+}
+
+func writeJSON(w http.ResponseWriter, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(v); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}

--- a/cmd/gcx/setup/preflight_test.go
+++ b/cmd/gcx/setup/preflight_test.go
@@ -1,10 +1,7 @@
 package setup_test
 
 import (
-	"context"
-	"encoding/json"
 	"net/http"
-	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -37,31 +34,41 @@ func TestCollectorAppRow(t *testing.T) {
 			wantDetails: "the grafana-collector-app plugin is installed but not enabled",
 		},
 		{
-			name:         "read action missing",
+			name:         "both route actions missing",
 			installed:    true,
 			enabled:      true,
 			actionsKnown: true,
 			wantEnabled:  true,
 			wantHealth:   "unhealthy",
-			wantDetails:  "your login is missing the grafana-collector-app:read action",
+			wantDetails:  "your login has neither the grafana-collector-app:read nor the grafana-collector-app:admin action",
 		},
 		{
-			name:         "admin action missing means read only",
+			name:         "admin route action missing",
 			installed:    true,
 			enabled:      true,
 			actionsKnown: true,
 			canRead:      true,
 			wantEnabled:  true,
 			wantHealth:   "degraded",
-			wantDetails:  "read only; write commands need the grafana-collector-app:admin action",
+			wantDetails:  "limited access; some commands, including read-only commands, need the grafana-collector-app:admin action",
+		},
+		{
+			name:         "named read route action missing",
+			installed:    true,
+			enabled:      true,
+			actionsKnown: true,
+			canAdmin:     true,
+			wantEnabled:  true,
+			wantHealth:   "degraded",
+			wantDetails:  "limited access; named read routes need the grafana-collector-app:read action",
 		},
 		{
 			name:        "actions endpoint unavailable",
 			installed:   true,
 			enabled:     true,
 			wantEnabled: true,
-			wantHealth:  "healthy",
-			wantDetails: "plugin enabled; permissions unknown",
+			wantHealth:  "unknown",
+			wantDetails: "plugin enabled; route permissions unknown",
 		},
 		{
 			name:         "both actions present",
@@ -72,7 +79,7 @@ func TestCollectorAppRow(t *testing.T) {
 			canAdmin:     true,
 			wantEnabled:  true,
 			wantHealth:   "healthy",
-			wantDetails:  "read and write",
+			wantDetails:  "read and admin routes",
 		},
 	}
 
@@ -94,120 +101,6 @@ func TestCollectorAppRow(t *testing.T) {
 				t.Fatalf("details = %q, want %q", details, tt.wantDetails)
 			}
 		})
-	}
-}
-
-// The preflight must treat a 404 from the plugin settings route as "not
-// installed", not as a request failure.
-func TestCheckCollectorApp(t *testing.T) {
-	tests := []struct {
-		name        string
-		handler     http.HandlerFunc
-		wantHealth  string
-		wantDetails string
-	}{
-		{
-			name: "plugin absent",
-			handler: func(w http.ResponseWriter, r *http.Request) {
-				switch r.URL.Path {
-				case "/api/plugins/grafana-collector-app/settings":
-					w.WriteHeader(http.StatusNotFound)
-				case "/api/access-control/user/actions":
-					writeJSON(w, map[string]bool{})
-				default:
-					w.WriteHeader(http.StatusNotFound)
-				}
-			},
-			wantHealth:  "unhealthy",
-			wantDetails: "the grafana-collector-app plugin is not installed",
-		},
-		{
-			name: "plugin enabled with both actions",
-			handler: func(w http.ResponseWriter, r *http.Request) {
-				switch r.URL.Path {
-				case "/api/plugins/grafana-collector-app/settings":
-					writeJSON(w, map[string]any{"id": "grafana-collector-app", "enabled": true})
-				case "/api/access-control/user/actions":
-					writeJSON(w, map[string]bool{
-						"grafana-collector-app:read":  true,
-						"grafana-collector-app:admin": true,
-					})
-				default:
-					w.WriteHeader(http.StatusNotFound)
-				}
-			},
-			wantHealth:  "healthy",
-			wantDetails: "read and write",
-		},
-		{
-			name: "plugin settings forbidden leaves the plugin state unknown",
-			handler: func(w http.ResponseWriter, r *http.Request) {
-				switch r.URL.Path {
-				case "/api/plugins/grafana-collector-app/settings":
-					w.WriteHeader(http.StatusForbidden)
-				case "/api/access-control/user/actions":
-					writeJSON(w, map[string]bool{})
-				default:
-					w.WriteHeader(http.StatusNotFound)
-				}
-			},
-			wantHealth:  "unknown",
-			wantDetails: "HTTP 403 from /api/plugins/grafana-collector-app/settings; the plugin state is unknown",
-		},
-		{
-			name: "plugin settings server error leaves the plugin state unknown",
-			handler: func(w http.ResponseWriter, r *http.Request) {
-				switch r.URL.Path {
-				case "/api/plugins/grafana-collector-app/settings":
-					w.WriteHeader(http.StatusInternalServerError)
-				case "/api/access-control/user/actions":
-					writeJSON(w, map[string]bool{})
-				default:
-					w.WriteHeader(http.StatusNotFound)
-				}
-			},
-			wantHealth:  "unknown",
-			wantDetails: "HTTP 500 from /api/plugins/grafana-collector-app/settings; the plugin state is unknown",
-		},
-		{
-			name: "actions endpoint forbidden leaves permissions unknown",
-			handler: func(w http.ResponseWriter, r *http.Request) {
-				switch r.URL.Path {
-				case "/api/plugins/grafana-collector-app/settings":
-					writeJSON(w, map[string]any{"id": "grafana-collector-app", "enabled": true})
-				default:
-					w.WriteHeader(http.StatusForbidden)
-				}
-			},
-			wantHealth:  "healthy",
-			wantDetails: "plugin enabled; permissions unknown",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			server := httptest.NewServer(tt.handler)
-			defer server.Close()
-
-			row, err := setup.CheckCollectorAppForTest(context.Background(), server.URL)
-			if err != nil {
-				t.Fatalf("CheckCollectorAppForTest() = %v", err)
-			}
-			_, _, health, details := setup.StatusRowFieldsForTest(row)
-			if health != tt.wantHealth {
-				t.Fatalf("health = %q, want %q", health, tt.wantHealth)
-			}
-			if details != tt.wantDetails {
-				t.Fatalf("details = %q, want %q", details, tt.wantDetails)
-			}
-		})
-	}
-}
-
-func writeJSON(w http.ResponseWriter, v any) {
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(v); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
 	}
 }
 

--- a/docs/adrs/fleet-plugin-proxy/001-fleet-via-collector-app-proxy.md
+++ b/docs/adrs/fleet-plugin-proxy/001-fleet-via-collector-app-proxy.md
@@ -79,8 +79,9 @@ Harder:
 - Every write needs the Admin role or the `grafana-collector-app:admin` action.
   A Viewer can read only.
 - `plugin.json` is not a stable contract. A plugin release can change the route
-  set. `gcx setup status` and the typed error for
-  `plugin route match not found` limit the cost of that risk.
+  set. `gcx setup status` and the typed error for a missing plugin route limit
+  the cost of that risk. Grafana returns more than one body for that cause, so
+  `fleet.IsPluginMissingBody` matches a set of markers without regard to case.
 - A 404 now has two meanings. `internal/providers/fleet/client.go` tests the
   body before it reports a missing resource.
 

--- a/docs/adrs/fleet-plugin-proxy/001-fleet-via-collector-app-proxy.md
+++ b/docs/adrs/fleet-plugin-proxy/001-fleet-via-collector-app-proxy.md
@@ -29,9 +29,11 @@ Measurements against a live stack on 2026-08-31, plugin version 4.27.0:
 
 - `/api/plugin-proxy/grafana-collector-app/fleet-management-api/<rpc>` serves
   every remote procedure call that gcx uses.
-- `plugin.json` names 17 read routes at the Viewer level. Every other path
-  matches the wildcard route, which needs the Admin role or the action
-  `grafana-collector-app:admin`.
+- `plugin.json` names 17 routes that need the Viewer role or the
+  `grafana-collector-app:read` action. Every other path matches the wildcard
+  route, which needs the Admin role or the `grafana-collector-app:admin`
+  action. The route class does not follow command intent. Some read-only RPCs,
+  including `GetLimits` and `RunK8sMonitoring`, match the admin route.
 - `GET /api/plugin-proxy/grafana-collector-app/grafanacom-api/instances/`
   returns the grafana.com instance record for the stack. It decodes into
   `cloud.StackInfo` field for field, so the instrumentation commands can derive
@@ -50,8 +52,8 @@ API.
 - `internal/fleet.LoadClient` and `LoadClientWithStack` take a loader with
   `LoadGrafanaConfig`, not `LoadCloudConfig`.
 - `LoadClientWithStack` reads `cloud.StackInfo` through the
-  `grafanacom-api/instances/` proxy route. The result is memoized per Grafana
-  host.
+  `grafanacom-api/instances/` proxy route. Each call performs one lookup, so a
+  transient failure cannot affect a later call.
 - gcx no longer requests the `fleet-management:read` and
   `fleet-management:write` scopes from grafana.com.
 - `gcx setup status` reports the plugin state and the two plugin actions, so a
@@ -76,8 +78,10 @@ Harder:
 - gcx now depends on the plugin. A stack without the `grafana-collector-app`
   plugin cannot run these commands. Self-hosted Grafana never could, because
   Fleet Management is a Grafana Cloud product.
-- Every write needs the Admin role or the `grafana-collector-app:admin` action.
-  A Viewer can read only.
+- Permission follows the matched plugin route, not the command intent. Named
+  routes need `grafana-collector-app:read`. Wildcard routes need the Admin role
+  or `grafana-collector-app:admin`. Some read-only commands match wildcard
+  routes.
 - `plugin.json` is not a stable contract. A plugin release can change the route
   set. `gcx setup status` and the typed error for a missing plugin route limit
   the cost of that risk. Grafana returns more than one body for that cause, so

--- a/docs/adrs/fleet-plugin-proxy/001-fleet-via-collector-app-proxy.md
+++ b/docs/adrs/fleet-plugin-proxy/001-fleet-via-collector-app-proxy.md
@@ -1,0 +1,90 @@
+# Fleet Management through the collector app plugin proxy
+
+**Created**: 2026-08-31
+**Status**: accepted
+**Supersedes**: none
+
+## Context
+
+Fleet Management was the only gcx product that needed a grafana.com Cloud Access
+Policy token. `internal/fleet/config.go` read `AgentManagementInstanceURL` and
+`AgentManagementInstanceID` from the grafana.com stack record, then called the
+Fleet Management API directly with Basic authentication
+(`{instanceID}:{apiToken}`).
+
+That design forced three costs on a user:
+
+- A `gcx login` to the stack was not enough. A user also needed
+  `gcx cloud login`, or a Cloud Access Policy token.
+- The token needed the `fleet-management:read` and `fleet-management:write`
+  scopes. gcx requested both for every user, whether or not they used Fleet.
+- Every fleet command paid for a grafana.com stack lookup, even the commands
+  that never read the stack record.
+
+The Grafana Cloud `grafana-collector-app` plugin already proxies the same API
+for its own user interface. It declares classic app proxy routes and injects the
+credentials server-side.
+
+Measurements against a live stack on 2026-08-31, plugin version 4.27.0:
+
+- `/api/plugin-proxy/grafana-collector-app/fleet-management-api/<rpc>` serves
+  every remote procedure call that gcx uses.
+- `plugin.json` names 17 read routes at the Viewer level. Every other path
+  matches the wildcard route, which needs the Admin role or the action
+  `grafana-collector-app:admin`.
+- `GET /api/plugin-proxy/grafana-collector-app/grafanacom-api/instances/`
+  returns the grafana.com instance record for the stack. It decodes into
+  `cloud.StackInfo` field for field, so the instrumentation commands can derive
+  their backend URLs and Prometheus headers without a grafana.com token.
+- `/api/plugins/grafana-collector-app/resources/...` does not work. The plugin
+  has no backend. Only the plugin proxy works.
+
+## Decision
+
+Fleet Management and the Instrumentation Hub reach their API only through the
+collector app plugin proxy at `cfg.Host`. There is no fallback to the direct
+API.
+
+- `internal/fleet.Client` carries no credentials. It takes an `*http.Client`
+  built with `rest.HTTPClientFor` from the stack REST config.
+- `internal/fleet.LoadClient` and `LoadClientWithStack` take a loader with
+  `LoadGrafanaConfig`, not `LoadCloudConfig`.
+- `LoadClientWithStack` reads `cloud.StackInfo` through the
+  `grafanacom-api/instances/` proxy route. The result is memoized per Grafana
+  host.
+- gcx no longer requests the `fleet-management:read` and
+  `fleet-management:write` scopes from grafana.com.
+- `gcx setup status` reports the plugin state and the two plugin actions, so a
+  user can diagnose the cause before a command fails.
+
+Rejected: keep both transports, with the plugin proxy as a fallback. Two
+transports mean two authorization models and two error surfaces for the same
+commands. The direct path also carries the cost that this decision removes.
+
+## Consequences
+
+Easier:
+
+- A stack login alone drives `gcx fleet` and `gcx instrumentation`.
+- gcx asks grafana.com for two fewer scopes.
+- `LoadClient` performs no stack lookup at all. It used to pay for one and
+  discard the result.
+- The proxy holds the Fleet Management credential, so gcx never handles it.
+
+Harder:
+
+- gcx now depends on the plugin. A stack without the `grafana-collector-app`
+  plugin cannot run these commands. Self-hosted Grafana never could, because
+  Fleet Management is a Grafana Cloud product.
+- Every write needs the Admin role or the `grafana-collector-app:admin` action.
+  A Viewer can read only.
+- `plugin.json` is not a stable contract. A plugin release can change the route
+  set. `gcx setup status` and the typed error for
+  `plugin route match not found` limit the cost of that risk.
+- A 404 now has two meanings. `internal/providers/fleet/client.go` tests the
+  body before it reports a missing resource.
+
+Follow-up: none required. `providers.CloudRESTConfig`, `LoadCloudConfig`, and
+`cloud.GCOMClient` stay, because k6, Synthetic Monitoring, the Faro sourcemap
+upload, Adaptive telemetry, `gcx cloud stacks`, and the login validation still
+use them.

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -762,7 +762,8 @@ grafana.com token is needed. See ADR-023.
 | File | Purpose |
 |------|---------|
 | `internal/fleet/client.go` | Shared fleet base HTTP client (used by fleet provider and instrumentation provider); carries no credentials of its own |
-| `internal/fleet/config.go` | Stack config loading, the plugin proxy prefix, `LoadClientWithStack`, and the memoized `cloud.StackInfo` lookup through the `grafanacom-api/instances/` proxy route |
+| `internal/fleet/config.go` | Stack config loading, the plugin proxy prefix, and `LoadClientWithStack` with a bounded `cloud.StackInfo` lookup through the `grafanacom-api/instances/` proxy route |
+| `internal/fleet/preflight.go` | Collector app availability and route-action checks used by `gcx setup status` |
 | `internal/fleet/errors.go` | Fleet API error types, including the marker for an absent plugin route |
 
 ### Setup

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -753,17 +753,24 @@ Each LGTM signal has its own provider in `internal/providers/{signal}/` that reg
 
 ### Shared Fleet Client
 
+Fleet Management runs behind the `grafana-collector-app` plugin proxy on the
+stack, at `/api/plugin-proxy/grafana-collector-app/fleet-management-api/`. The
+plugin adds the Fleet Management credentials and the tenant headers
+server-side, so the client carries the caller's Grafana credential only. No
+grafana.com token is needed. See ADR-023.
+
 | File | Purpose |
 |------|---------|
-| `internal/fleet/client.go` | Shared fleet base HTTP client (used by fleet provider and instrumentation provider) |
-| `internal/fleet/config.go` | Config loading, `LoadClientWithStack` helper |
-| `internal/fleet/errors.go` | Fleet API error types |
+| `internal/fleet/client.go` | Shared fleet base HTTP client (used by fleet provider and instrumentation provider); carries no credentials of its own |
+| `internal/fleet/config.go` | Stack config loading, the plugin proxy prefix, `LoadClientWithStack`, and the memoized `cloud.StackInfo` lookup through the `grafanacom-api/instances/` proxy route |
+| `internal/fleet/errors.go` | Fleet API error types, including the marker for an absent plugin route |
 
 ### Setup
 
 | File | Purpose |
 |------|---------|
 | `cmd/gcx/setup/command.go` | Setup command area: aggregated cross-product `status` |
+| `cmd/gcx/setup/preflight.go` | Collector app plugin and permission preflight for the `status` document |
 
 ### Instrumentation Hub Provider
 

--- a/docs/architecture/project-structure.md
+++ b/docs/architecture/project-structure.md
@@ -38,7 +38,7 @@ gcx/
 │   ├── auth/                 # OAuth PKCE flow, token refresh transport
 │   │   └── adaptive/         # Shared adaptive telemetry auth (GCOM caching, Basic auth)
 │   ├── cloud/                # Grafana Cloud stack discovery via GCOM API
-│   ├── fleet/                # Shared fleet base client (HTTP, auth, config — shared by fleet provider and instrumentation provider)
+│   ├── fleet/                # Shared fleet base client (HTTP + stack config, over the grafana-collector-app plugin proxy — shared by fleet provider and instrumentation provider)
 │   ├── config/               # Config loading, context management, auth types (auto-migrates plaintext token-shaped secrets into the OS keychain via internal/credentials)
 │   │   └── testdata/         # YAML fixtures for config unit tests
 │   ├── credentials/          # OS-keychain backend for token-shaped secrets; sentinel format + Store interface; auto-disabled under `go test`

--- a/docs/reference/cli/gcx_cloud_login.md
+++ b/docs/reference/cli/gcx_cloud_login.md
@@ -47,7 +47,7 @@ gcx cloud login [flags]
   -h, --help                 help for login
       --oauth-manual         Complete browser OAuth without a local callback server: gcx prints the URL, then reads the redirect URL that you copy from the browser address bar. Use this when gcx runs on a remote host and the browser runs on your own computer
       --oauth-url string     Base URL for the OAuth login flow (used only by this command) (default "https://grafana.com")
-      --scope strings        OAuth2 scopes to request (default [stacks:read,stacks:write,stacks:delete,metrics:write,logs:write,traces:write,fleet-management:read,fleet-management:write])
+      --scope strings        OAuth2 scopes to request (default [stacks:read,stacks:write,stacks:delete,metrics:write,logs:write,traces:write])
 ```
 
 ### Options inherited from parent commands

--- a/docs/reference/grafana-cloud-api-tiers.md
+++ b/docs/reference/grafana-cloud-api-tiers.md
@@ -67,7 +67,7 @@ reflecting Grafana's 10-year evolution from REST to K8s-style to plugin-hosted:
 | Legacy REST                      | `/api/...`                          | Oldest, broadest. Dashboards, users, teams, datasources, alerting, library panels, annotations, reports.  |
 | K8s-style API (Grafana 12+)      | `/apis/<group>.grafana.app/...`     | 33+ groups. Kubeconfig-style auth via `k8s.io/client-go`. Future of all resources.                        |
 | Plugin resources                 | `/api/plugins/<id>/resources/...`   | Per-app-plugin backends. Where Cloud products (SLO, SM, IRM, k6-shim) live.                               |
-| Plugin proxy                     | `/api/plugin-proxy/<id>/...`        | Thin auth-passthrough to a plugin. Used by Fleet UI, App O11y, Faro CRUD.                                 |
+| Plugin proxy                     | `/api/plugin-proxy/<id>/...`        | Thin auth-passthrough to a plugin. Used by Fleet Management (`gcx fleet`, `gcx instrumentation`), App O11y, Faro CRUD. |
 | App routes + Live WebSocket      | `/a/<id>/...`, `/api/live/ws`       | UI deep-links, CLI proxies (Assistant), streaming.                                                        |
 
 **gcx mapping**:
@@ -75,6 +75,7 @@ reflecting Grafana's 10-year evolution from REST to K8s-style to plugin-hosted:
 - `internal/resources/` + `cmd/gcx/resources/` → K8s-style API tier
 - `internal/datasources/` + `cmd/gcx/datasources/` → `/api/datasources` + per-ds query clients
 - `internal/providers/<product>/` → plugin-resources and plugin-proxy routes, one provider per product (alert, slo, synth, irm, faro, k6, agento11y, kg, appo11y, fleet)
+- `internal/fleet/` → Fleet Management connect client, behind the `grafana-collector-app` plugin proxy
 - `internal/assistant/` → `/a/<id>/...` CLI proxy + A2A SSE streaming
 
 The K8s-style tier is where Grafana's architecture is heading. Legacy REST and
@@ -101,7 +102,6 @@ hostnames.
 
 - `internal/query/prometheus`, `internal/query/loki` → signal store queries
 - `internal/auth/adaptive/` → shared adaptive auth transport used by all signal providers
-- `internal/fleet/` → Fleet Management connect client
 - `internal/providers/{metrics,logs,traces,profiles}/` → signal + adaptive commands
 - `internal/providers/synth/`, `internal/providers/irm/` → regional REST clients
 
@@ -125,7 +125,7 @@ calls go to the global host.
 | GCOM token                   | Control plane                                           | `internal/cloud/`                            |
 | OAuth PKCE                   | Interactive stack login                                 | `internal/auth/` + `cmd/gcx/auth/`           |
 | Service-account token        | Stack REST + K8s API                                    | `internal/config/` (rest.Config builder)     |
-| Instance credential          | Regional runtime (signal stores, Fleet)                 | `internal/auth/adaptive/`                    |
+| Instance credential          | Regional runtime (signal stores)                        | `internal/auth/adaptive/`                    |
 | Product tokens               | SM, OnCall, Faro, k6                                    | per-provider client                          |
 
 ### Hybrid products (multi-tier surfaces)
@@ -134,7 +134,7 @@ Some products emit calls across tiers. Knowing the map avoids wrong-tier fixes:
 
 - **Alerting** — Tier 2 (legacy `/api/ruler` + K8s `rules.alerting.grafana.app`) + Tier 3 (regional ruler + AM)
 - **Synthetic Monitoring** — Tier 2 (plugin settings) + Tier 3 (REST + gRPC) + Tier 1 (install/register)
-- **Fleet Management** — Tier 1 (discovery) + Tier 3 (gRPC) + Tier 2 (plugin-proxy UI)
+- **Fleet Management** — Tier 2 only (plugin proxy: the `fleet-management-api` RPCs, plus the `grafanacom-api` instance-record passthrough). See ADR-023.
 - **Frontend Observability (Faro)** — Tier 2 (plugin-proxy CRUD + sourcemaps) + Tier 3 (API + ingest)
 - **IRM** — Tier 2 (plugin-resources for OnCall + Incidents) + Tier 3 (OnCall public) + legacy Tier 3 Incident
 - **Adaptive {Metrics,Logs,Traces}** — Tier 2 (plugin UI) + Tier 3 (runtime config) + Tier 1 (enablement)

--- a/docs/reference/login.md
+++ b/docs/reference/login.md
@@ -173,11 +173,15 @@ Scope the access policy to what you manage. `stacks:read` is the required baseli
 |-------|---------|
 | `stacks:read` | **Required.** Stack discovery (resolves the stack slug for all Cloud commands; also covers `gcx k6` reads) |
 | `metrics:write`, `logs:write`, `traces:write` | Synthetic Monitoring and k6 (`gcx sm`, `gcx k6`) — these write verbs are needed to mint the Synthetic Monitoring token |
-| `fleet-management:read` (and `fleet-management:write` for changes) | Fleet Management (`gcx fleet`) |
 | `stacks:write` | Creating or updating stacks |
 | `set:alloy-data-write` | Instrumentation Hub setup (`gcx instrumentation`) |
 
-The Cloud Access Policy token is for Grafana Cloud product APIs (GCOM stack management, Synthetic Monitoring, k6, Fleet, IRM, SLO). Signal queries (`gcx metrics`, `gcx logs`, `gcx traces`, `gcx profiles`) authenticate with your Grafana token (OAuth or service account), not this token. When in doubt, start narrow and widen the policy as commands report missing-scope errors — the token can be re-scoped without re-running `gcx login`.
+`gcx fleet` and `gcx instrumentation` need no scope here. Fleet Management
+reaches its API through the `grafana-collector-app` plugin proxy on your stack,
+so your Grafana login alone is enough. See
+[ADR-023](../adrs/fleet-plugin-proxy/001-fleet-via-collector-app-proxy.md).
+
+The Cloud Access Policy token is for Grafana Cloud product APIs (GCOM stack management, Synthetic Monitoring, k6, IRM, SLO). Signal queries (`gcx metrics`, `gcx logs`, `gcx traces`, `gcx profiles`) authenticate with your Grafana token (OAuth or service account), not this token. When in doubt, start narrow and widen the policy as commands report missing-scope errors — the token can be re-scoped without re-running `gcx login`.
 
 The interactive `gcx login` prompt links to this guidance when it offers Cloud
 authentication choices.

--- a/internal/auth/gcom.go
+++ b/internal/auth/gcom.go
@@ -22,18 +22,21 @@ import (
 const DefaultGCOMClientID = "gcx"
 
 // DefaultGCOMScopes returns the grafana.com API scopes gcx needs across all
-// commands: stacks (discovery + management), the signal write scopes for
-// minting the Synthetic Monitoring token (metrics/logs/traces:write), and
-// Fleet Management. Both `gcx cloud login` and the `gcx login` cloud followup
-// request this set. A fresh slice is returned on each call so callers (e.g. a
-// Cobra flag default) can mutate their copy without affecting others.
+// commands: stacks (discovery + management) and the signal write scopes for
+// minting the Synthetic Monitoring token (metrics/logs/traces:write). Both
+// `gcx cloud login` and the `gcx login` cloud followup request this set. A
+// fresh slice is returned on each call so callers (e.g. a Cobra flag default)
+// can mutate their copy without affecting others.
+//
+// Fleet Management is absent on purpose. It reaches its API through the
+// collector app plugin proxy on the stack, so it needs the stack credential
+// only.
 func DefaultGCOMScopes() []string {
 	return []string{
 		"stacks:read", "stacks:write", "stacks:delete",
 		"metrics:write",
 		"logs:write",
 		"traces:write",
-		"fleet-management:read", "fleet-management:write",
 	}
 }
 

--- a/internal/auth/gcom_test.go
+++ b/internal/auth/gcom_test.go
@@ -9,13 +9,14 @@ import (
 
 // The `gcx login` cloud followup requests DefaultGCOMScopes directly, so this
 // pins the full scope set gcx needs across all commands - not just stacks.
+// Fleet Management is absent on purpose: it reaches its API through the
+// collector app plugin proxy on the stack, so it needs no grafana.com scope.
 func TestDefaultGCOMScopes(t *testing.T) {
 	want := []string{
 		"stacks:read", "stacks:write", "stacks:delete",
 		"metrics:write",
 		"logs:write",
 		"traces:write",
-		"fleet-management:read", "fleet-management:write",
 	}
 	assert.Equal(t, want, auth.DefaultGCOMScopes())
 

--- a/internal/config/cloud_login_test.go
+++ b/internal/config/cloud_login_test.go
@@ -307,7 +307,7 @@ func TestSaveCloudConfigOAuthMetadataChangeUsesCopyOnWrite(t *testing.T) {
 	_, entryName, err := config.SaveCloudConfig(ctx, source, "staging", &config.CloudEntry{
 		OAuthToken:          "shared-oauth",
 		OAuthTokenExpiresAt: "2099-02-01T00:00:00Z",
-		OAuthScopes:         []string{"stacks:read", "fleet-management:read"},
+		OAuthScopes:         []string{"stacks:read", "metrics:write"},
 		OAuthUrl:            "https://grafana.com",
 		APIUrl:              "https://grafana.com",
 	})
@@ -319,7 +319,7 @@ func TestSaveCloudConfigOAuthMetadataChangeUsesCopyOnWrite(t *testing.T) {
 	assert.Equal(t, "2099-01-01T00:00:00Z", got.Cloud["grafana-com"].OAuthTokenExpiresAt)
 	assert.Equal(t, []string{"stacks:read"}, got.Cloud["grafana-com"].OAuthScopes)
 	assert.Equal(t, "2099-02-01T00:00:00Z", got.Cloud[entryName].OAuthTokenExpiresAt)
-	assert.ElementsMatch(t, []string{"stacks:read", "fleet-management:read"}, got.Cloud[entryName].OAuthScopes)
+	assert.ElementsMatch(t, []string{"stacks:read", "metrics:write"}, got.Cloud[entryName].OAuthScopes)
 }
 
 func TestSaveCloudConfigOAuthScopeOrderDoesNotTriggerCopyOnWrite(t *testing.T) {
@@ -331,7 +331,7 @@ func TestSaveCloudConfigOAuthScopeOrderDoesNotTriggerCopyOnWrite(t *testing.T) {
 	seed.SetCloudEntry("grafana-com", config.CloudEntry{
 		OAuthToken:          "shared-oauth",
 		OAuthTokenExpiresAt: "2099-01-01T00:00:00Z",
-		OAuthScopes:         []string{"stacks:read", "fleet-management:read"},
+		OAuthScopes:         []string{"stacks:read", "metrics:write"},
 		OAuthUrl:            "https://grafana.com",
 		APIUrl:              "https://grafana.com",
 	})
@@ -342,7 +342,7 @@ func TestSaveCloudConfigOAuthScopeOrderDoesNotTriggerCopyOnWrite(t *testing.T) {
 	_, entryName, err := config.SaveCloudConfig(ctx, source, "staging", &config.CloudEntry{
 		OAuthToken:          "shared-oauth",
 		OAuthTokenExpiresAt: "2099-01-01T00:00:00Z",
-		OAuthScopes:         []string{"fleet-management:read", "stacks:read", "stacks:read"},
+		OAuthScopes:         []string{"metrics:write", "stacks:read", "stacks:read"},
 		OAuthUrl:            "https://grafana.com",
 		APIUrl:              "https://grafana.com",
 	})

--- a/internal/docs/links.go
+++ b/internal/docs/links.go
@@ -31,6 +31,11 @@ const (
 	// reference for the "invalid scope" / "permission denied" cloud errors.
 	AccessPolicies = "https://grafana.com/docs/grafana-cloud/security-and-account-management/authentication-and-permissions/access-policies/create-access-policies.md"
 
+	// RolesAndPermissions documents Grafana roles and plugin permissions. It is
+	// the reference for a plugin action a user does not hold, such as
+	// grafana-collector-app:admin.
+	RolesAndPermissions = "https://grafana.com/docs/grafana/latest/administration/roles-and-permissions.md"
+
 	// GrafanaInstallation documents Grafana setup, referenced when a stack is
 	// older than the minimum supported version.
 	GrafanaInstallation = "https://grafana.com/docs/grafana/latest/setup-grafana/installation.md"

--- a/internal/fleet/client.go
+++ b/internal/fleet/client.go
@@ -14,28 +14,26 @@ import (
 
 // Client is a base HTTP client for the Grafana Fleet Management API.
 // All operations use POST (gRPC/Connect style JSON-over-HTTP).
+//
+// The client carries no credentials of its own. Callers build it with an
+// *http.Client whose transport authenticates against the Grafana stack, and a
+// baseURL that points at the collector app plugin proxy. The plugin adds the
+// Fleet Management credentials and the tenant headers server-side.
 type Client struct {
-	baseURL      string
-	instanceID   string
-	apiToken     string
-	useBasicAuth bool
-	httpClient   *http.Client
+	baseURL    string
+	httpClient *http.Client
 }
 
 // NewClient creates a new Fleet Management base client.
-// When useBasicAuth is true, requests use Basic auth with instanceID:apiToken.
-// Otherwise, requests use Bearer token auth.
+// baseURL must already include the plugin proxy prefix.
 // If httpClient is nil, httputils.NewDefaultClient is used.
-func NewClient(ctx context.Context, baseURL, instanceID, apiToken string, useBasicAuth bool, httpClient *http.Client) *Client {
+func NewClient(ctx context.Context, baseURL string, httpClient *http.Client) *Client {
 	if httpClient == nil {
 		httpClient = httputils.NewDefaultClient(ctx)
 	}
 	return &Client{
-		baseURL:      strings.TrimRight(baseURL, "/"),
-		instanceID:   instanceID,
-		apiToken:     apiToken,
-		useBasicAuth: useBasicAuth,
-		httpClient:   httpClient,
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		httpClient: httpClient,
 	}
 }
 
@@ -66,12 +64,6 @@ func (c *Client) DoRequestWithHeaders(ctx context.Context, path string, body any
 
 	for k, v := range headers {
 		req.Header.Set(k, v)
-	}
-
-	if c.useBasicAuth {
-		req.SetBasicAuth(c.instanceID, c.apiToken)
-	} else {
-		req.Header.Set("Authorization", "Bearer "+c.apiToken)
 	}
 
 	resp, err := c.httpClient.Do(req)

--- a/internal/fleet/client_test.go
+++ b/internal/fleet/client_test.go
@@ -2,7 +2,6 @@ package fleet_test
 
 import (
 	"context"
-	"encoding/base64"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -14,63 +13,54 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestNewClient_DoRequest_AuthHeaders(t *testing.T) {
-	tests := []struct {
-		name         string
-		instanceID   string
-		apiToken     string
-		useBasicAuth bool
-		checkAuth    func(t *testing.T, r *http.Request)
-	}{
-		{
-			name:         "basic auth sends Authorization: Basic header",
-			instanceID:   "12345",
-			apiToken:     "secret-token",
-			useBasicAuth: true,
-			checkAuth: func(t *testing.T, r *http.Request) {
-				t.Helper()
-				user, pass, ok := r.BasicAuth()
-				require.True(t, ok, "expected Basic auth header")
-				assert.Equal(t, "12345", user)
-				assert.Equal(t, "secret-token", pass)
+// The base client sets no credentials of its own. The caller supplies an
+// *http.Client whose transport authenticates against the Grafana stack, and the
+// collector app plugin proxy adds the Fleet Management credentials server-side.
+func TestNewClient_DoRequest_SetsNoAuthHeader(t *testing.T) {
+	var capturedReq *http.Request
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedReq = r
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
 
-				// Verify the raw header format: Basic base64(instanceID:apiToken)
-				expected := "Basic " + base64.StdEncoding.EncodeToString([]byte("12345:secret-token"))
-				assert.Equal(t, expected, r.Header.Get("Authorization"))
-			},
-		},
-		{
-			name:         "bearer auth sends Authorization: Bearer header",
-			instanceID:   "",
-			apiToken:     "bearer-token",
-			useBasicAuth: false,
-			checkAuth: func(t *testing.T, r *http.Request) {
-				t.Helper()
-				assert.Equal(t, "Bearer bearer-token", r.Header.Get("Authorization"))
-			},
-		},
-	}
+	client := fleet.NewClient(context.Background(), server.URL, nil)
+	resp, err := client.DoRequest(context.Background(), "/some.v1.Service/Method", nil)
+	require.NoError(t, err)
+	defer resp.Body.Close()
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var capturedReq *http.Request
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-				capturedReq = r
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write([]byte(`{}`))
-			}))
-			defer server.Close()
-
-			client := fleet.NewClient(context.Background(), server.URL, tt.instanceID, tt.apiToken, tt.useBasicAuth, nil)
-			resp, err := client.DoRequest(context.Background(), "/some.v1.Service/Method", nil)
-			require.NoError(t, err)
-			defer resp.Body.Close()
-
-			require.NotNil(t, capturedReq)
-			tt.checkAuth(t, capturedReq)
-		})
-	}
+	require.NotNil(t, capturedReq)
+	assert.Empty(t, capturedReq.Header.Get("Authorization"))
 }
+
+// The transport of the supplied *http.Client carries the credential.
+func TestNewClient_DoRequest_UsesSuppliedHTTPClient(t *testing.T) {
+	var capturedReq *http.Request
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedReq = r
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	httpClient := &http.Client{Transport: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+		req.Header.Set("Authorization", "Bearer from-transport")
+		return http.DefaultTransport.RoundTrip(req)
+	})}
+
+	client := fleet.NewClient(context.Background(), server.URL, httpClient)
+	resp, err := client.DoRequest(context.Background(), "/some.v1.Service/Method", nil)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.NotNil(t, capturedReq)
+	assert.Equal(t, "Bearer from-transport", capturedReq.Header.Get("Authorization"))
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
 
 func TestNewClient_DoRequest_RequestFormat(t *testing.T) {
 	tests := []struct {
@@ -114,7 +104,7 @@ func TestNewClient_DoRequest_RequestFormat(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := fleet.NewClient(context.Background(), server.URL, "inst", "tok", true, nil)
+			client := fleet.NewClient(context.Background(), server.URL, nil)
 			resp, err := client.DoRequest(context.Background(), tt.path, tt.body)
 			require.NoError(t, err)
 			defer resp.Body.Close()
@@ -132,19 +122,24 @@ func TestNewClient_DoRequest_RequestFormat(t *testing.T) {
 	}
 }
 
+// The base URL carries the plugin proxy prefix, so the client must not add a
+// second slash between the prefix and the RPC path.
 func TestNewClient_DoRequest_URLTrimming(t *testing.T) {
-	// Verify that trailing slashes on baseURL are trimmed so paths are clean.
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+	var capturedPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		capturedPath = r.URL.Path
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte(`{}`))
 	}))
 	defer server.Close()
 
-	client := fleet.NewClient(context.Background(), server.URL+"/", "inst", "tok", true, nil)
+	client := fleet.NewClient(context.Background(), server.URL+"/api/plugin-proxy/grafana-collector-app/fleet-management-api/", nil)
 	resp, err := client.DoRequest(context.Background(), "/path.v1.Service/Method", nil)
 	require.NoError(t, err)
 	defer resp.Body.Close()
+
 	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "/api/plugin-proxy/grafana-collector-app/fleet-management-api/path.v1.Service/Method", capturedPath)
 }
 
 func TestReadErrorBody(t *testing.T) {

--- a/internal/fleet/config.go
+++ b/internal/fleet/config.go
@@ -2,67 +2,142 @@ package fleet
 
 import (
 	"context"
-	"errors"
+	"encoding/json"
 	"fmt"
-	"strconv"
+	"io"
+	"net/http"
+	"sync"
 
 	"github.com/grafana/gcx/internal/cloud"
-	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/config"
+	"k8s.io/client-go/rest"
 )
 
-// ConfigLoader can load Grafana Cloud configuration from the active context.
+const (
+	// pluginID is the Grafana app plugin that proxies the Fleet Management API.
+	pluginID = "grafana-collector-app"
+
+	// pluginProxyPath is the plugin proxy prefix for the Fleet Management RPCs.
+	pluginProxyPath = "/api/plugin-proxy/" + pluginID + "/fleet-management-api"
+
+	// stackInfoPath is the plugin proxy route that returns the grafana.com
+	// instance record for the current stack. It needs the Viewer role only.
+	stackInfoPath = "/api/plugin-proxy/" + pluginID + "/grafanacom-api/instances/"
+)
+
+// ConfigLoader can load the Grafana stack configuration from the active context.
 // This mirrors the interface in internal/providers/fleet/ to avoid a circular import.
 type ConfigLoader interface {
-	LoadCloudConfig(ctx context.Context) (providers.CloudRESTConfig, error)
+	LoadGrafanaConfig(ctx context.Context) (config.NamespacedRESTConfig, error)
 }
 
-// ClientResult holds the results of LoadClient including the fleet base client,
-// resolved namespace, and the full stack info for deriving backend URLs and
-// prom headers.
+// ClientResult holds the results of LoadClientWithStack including the fleet base
+// client, resolved namespace, and the full stack info for deriving backend URLs
+// and prom headers.
 type ClientResult struct {
 	Client    *Client
 	Namespace string
 	Stack     cloud.StackInfo
 }
 
-// LoadClient loads cloud configuration and constructs a Fleet Management client
-// using Basic auth ({instanceID}:{apiToken}).
+// LoadClient loads the Grafana stack configuration and constructs a Fleet
+// Management client that talks to the collector app plugin proxy.
 // Returns the client, the resolved namespace, and any error.
-// Fails with a descriptive error if AgentManagementInstanceURL or
-// AgentManagementInstanceID is not available for the stack.
 func LoadClient(ctx context.Context, loader ConfigLoader) (*Client, string, error) {
-	r, err := LoadClientWithStack(ctx, loader)
+	cfg, err := loader.LoadGrafanaConfig(ctx)
 	if err != nil {
 		return nil, "", err
 	}
-	return r.Client, r.Namespace, nil
+
+	httpClient, err := rest.HTTPClientFor(&cfg.Config)
+	if err != nil {
+		return nil, "", fmt.Errorf("fleet: failed to create HTTP client: %w", err)
+	}
+
+	return NewClient(ctx, cfg.Host+pluginProxyPath, httpClient), cfg.Namespace, nil
 }
 
 // LoadClientWithStack is like LoadClient but also returns the full stack info,
 // needed by instrumentation commands to derive backend URLs and prom headers.
+// The stack info comes from the collector app plugin proxy, so it needs no
+// grafana.com token.
 func LoadClientWithStack(ctx context.Context, loader ConfigLoader) (*ClientResult, error) {
-	cloudCfg, err := loader.LoadCloudConfig(ctx)
+	cfg, err := loader.LoadGrafanaConfig(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	url := cloudCfg.Stack.AgentManagementInstanceURL
-	if url == "" {
-		return nil, errors.New("fleet management endpoint is not available for this stack")
-	}
-	if cloudCfg.Stack.AgentManagementInstanceID == 0 {
-		return nil, errors.New("fleet management instance ID is not available for this stack")
-	}
-
-	instanceID := strconv.Itoa(cloudCfg.Stack.AgentManagementInstanceID)
-	httpClient, err := cloudCfg.HTTPClient(ctx)
+	httpClient, err := rest.HTTPClientFor(&cfg.Config)
 	if err != nil {
 		return nil, fmt.Errorf("fleet: failed to create HTTP client: %w", err)
 	}
 
+	stack, err := fetchStackInfo(ctx, cfg.Host, httpClient)
+	if err != nil {
+		return nil, err
+	}
+
 	return &ClientResult{
-		Client:    NewClient(ctx, url, instanceID, cloudCfg.Token, true, httpClient),
-		Namespace: cloudCfg.Namespace,
-		Stack:     cloudCfg.Stack,
+		Client:    NewClient(ctx, cfg.Host+pluginProxyPath, httpClient),
+		Namespace: cfg.Namespace,
+		Stack:     stack,
 	}, nil
+}
+
+// stackInfoEntry memoizes one stack lookup per Grafana host.
+type stackInfoEntry struct {
+	once sync.Once
+	info cloud.StackInfo
+	err  error
+}
+
+//nolint:gochecknoglobals // process-wide memoization of an idempotent GET, keyed by host.
+var stackInfoCache sync.Map
+
+// fetchStackInfo reads the grafana.com instance record for the stack through the
+// collector app plugin proxy. The result is memoized per host, because several
+// commands load the client more than once in a run.
+func fetchStackInfo(ctx context.Context, host string, httpClient *http.Client) (cloud.StackInfo, error) {
+	v, _ := stackInfoCache.LoadOrStore(host, &stackInfoEntry{})
+	entry, ok := v.(*stackInfoEntry)
+	if !ok {
+		return cloud.StackInfo{}, fmt.Errorf("fleet: unexpected stack info cache entry for %q", host)
+	}
+	entry.once.Do(func() {
+		entry.info, entry.err = getStackInfo(ctx, host, httpClient)
+	})
+	return entry.info, entry.err
+}
+
+func getStackInfo(ctx context.Context, host string, httpClient *http.Client) (cloud.StackInfo, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, host+stackInfoPath, nil)
+	if err != nil {
+		return cloud.StackInfo{}, fmt.Errorf("fleet: create stack info request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return cloud.StackInfo{}, fmt.Errorf("fleet: fetch stack info: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return cloud.StackInfo{}, &HTTPError{
+			Status: resp.StatusCode,
+			Path:   stackInfoPath,
+			Body:   ReadErrorBody(resp),
+		}
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return cloud.StackInfo{}, fmt.Errorf("fleet: read stack info: %w", err)
+	}
+
+	var stack cloud.StackInfo
+	if err := json.Unmarshal(body, &stack); err != nil {
+		return cloud.StackInfo{}, fmt.Errorf("fleet: decode stack info: %w", err)
+	}
+	return stack, nil
 }

--- a/internal/fleet/config.go
+++ b/internal/fleet/config.go
@@ -4,25 +4,31 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
-	"sync"
 
 	"github.com/grafana/gcx/internal/cloud"
 	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/httputils"
 	"k8s.io/client-go/rest"
 )
 
 const (
-	// pluginID is the Grafana app plugin that proxies the Fleet Management API.
-	pluginID = "grafana-collector-app"
+	// CollectorAppID is the Grafana app plugin that proxies Fleet Management.
+	CollectorAppID = "grafana-collector-app"
+
+	// CollectorAppReadAction grants access to the plugin's named read routes.
+	CollectorAppReadAction = CollectorAppID + ":read"
+
+	// CollectorAppAdminAction grants access to the plugin's wildcard routes.
+	// Some read-only Fleet operations use these routes.
+	CollectorAppAdminAction = CollectorAppID + ":admin"
 
 	// pluginProxyPath is the plugin proxy prefix for the Fleet Management RPCs.
-	pluginProxyPath = "/api/plugin-proxy/" + pluginID + "/fleet-management-api"
+	pluginProxyPath = "/api/plugin-proxy/" + CollectorAppID + "/fleet-management-api"
 
 	// stackInfoPath is the plugin proxy route that returns the grafana.com
 	// instance record for the current stack. It needs the Viewer role only.
-	stackInfoPath = "/api/plugin-proxy/" + pluginID + "/grafanacom-api/instances/"
+	stackInfoPath = "/api/plugin-proxy/" + CollectorAppID + "/grafanacom-api/instances/"
 )
 
 // ConfigLoader can load the Grafana stack configuration from the active context.
@@ -72,7 +78,7 @@ func LoadClientWithStack(ctx context.Context, loader ConfigLoader) (*ClientResul
 		return nil, fmt.Errorf("fleet: failed to create HTTP client: %w", err)
 	}
 
-	stack, err := fetchStackInfo(ctx, cfg.Host, httpClient)
+	stack, err := getStackInfo(ctx, cfg.Host, httpClient)
 	if err != nil {
 		return nil, err
 	}
@@ -82,31 +88,6 @@ func LoadClientWithStack(ctx context.Context, loader ConfigLoader) (*ClientResul
 		Namespace: cfg.Namespace,
 		Stack:     stack,
 	}, nil
-}
-
-// stackInfoEntry memoizes one stack lookup per Grafana host.
-type stackInfoEntry struct {
-	once sync.Once
-	info cloud.StackInfo
-	err  error
-}
-
-//nolint:gochecknoglobals // process-wide memoization of an idempotent GET, keyed by host.
-var stackInfoCache sync.Map
-
-// fetchStackInfo reads the grafana.com instance record for the stack through the
-// collector app plugin proxy. The result is memoized per host, because several
-// commands load the client more than once in a run.
-func fetchStackInfo(ctx context.Context, host string, httpClient *http.Client) (cloud.StackInfo, error) {
-	v, _ := stackInfoCache.LoadOrStore(host, &stackInfoEntry{})
-	entry, ok := v.(*stackInfoEntry)
-	if !ok {
-		return cloud.StackInfo{}, fmt.Errorf("fleet: unexpected stack info cache entry for %q", host)
-	}
-	entry.once.Do(func() {
-		entry.info, entry.err = getStackInfo(ctx, host, httpClient)
-	})
-	return entry.info, entry.err
 }
 
 func getStackInfo(ctx context.Context, host string, httpClient *http.Client) (cloud.StackInfo, error) {
@@ -130,7 +111,7 @@ func getStackInfo(ctx context.Context, host string, httpClient *http.Client) (cl
 		}
 	}
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := httputils.ReadResponseBody(resp.Body, maxResponseBodyBytes)
 	if err != nil {
 		return cloud.StackInfo{}, fmt.Errorf("fleet: read stack info: %w", err)
 	}

--- a/internal/fleet/config_test.go
+++ b/internal/fleet/config_test.go
@@ -1,0 +1,135 @@
+package fleet_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/fleet"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	proxyPrefix   = "/api/plugin-proxy/grafana-collector-app/fleet-management-api"
+	instancesPath = "/api/plugin-proxy/grafana-collector-app/grafanacom-api/instances/"
+)
+
+// fakeLoader returns a stack REST config pointing at a test server.
+type fakeLoader struct {
+	host      string
+	namespace string
+	err       error
+}
+
+func (f fakeLoader) LoadGrafanaConfig(_ context.Context) (config.NamespacedRESTConfig, error) {
+	if f.err != nil {
+		return config.NamespacedRESTConfig{}, f.err
+	}
+	return config.NamespacedRESTConfig{
+		Config:    rest.Config{Host: f.host},
+		Namespace: f.namespace,
+	}, nil
+}
+
+const stackInfoJSON = `{
+	"id": 1631916,
+	"slug": "wbkprez",
+	"orgSlug": "wardbekker",
+	"regionSlug": "prod-eu-west-2",
+	"hmInstancePromId": 3188056,
+	"hmInstancePromUrl": "https://prometheus-prod-65-prod-eu-west-2.grafana.net",
+	"hmInstancePromClusterId": 417,
+	"hlInstanceId": 1589703,
+	"hlInstanceUrl": "https://logs-prod-012.grafana.net",
+	"agentManagementInstanceId": 1631916,
+	"agentManagementInstanceUrl": "https://fleet-management-prod-011.grafana.net"
+}`
+
+func TestLoadClient(t *testing.T) {
+	var stackInfoCalls atomic.Int64
+	var rpcPath atomic.Value
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == instancesPath {
+			stackInfoCalls.Add(1)
+		} else {
+			rpcPath.Store(r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	client, namespace, err := fleet.LoadClient(context.Background(), fakeLoader{host: server.URL, namespace: "stack-1"})
+	require.NoError(t, err)
+	assert.Equal(t, "stack-1", namespace)
+
+	// LoadClient must not fetch the stack record. Only LoadClientWithStack does.
+	assert.Equal(t, int64(0), stackInfoCalls.Load())
+
+	resp, err := client.DoRequest(context.Background(), "/pipeline.v1.PipelineService/ListPipelines", nil)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, proxyPrefix+"/pipeline.v1.PipelineService/ListPipelines", rpcPath.Load())
+}
+
+func TestLoadClient_LoaderError(t *testing.T) {
+	_, _, err := fleet.LoadClient(context.Background(), fakeLoader{err: assert.AnError})
+	require.ErrorIs(t, err, assert.AnError)
+}
+
+func TestLoadClientWithStack(t *testing.T) {
+	var stackInfoCalls atomic.Int64
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != instancesPath {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		stackInfoCalls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(stackInfoJSON))
+	}))
+	defer server.Close()
+
+	loader := fakeLoader{host: server.URL, namespace: "stack-1"}
+
+	result, err := fleet.LoadClientWithStack(context.Background(), loader)
+	require.NoError(t, err)
+
+	assert.Equal(t, "stack-1", result.Namespace)
+	assert.Equal(t, "wbkprez", result.Stack.Slug)
+	assert.Equal(t, "wardbekker", result.Stack.OrgSlug)
+	assert.Equal(t, 3188056, result.Stack.HMInstancePromID)
+	assert.Equal(t, 417, result.Stack.HMInstancePromClusterID)
+	assert.Equal(t, 1589703, result.Stack.HLInstanceID)
+	assert.Equal(t, "https://fleet-management-prod-011.grafana.net", result.Stack.AgentManagementInstanceURL)
+	assert.Equal(t, 1631916, result.Stack.AgentManagementInstanceID)
+
+	// A second load reuses the memoized record for the same host.
+	_, err = fleet.LoadClientWithStack(context.Background(), loader)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), stackInfoCalls.Load())
+}
+
+func TestLoadClientWithStack_PluginMissing(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"message":"plugin route match not found"}`))
+	}))
+	defer server.Close()
+
+	_, err := fleet.LoadClientWithStack(context.Background(), fakeLoader{host: server.URL})
+	require.Error(t, err)
+
+	var httpErr *fleet.HTTPError
+	require.ErrorAs(t, err, &httpErr)
+	assert.Equal(t, http.StatusNotFound, httpErr.Status)
+	assert.Contains(t, httpErr.Body, fleet.PluginRouteMissingMarker)
+}

--- a/internal/fleet/config_test.go
+++ b/internal/fleet/config_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -112,10 +113,49 @@ func TestLoadClientWithStack(t *testing.T) {
 	assert.Equal(t, "https://fleet-management-prod-011.grafana.net", result.Stack.AgentManagementInstanceURL)
 	assert.Equal(t, 1631916, result.Stack.AgentManagementInstanceID)
 
-	// A second load reuses the memoized record for the same host.
+	// A second load performs a new request. A previous transient error must not
+	// affect a later command path in the same process.
 	_, err = fleet.LoadClientWithStack(context.Background(), loader)
 	require.NoError(t, err)
-	assert.Equal(t, int64(1), stackInfoCalls.Load())
+	assert.Equal(t, int64(2), stackInfoCalls.Load())
+}
+
+func TestLoadClientWithStack_RetriesAfterTransientFailure(t *testing.T) {
+	var stackInfoCalls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != instancesPath {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		if stackInfoCalls.Add(1) == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(stackInfoJSON))
+	}))
+	defer server.Close()
+
+	loader := fakeLoader{host: server.URL, namespace: "stack-1"}
+	_, err := fleet.LoadClientWithStack(context.Background(), loader)
+	require.Error(t, err)
+
+	result, err := fleet.LoadClientWithStack(context.Background(), loader)
+	require.NoError(t, err)
+	assert.Equal(t, "wbkprez", result.Stack.Slug)
+	assert.Equal(t, int64(2), stackInfoCalls.Load())
+}
+
+func TestLoadClientWithStack_RejectsOversizedStackInfo(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"slug":"test","padding":"` + strings.Repeat("x", (1<<20)+1) + `"}`))
+	}))
+	defer server.Close()
+
+	_, err := fleet.LoadClientWithStack(context.Background(), fakeLoader{host: server.URL})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "response body exceeds 1 MB limit")
 }
 
 func TestLoadClientWithStack_PluginMissing(t *testing.T) {

--- a/internal/fleet/config_test.go
+++ b/internal/fleet/config_test.go
@@ -131,5 +131,5 @@ func TestLoadClientWithStack_PluginMissing(t *testing.T) {
 	var httpErr *fleet.HTTPError
 	require.ErrorAs(t, err, &httpErr)
 	assert.Equal(t, http.StatusNotFound, httpErr.Status)
-	assert.Contains(t, httpErr.Body, fleet.PluginRouteMissingMarker)
+	assert.True(t, fleet.IsPluginMissingBody(httpErr.Body))
 }

--- a/internal/fleet/errors.go
+++ b/internal/fleet/errors.go
@@ -4,12 +4,37 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 )
 
-// PluginRouteMissingMarker is the body Grafana returns when the collector app
-// plugin is absent or disabled. Callers use it to tell a missing plugin apart
-// from a missing resource, because both arrive as HTTP 404.
-const PluginRouteMissingMarker = "plugin route match not found"
+// pluginMissingMarkers are the response bodies that Grafana returns when the
+// collector app plugin cannot serve a proxy route. Grafana returns "Plugin not
+// found" when no plugin with that identifier is installed or enabled. Grafana
+// returns "plugin route match not found" when the plugin is installed but has
+// no route for the path. The markers are lower case, because the comparison
+// ignores case.
+//
+//nolint:gochecknoglobals // an immutable lookup table, not mutable state.
+var pluginMissingMarkers = []string{
+	"plugin not found",
+	"plugin route match not found",
+	"plugin is not enabled",
+}
+
+// IsPluginMissingBody reports whether the response body says that the collector
+// app plugin cannot serve the proxy route. Callers use it to tell a missing
+// plugin apart from a missing resource, because both arrive as HTTP 404. The
+// comparison ignores case, because Grafana does not capitalize these messages
+// in the same way.
+func IsPluginMissingBody(body string) bool {
+	lower := strings.ToLower(body)
+	for _, marker := range pluginMissingMarkers {
+		if strings.Contains(lower, marker) {
+			return true
+		}
+	}
+	return false
+}
 
 // ReadErrorBody reads and returns the response body as a string for error messages.
 func ReadErrorBody(resp *http.Response) string {

--- a/internal/fleet/errors.go
+++ b/internal/fleet/errors.go
@@ -7,6 +7,9 @@ import (
 	"strings"
 )
 
+// maxResponseBodyBytes caps Fleet response bodies at 1 MiB.
+const maxResponseBodyBytes int64 = 1 << 20
+
 // pluginMissingMarkers are the response bodies that Grafana returns when the
 // collector app plugin cannot serve a proxy route. Grafana returns "Plugin not
 // found" when no plugin with that identifier is installed or enabled. Grafana
@@ -36,9 +39,9 @@ func IsPluginMissingBody(body string) bool {
 	return false
 }
 
-// ReadErrorBody reads and returns the response body as a string for error messages.
+// ReadErrorBody reads up to 1 MiB of a response body for error messages.
 func ReadErrorBody(resp *http.Response) string {
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, maxResponseBodyBytes))
 	if err != nil {
 		return "(could not read body)"
 	}

--- a/internal/fleet/errors.go
+++ b/internal/fleet/errors.go
@@ -6,6 +6,11 @@ import (
 	"net/http"
 )
 
+// PluginRouteMissingMarker is the body Grafana returns when the collector app
+// plugin is absent or disabled. Callers use it to tell a missing plugin apart
+// from a missing resource, because both arrive as HTTP 404.
+const PluginRouteMissingMarker = "plugin route match not found"
+
 // ReadErrorBody reads and returns the response body as a string for error messages.
 func ReadErrorBody(resp *http.Response) string {
 	body, err := io.ReadAll(resp.Body)

--- a/internal/fleet/errors_test.go
+++ b/internal/fleet/errors_test.go
@@ -1,0 +1,57 @@
+package fleet_test
+
+import (
+	"testing"
+
+	"github.com/grafana/gcx/internal/fleet"
+)
+
+// Grafana answers with a different body for each cause, and it does not
+// capitalize the messages in the same way. A resource that is absent must not
+// match.
+func TestIsPluginMissingBody(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{
+			name: "plugin is not installed",
+			body: `{"message":"Plugin not found","traceID":""}`,
+			want: true,
+		},
+		{
+			name: "plugin has no route for the path",
+			body: `{"message":"plugin route match not found"}`,
+			want: true,
+		},
+		{
+			name: "plugin is installed but not enabled",
+			body: `{"message":"Plugin is not enabled"}`,
+			want: true,
+		},
+		{
+			name: "an absent pipeline is not a missing plugin",
+			body: `{"code":"not_found","message":"pipeline not found"}`,
+			want: false,
+		},
+		{
+			name: "an absent collector is not a missing plugin",
+			body: `{"code":"not_found","message":"collector not found"}`,
+			want: false,
+		},
+		{
+			name: "an empty body is not a missing plugin",
+			body: "",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := fleet.IsPluginMissingBody(tt.body); got != tt.want {
+				t.Fatalf("IsPluginMissingBody(%q) = %v, want %v", tt.body, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/fleet/errors_test.go
+++ b/internal/fleet/errors_test.go
@@ -1,6 +1,9 @@
 package fleet_test
 
 import (
+	"io"
+	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/grafana/gcx/internal/fleet"
@@ -53,5 +56,15 @@ func TestIsPluginMissingBody(t *testing.T) {
 				t.Fatalf("IsPluginMissingBody(%q) = %v, want %v", tt.body, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestReadErrorBody_LimitsDiagnosticBody(t *testing.T) {
+	resp := &http.Response{Body: io.NopCloser(strings.NewReader(strings.Repeat("x", (1<<20)+100)))}
+
+	body := fleet.ReadErrorBody(resp)
+
+	if len(body) != 1<<20 {
+		t.Fatalf("body length = %d, want %d", len(body), 1<<20)
 	}
 }

--- a/internal/fleet/preflight.go
+++ b/internal/fleet/preflight.go
@@ -1,0 +1,114 @@
+package fleet
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/grafana/gcx/internal/httputils"
+)
+
+const (
+	// CollectorAppSettingsPath returns the state of the collector app plugin.
+	CollectorAppSettingsPath = "/api/plugins/" + CollectorAppID + "/settings"
+
+	collectorAppUserActionsPath = "/api/access-control/user/actions"
+)
+
+// CollectorAppState describes whether the collector app can serve Fleet
+// requests and which route actions the current login has.
+type CollectorAppState struct {
+	// PluginKnown is false when Grafana returns a status other than 200 or 404.
+	PluginKnown bool
+	// PluginStatus is the HTTP status that left the plugin state unknown.
+	PluginStatus int
+	Installed    bool
+	Enabled      bool
+	// ActionsKnown is false when Grafana does not return the current actions.
+	ActionsKnown bool
+	CanRead      bool
+	CanAdmin     bool
+}
+
+// CheckCollectorApp reads the collector app state and the route actions of the
+// current login. It checks actions only when the plugin is installed and
+// enabled. This keeps a later action request from hiding a known plugin state.
+func CheckCollectorApp(ctx context.Context, host string, httpClient *http.Client) (CollectorAppState, error) {
+	var state CollectorAppState
+
+	var settings struct {
+		ID      string `json:"id"`
+		Enabled bool   `json:"enabled"`
+	}
+	status, err := getJSON(ctx, httpClient, host+CollectorAppSettingsPath, &settings)
+	if err != nil {
+		return state, err
+	}
+	switch status {
+	case http.StatusOK:
+		state.PluginKnown = true
+		state.Installed = true
+		state.Enabled = settings.Enabled
+	case http.StatusNotFound:
+		state.PluginKnown = true
+	default:
+		state.PluginStatus = status
+	}
+
+	if !state.PluginKnown || !state.Installed || !state.Enabled {
+		return state, nil
+	}
+
+	actions := map[string]bool{}
+	status, err = getJSON(ctx, httpClient, host+collectorAppUserActionsPath, &actions)
+	if err != nil {
+		return state, err
+	}
+	if status == http.StatusOK {
+		state.ActionsKnown = true
+		state.CanRead = actions[CollectorAppReadAction]
+		state.CanAdmin = actions[CollectorAppAdminAction]
+	}
+
+	return state, nil
+}
+
+// MayServe reports whether a Fleet request through the plugin proxy is useful.
+// An unknown plugin state permits a request so that the API can return the
+// authoritative error.
+func (s CollectorAppState) MayServe() bool {
+	if !s.PluginKnown {
+		return true
+	}
+	return s.Installed && s.Enabled
+}
+
+// getJSON performs a GET and decodes a successful body into out. For a
+// non-success response, it returns the status without an error.
+func getJSON(ctx context.Context, httpClient *http.Client, url string, out any) (int, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return 0, fmt.Errorf("fleet preflight: create request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("fleet preflight: request %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode > 299 {
+		return resp.StatusCode, nil
+	}
+
+	body, err := httputils.ReadResponseBody(resp.Body, maxResponseBodyBytes)
+	if err != nil {
+		return resp.StatusCode, fmt.Errorf("fleet preflight: read %s: %w", url, err)
+	}
+	if err := json.Unmarshal(body, out); err != nil {
+		return resp.StatusCode, fmt.Errorf("fleet preflight: decode %s: %w", url, err)
+	}
+	return resp.StatusCode, nil
+}

--- a/internal/fleet/preflight_test.go
+++ b/internal/fleet/preflight_test.go
@@ -1,0 +1,134 @@
+package fleet_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/grafana/gcx/internal/fleet"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckCollectorApp(t *testing.T) {
+	tests := []struct {
+		name             string
+		settingsStatus   int
+		enabled          bool
+		actionsStatus    int
+		actions          map[string]bool
+		want             fleet.CollectorAppState
+		wantActionsCalls int64
+	}{
+		{
+			name:           "plugin is absent",
+			settingsStatus: http.StatusNotFound,
+			want: fleet.CollectorAppState{
+				PluginKnown: true,
+			},
+		},
+		{
+			name:           "plugin is disabled",
+			settingsStatus: http.StatusOK,
+			want: fleet.CollectorAppState{
+				PluginKnown: true,
+				Installed:   true,
+			},
+		},
+		{
+			name:           "plugin state is unknown",
+			settingsStatus: http.StatusForbidden,
+			want: fleet.CollectorAppState{
+				PluginStatus: http.StatusForbidden,
+			},
+		},
+		{
+			name:           "plugin has both route actions",
+			settingsStatus: http.StatusOK,
+			enabled:        true,
+			actionsStatus:  http.StatusOK,
+			actions: map[string]bool{
+				fleet.CollectorAppReadAction:  true,
+				fleet.CollectorAppAdminAction: true,
+			},
+			want: fleet.CollectorAppState{
+				PluginKnown:  true,
+				Installed:    true,
+				Enabled:      true,
+				ActionsKnown: true,
+				CanRead:      true,
+				CanAdmin:     true,
+			},
+			wantActionsCalls: 1,
+		},
+		{
+			name:           "route actions are unknown",
+			settingsStatus: http.StatusOK,
+			enabled:        true,
+			actionsStatus:  http.StatusForbidden,
+			want: fleet.CollectorAppState{
+				PluginKnown: true,
+				Installed:   true,
+				Enabled:     true,
+			},
+			wantActionsCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var actionsCalls atomic.Int64
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case fleet.CollectorAppSettingsPath:
+					if tt.settingsStatus != http.StatusOK {
+						w.WriteHeader(tt.settingsStatus)
+						return
+					}
+					writeFleetJSON(w, map[string]any{
+						"id":      fleet.CollectorAppID,
+						"enabled": tt.enabled,
+					})
+				case "/api/access-control/user/actions":
+					actionsCalls.Add(1)
+					if tt.actionsStatus != http.StatusOK {
+						w.WriteHeader(tt.actionsStatus)
+						return
+					}
+					writeFleetJSON(w, tt.actions)
+				default:
+					w.WriteHeader(http.StatusNotFound)
+				}
+			}))
+			defer server.Close()
+
+			got, err := fleet.CheckCollectorApp(context.Background(), server.URL, server.Client())
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.wantActionsCalls, actionsCalls.Load())
+		})
+	}
+}
+
+func TestCheckCollectorApp_RejectsOversizedResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"enabled":true,"padding":"` + strings.Repeat("x", (1<<20)+1) + `"}`))
+	}))
+	defer server.Close()
+
+	_, err := fleet.CheckCollectorApp(context.Background(), server.URL, server.Client())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "response body exceeds 1 MB limit")
+}
+
+func writeFleetJSON(w http.ResponseWriter, value any) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+}

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -33,7 +33,6 @@ func cloudTokenHint(server string) string {
 	return create + " (Access Policies → Create access policy).\n" +
 		"Recommended scopes: stacks:read (required — resolves your stack). Then add per product:\n" +
 		"  metrics:write, logs:write, traces:write — Synthetic Monitoring\n" +
-		"  fleet-management:read — Fleet\n" +
 		"  stacks:write — create or update stacks\n" +
 		"Docs: https://grafana.com/docs/grafana-cloud/security-and-account-management/authentication-and-permissions/access-policies/create-access-policies\n" +
 		"Press Enter to skip (Cloud management features will be unavailable)."

--- a/internal/login/login_test.go
+++ b/internal/login/login_test.go
@@ -218,7 +218,7 @@ func TestRun(t *testing.T) { //nolint:maintidx // 8 table-driven cases; complexi
 						CloudCredentialKind:      login.CloudCredentialOAuth,
 						CloudTokenTrusted:        true,
 						CloudOAuthTokenExpiresAt: "2030-01-01T00:00:00Z",
-						CloudOAuthScopes:         []string{"stacks:read", "fleet-management:read"},
+						CloudOAuthScopes:         []string{"stacks:read", "metrics:write"},
 					},
 					Hooks: login.Hooks{
 						ConfigSource: configSource(dir),
@@ -238,7 +238,7 @@ func TestRun(t *testing.T) { //nolint:maintidx // 8 table-driven cases; complexi
 				assert.Equal(t, "gcom-oauth-token", ctx.CloudEntry.OAuthToken, "OAuth-issued tokens land in oauth-token, not token")
 				assert.Empty(t, ctx.CloudEntry.Token)
 				assert.Equal(t, "2030-01-01T00:00:00Z", ctx.CloudEntry.OAuthTokenExpiresAt)
-				assert.ElementsMatch(t, []string{"stacks:read", "fleet-management:read"}, ctx.CloudEntry.OAuthScopes)
+				assert.ElementsMatch(t, []string{"stacks:read", "metrics:write"}, ctx.CloudEntry.OAuthScopes)
 				assert.Equal(t, "https://grafana-ops.com", ctx.CloudEntry.OAuthUrl, "OAuth token must record its GCOM origin")
 				assert.Equal(t, "https://grafana-ops.com", ctx.CloudEntry.APIUrl, "APIUrl defaults to the same GCOM root")
 			},
@@ -1733,7 +1733,7 @@ func TestRun_CloudTokenHintGuidance(t *testing.T) {
 	assert.Contains(t, hint, "access-policies", "hint must link to the access-policies docs")
 	assert.Contains(t, hint, "stacks:read", "hint must name stacks:read as the required baseline scope")
 	assert.Contains(t, hint, "metrics:write", "hint must name the Synthetic Monitoring write scopes")
-	assert.Contains(t, hint, "fleet-management:read", "hint must name the Fleet scope")
+	assert.NotContains(t, hint, "fleet-management", "Fleet needs no grafana.com scope")
 	assert.Contains(t, hint, "stacks:write", "hint must name the stack-management scope")
 	assert.Contains(t, strings.ToLower(hint), "skip", "hint must retain the skip affordance")
 }

--- a/internal/providers/fleet/client.go
+++ b/internal/providers/fleet/client.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
 
 	fleetbase "github.com/grafana/gcx/internal/fleet"
 )
@@ -68,7 +67,7 @@ func httpError(resp *http.Response, path string) *fleetbase.HTTPError {
 // because the resource is absent.
 func pluginRouteMissing(err *fleetbase.HTTPError) bool {
 	return err.Status == http.StatusNotFound &&
-		strings.Contains(err.Body, fleetbase.PluginRouteMissingMarker)
+		fleetbase.IsPluginMissingBody(err.Body)
 }
 
 // ListPipelines returns all pipelines.

--- a/internal/providers/fleet/client.go
+++ b/internal/providers/fleet/client.go
@@ -225,7 +225,10 @@ func (c *Client) CreateCollector(ctx context.Context, col Collector) (*Collector
 		return nil, fmt.Errorf("fleet: create collector: %w", httpError(resp, pathCreateCollector))
 	}
 
-	var result Collector
+	// The production API can return an empty or partial object after a
+	// successful create. Start with the submitted collector so callers retain
+	// the canonical ID and name when the response omits them.
+	result := col
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return nil, fmt.Errorf("fleet: create collector: decode: %w", err)
 	}

--- a/internal/providers/fleet/client.go
+++ b/internal/providers/fleet/client.go
@@ -5,8 +5,26 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	fleetbase "github.com/grafana/gcx/internal/fleet"
+)
+
+// Fleet Management RPC paths, relative to the plugin proxy prefix.
+const (
+	pathListPipelines  = "/pipeline.v1.PipelineService/ListPipelines"
+	pathGetPipeline    = "/pipeline.v1.PipelineService/GetPipeline"
+	pathCreatePipeline = "/pipeline.v1.PipelineService/CreatePipeline"
+	pathUpdatePipeline = "/pipeline.v1.PipelineService/UpdatePipeline"
+	pathDeletePipeline = "/pipeline.v1.PipelineService/DeletePipeline"
+
+	pathListCollectors  = "/collector.v1.CollectorService/ListCollectors"
+	pathGetCollector    = "/collector.v1.CollectorService/GetCollector"
+	pathCreateCollector = "/collector.v1.CollectorService/CreateCollector"
+	pathUpdateCollector = "/collector.v1.CollectorService/UpdateCollector"
+	pathDeleteCollector = "/collector.v1.CollectorService/DeleteCollector"
+
+	pathGetLimits = "/tenant.v1.TenantService/GetLimits"
 )
 
 // Client is an HTTP client for the Grafana Fleet Management API.
@@ -17,12 +35,11 @@ type Client struct {
 }
 
 // NewClient creates a new Fleet Management client.
-// When useBasicAuth is true, requests use Basic auth with instanceID:apiToken.
-// Otherwise, requests use Bearer token auth.
+// baseURL must already include the collector app plugin proxy prefix.
 // If httpClient is nil, a default client with a 30-second timeout is used.
-func NewClient(ctx context.Context, baseURL, instanceID, apiToken string, useBasicAuth bool, httpClient *http.Client) *Client {
+func NewClient(ctx context.Context, baseURL string, httpClient *http.Client) *Client {
 	return &Client{
-		Client: fleetbase.NewClient(ctx, baseURL, instanceID, apiToken, useBasicAuth, httpClient),
+		Client: fleetbase.NewClient(ctx, baseURL, httpClient),
 	}
 }
 
@@ -36,16 +53,34 @@ func readErrorBody(resp *http.Response) string {
 	return fleetbase.ReadErrorBody(resp)
 }
 
+// httpError builds the typed error that cmd/gcx/fail recognises. It reads the
+// response body once, so callers must not read the body again.
+func httpError(resp *http.Response, path string) *fleetbase.HTTPError {
+	return &fleetbase.HTTPError{
+		Status: resp.StatusCode,
+		Path:   path,
+		Body:   readErrorBody(resp),
+	}
+}
+
+// pluginRouteMissing reports whether a 404 came from Grafana because the
+// collector app plugin is absent or disabled, rather than from Fleet Management
+// because the resource is absent.
+func pluginRouteMissing(err *fleetbase.HTTPError) bool {
+	return err.Status == http.StatusNotFound &&
+		strings.Contains(err.Body, fleetbase.PluginRouteMissingMarker)
+}
+
 // ListPipelines returns all pipelines.
 func (c *Client) ListPipelines(ctx context.Context) ([]Pipeline, error) {
-	resp, err := c.doRequest(ctx, "/pipeline.v1.PipelineService/ListPipelines", map[string]any{})
+	resp, err := c.doRequest(ctx, pathListPipelines, map[string]any{})
 	if err != nil {
 		return nil, fmt.Errorf("fleet: list pipelines: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("fleet: list pipelines: status %d: %s", resp.StatusCode, readErrorBody(resp))
+		return nil, fmt.Errorf("fleet: list pipelines: %w", httpError(resp, pathListPipelines))
 	}
 
 	var result struct {
@@ -60,17 +95,18 @@ func (c *Client) ListPipelines(ctx context.Context) ([]Pipeline, error) {
 
 // GetPipeline returns a single pipeline by ID. Returns nil if not found.
 func (c *Client) GetPipeline(ctx context.Context, id string) (*Pipeline, error) {
-	resp, err := c.doRequest(ctx, "/pipeline.v1.PipelineService/GetPipeline", map[string]string{"id": id})
+	resp, err := c.doRequest(ctx, pathGetPipeline, map[string]string{"id": id})
 	if err != nil {
 		return nil, fmt.Errorf("fleet: get pipeline %s: %w", id, err)
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf("fleet: get pipeline %s: not found", id)
-	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("fleet: get pipeline %s: status %d: %s", id, resp.StatusCode, readErrorBody(resp))
+		apiErr := httpError(resp, pathGetPipeline)
+		if apiErr.Status == http.StatusNotFound && !pluginRouteMissing(apiErr) {
+			return nil, fmt.Errorf("fleet: get pipeline %s: not found", id)
+		}
+		return nil, fmt.Errorf("fleet: get pipeline %s: %w", id, apiErr)
 	}
 
 	var result Pipeline
@@ -83,14 +119,14 @@ func (c *Client) GetPipeline(ctx context.Context, id string) (*Pipeline, error) 
 
 // CreatePipeline creates a new pipeline and returns it.
 func (c *Client) CreatePipeline(ctx context.Context, p Pipeline) (*Pipeline, error) {
-	resp, err := c.doRequest(ctx, "/pipeline.v1.PipelineService/CreatePipeline", map[string]any{"pipeline": p})
+	resp, err := c.doRequest(ctx, pathCreatePipeline, map[string]any{"pipeline": p})
 	if err != nil {
 		return nil, fmt.Errorf("fleet: create pipeline: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("fleet: create pipeline: status %d: %s", resp.StatusCode, readErrorBody(resp))
+		return nil, fmt.Errorf("fleet: create pipeline: %w", httpError(resp, pathCreatePipeline))
 	}
 
 	var result Pipeline
@@ -104,14 +140,14 @@ func (c *Client) CreatePipeline(ctx context.Context, p Pipeline) (*Pipeline, err
 // UpdatePipeline updates an existing pipeline.
 func (c *Client) UpdatePipeline(ctx context.Context, id string, p Pipeline) error {
 	p.ID = id
-	resp, err := c.doRequest(ctx, "/pipeline.v1.PipelineService/UpdatePipeline", map[string]any{"pipeline": p})
+	resp, err := c.doRequest(ctx, pathUpdatePipeline, map[string]any{"pipeline": p})
 	if err != nil {
 		return fmt.Errorf("fleet: update pipeline %s: %w", id, err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("fleet: update pipeline %s: status %d: %s", id, resp.StatusCode, readErrorBody(resp))
+		return fmt.Errorf("fleet: update pipeline %s: %w", id, httpError(resp, pathUpdatePipeline))
 	}
 
 	return nil
@@ -119,14 +155,14 @@ func (c *Client) UpdatePipeline(ctx context.Context, id string, p Pipeline) erro
 
 // DeletePipeline deletes a pipeline by ID.
 func (c *Client) DeletePipeline(ctx context.Context, id string) error {
-	resp, err := c.doRequest(ctx, "/pipeline.v1.PipelineService/DeletePipeline", map[string]string{"id": id})
+	resp, err := c.doRequest(ctx, pathDeletePipeline, map[string]string{"id": id})
 	if err != nil {
 		return fmt.Errorf("fleet: delete pipeline %s: %w", id, err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("fleet: delete pipeline %s: status %d: %s", id, resp.StatusCode, readErrorBody(resp))
+		return fmt.Errorf("fleet: delete pipeline %s: %w", id, httpError(resp, pathDeletePipeline))
 	}
 
 	return nil
@@ -134,14 +170,14 @@ func (c *Client) DeletePipeline(ctx context.Context, id string) error {
 
 // ListCollectors returns all collectors.
 func (c *Client) ListCollectors(ctx context.Context) ([]Collector, error) {
-	resp, err := c.doRequest(ctx, "/collector.v1.CollectorService/ListCollectors", map[string]any{})
+	resp, err := c.doRequest(ctx, pathListCollectors, map[string]any{})
 	if err != nil {
 		return nil, fmt.Errorf("fleet: list collectors: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("fleet: list collectors: status %d: %s", resp.StatusCode, readErrorBody(resp))
+		return nil, fmt.Errorf("fleet: list collectors: %w", httpError(resp, pathListCollectors))
 	}
 
 	var result struct {
@@ -156,17 +192,18 @@ func (c *Client) ListCollectors(ctx context.Context) ([]Collector, error) {
 
 // GetCollector returns a single collector by ID. Returns nil if not found.
 func (c *Client) GetCollector(ctx context.Context, id string) (*Collector, error) {
-	resp, err := c.doRequest(ctx, "/collector.v1.CollectorService/GetCollector", map[string]string{"id": id})
+	resp, err := c.doRequest(ctx, pathGetCollector, map[string]string{"id": id})
 	if err != nil {
 		return nil, fmt.Errorf("fleet: get collector %s: %w", id, err)
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode == http.StatusNotFound {
-		return nil, fmt.Errorf("fleet: get collector %s: not found", id)
-	}
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("fleet: get collector %s: status %d: %s", id, resp.StatusCode, readErrorBody(resp))
+		apiErr := httpError(resp, pathGetCollector)
+		if apiErr.Status == http.StatusNotFound && !pluginRouteMissing(apiErr) {
+			return nil, fmt.Errorf("fleet: get collector %s: not found", id)
+		}
+		return nil, fmt.Errorf("fleet: get collector %s: %w", id, apiErr)
 	}
 
 	var result Collector
@@ -179,14 +216,14 @@ func (c *Client) GetCollector(ctx context.Context, id string) (*Collector, error
 
 // CreateCollector creates a new collector and returns it.
 func (c *Client) CreateCollector(ctx context.Context, col Collector) (*Collector, error) {
-	resp, err := c.doRequest(ctx, "/collector.v1.CollectorService/CreateCollector", map[string]any{"collector": col})
+	resp, err := c.doRequest(ctx, pathCreateCollector, map[string]any{"collector": col})
 	if err != nil {
 		return nil, fmt.Errorf("fleet: create collector: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("fleet: create collector: status %d: %s", resp.StatusCode, readErrorBody(resp))
+		return nil, fmt.Errorf("fleet: create collector: %w", httpError(resp, pathCreateCollector))
 	}
 
 	var result Collector
@@ -199,14 +236,14 @@ func (c *Client) CreateCollector(ctx context.Context, col Collector) (*Collector
 
 // UpdateCollector updates an existing collector.
 func (c *Client) UpdateCollector(ctx context.Context, col Collector) error {
-	resp, err := c.doRequest(ctx, "/collector.v1.CollectorService/UpdateCollector", map[string]any{"collector": col})
+	resp, err := c.doRequest(ctx, pathUpdateCollector, map[string]any{"collector": col})
 	if err != nil {
 		return fmt.Errorf("fleet: update collector %s: %w", col.ID, err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("fleet: update collector %s: status %d: %s", col.ID, resp.StatusCode, readErrorBody(resp))
+		return fmt.Errorf("fleet: update collector %s: %w", col.ID, httpError(resp, pathUpdateCollector))
 	}
 
 	return nil
@@ -214,14 +251,14 @@ func (c *Client) UpdateCollector(ctx context.Context, col Collector) error {
 
 // DeleteCollector deletes a collector by ID.
 func (c *Client) DeleteCollector(ctx context.Context, id string) error {
-	resp, err := c.doRequest(ctx, "/collector.v1.CollectorService/DeleteCollector", map[string]string{"id": id})
+	resp, err := c.doRequest(ctx, pathDeleteCollector, map[string]string{"id": id})
 	if err != nil {
 		return fmt.Errorf("fleet: delete collector %s: %w", id, err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("fleet: delete collector %s: status %d: %s", id, resp.StatusCode, readErrorBody(resp))
+		return fmt.Errorf("fleet: delete collector %s: %w", id, httpError(resp, pathDeleteCollector))
 	}
 
 	return nil
@@ -229,14 +266,14 @@ func (c *Client) DeleteCollector(ctx context.Context, id string) error {
 
 // GetLimits returns the tenant limits for the Fleet Management stack.
 func (c *Client) GetLimits(ctx context.Context) (*Limits, error) {
-	resp, err := c.doRequest(ctx, "/tenant.v1.TenantService/GetLimits", map[string]any{})
+	resp, err := c.doRequest(ctx, pathGetLimits, map[string]any{})
 	if err != nil {
 		return nil, fmt.Errorf("fleet: get limits: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("fleet: get limits: status %d: %s", resp.StatusCode, readErrorBody(resp))
+		return nil, fmt.Errorf("fleet: get limits: %w", httpError(resp, pathGetLimits))
 	}
 
 	var result Limits

--- a/internal/providers/fleet/client_test.go
+++ b/internal/providers/fleet/client_test.go
@@ -424,34 +424,65 @@ func TestClient_GetCollector(t *testing.T) {
 }
 
 func TestClient_CreateCollector(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, http.MethodPost, r.Method)
-		assert.Contains(t, r.URL.Path, "/collector.v1.CollectorService/CreateCollector")
+	tests := []struct {
+		name     string
+		response map[string]any
+		wantID   string
+		wantName string
+	}{
+		{
+			name:     "uses complete server response",
+			response: map[string]any{"id": "server-id", "name": "server-name", "collector_type": "alloy"},
+			wantID:   "server-id",
+			wantName: "server-name",
+		},
+		{
+			name:     "fills fields omitted from partial response",
+			response: map[string]any{"name": "server-name"},
+			wantID:   "submitted-id",
+			wantName: "server-name",
+		},
+		{
+			name:     "uses submitted collector for empty response",
+			response: map[string]any{},
+			wantID:   "submitted-id",
+			wantName: "new-collector",
+		},
+	}
 
-		var body map[string]json.RawMessage
-		assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, http.MethodPost, r.Method)
+				assert.Contains(t, r.URL.Path, "/collector.v1.CollectorService/CreateCollector")
 
-		var col fleet.Collector
-		assert.NoError(t, json.Unmarshal(body["collector"], &col))
-		assert.Equal(t, "new-collector", col.Name)
-		assert.Equal(t, "alloy", col.CollectorType)
+				var body map[string]json.RawMessage
+				assert.NoError(t, json.NewDecoder(r.Body).Decode(&body))
 
-		writeJSON(w, map[string]any{
-			"id": "c-created", "name": "new-collector", "collector_type": "alloy",
+				var col fleet.Collector
+				assert.NoError(t, json.Unmarshal(body["collector"], &col))
+				assert.Equal(t, "submitted-id", col.ID)
+				assert.Equal(t, "new-collector", col.Name)
+				assert.Equal(t, "alloy", col.CollectorType)
+
+				writeJSON(w, tt.response)
+			}))
+			defer server.Close()
+
+			client := newTestClient(t, server)
+			created, err := client.CreateCollector(context.Background(), fleet.Collector{
+				ID:            "submitted-id",
+				Name:          "new-collector",
+				CollectorType: "alloy",
+			})
+
+			require.NoError(t, err)
+			require.NotNil(t, created)
+			assert.Equal(t, tt.wantID, created.ID)
+			assert.Equal(t, tt.wantName, created.Name)
+			assert.Equal(t, "alloy", created.CollectorType)
 		})
-	}))
-	defer server.Close()
-
-	client := newTestClient(t, server)
-	created, err := client.CreateCollector(context.Background(), fleet.Collector{
-		Name:          "new-collector",
-		CollectorType: "alloy",
-	})
-
-	require.NoError(t, err)
-	require.NotNil(t, created)
-	assert.Equal(t, "c-created", created.ID)
-	assert.Equal(t, "new-collector", created.Name)
+	}
 }
 
 func TestClient_DeleteCollector(t *testing.T) {

--- a/internal/providers/fleet/client_test.go
+++ b/internal/providers/fleet/client_test.go
@@ -3,10 +3,12 @@ package fleet_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	fleetbase "github.com/grafana/gcx/internal/fleet"
 	"github.com/grafana/gcx/internal/providers/fleet"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -14,7 +16,7 @@ import (
 
 func newTestClient(t *testing.T, server *httptest.Server) *fleet.Client {
 	t.Helper()
-	return fleet.NewClient(context.Background(), server.URL, "test-instance", "test-token", true, nil)
+	return fleet.NewClient(context.Background(), server.URL, nil)
 }
 
 func writeJSON(w http.ResponseWriter, v any) {
@@ -499,4 +501,108 @@ func TestClient_GetLimits(t *testing.T) {
 	assert.Equal(t, int64(10), *limits.RequestsPerSecondCollector)
 	require.NotNil(t, limits.RequestsPerSecondAPI)
 	assert.Equal(t, int64(20), *limits.RequestsPerSecondAPI)
+}
+
+// A 404 has two meanings behind the plugin proxy: Fleet Management has no such
+// resource, or Grafana has no such plugin route. The two must not be confused.
+func TestClient_PluginRouteMissing(t *testing.T) {
+	tests := []struct {
+		name         string
+		body         string
+		wantTypedErr bool
+		wantMessage  string
+	}{
+		{
+			name:         "missing resource stays a not found message",
+			body:         `{"code":"not_found","message":"pipeline not found"}`,
+			wantTypedErr: false,
+			wantMessage:  "not found",
+		},
+		{
+			name:         "missing plugin route returns the typed error",
+			body:         `{"message":"plugin route match not found"}`,
+			wantTypedErr: true,
+			wantMessage:  "plugin route match not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusNotFound)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+
+			client := newTestClient(t, server)
+
+			_, err := client.GetPipeline(context.Background(), "123")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantMessage)
+
+			var httpErr *fleetbase.HTTPError
+			assert.Equal(t, tt.wantTypedErr, errors.As(err, &httpErr))
+
+			_, err = client.GetCollector(context.Background(), "123")
+			require.Error(t, err)
+			assert.Equal(t, tt.wantTypedErr, errors.As(err, &httpErr))
+		})
+	}
+}
+
+// Every non-2xx from a mutation must carry the typed error, so that
+// cmd/gcx/fail can map the status to an actionable message.
+func TestClient_MutationsReturnTypedError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"forbidden"}`))
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server)
+
+	tests := []struct {
+		name string
+		call func() error
+	}{
+		{"create pipeline", func() error {
+			_, err := client.CreatePipeline(context.Background(), fleet.Pipeline{Name: "p"})
+			return err
+		}},
+		{"update pipeline", func() error {
+			return client.UpdatePipeline(context.Background(), "1", fleet.Pipeline{Name: "p"})
+		}},
+		{"delete pipeline", func() error { return client.DeletePipeline(context.Background(), "1") }},
+		{"create collector", func() error {
+			_, err := client.CreateCollector(context.Background(), fleet.Collector{Name: "c"})
+			return err
+		}},
+		{"update collector", func() error {
+			return client.UpdateCollector(context.Background(), fleet.Collector{ID: "1", Name: "c"})
+		}},
+		{"delete collector", func() error { return client.DeleteCollector(context.Background(), "1") }},
+		{"list pipelines", func() error {
+			_, err := client.ListPipelines(context.Background())
+			return err
+		}},
+		{"list collectors", func() error {
+			_, err := client.ListCollectors(context.Background())
+			return err
+		}},
+		{"get limits", func() error {
+			_, err := client.GetLimits(context.Background())
+			return err
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.call()
+			require.Error(t, err)
+
+			var httpErr *fleetbase.HTTPError
+			require.ErrorAs(t, err, &httpErr)
+			assert.Equal(t, http.StatusForbidden, httpErr.Status)
+		})
+	}
 }

--- a/internal/providers/fleet/collector_contract_test.go
+++ b/internal/providers/fleet/collector_contract_test.go
@@ -1,0 +1,126 @@
+package fleet //nolint:testpackage // Tests unexported Fleet resource contracts.
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFleetExamplesMatchLiveCreateRequirements(t *testing.T) {
+	var pipeline map[string]any
+	require.NoError(t, json.Unmarshal(pipelineExample(), &pipeline))
+	pipelineSpec, ok := pipeline["spec"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "my_pipeline", pipelineSpec["name"])
+	assert.Regexp(t, `^[A-Za-z_][A-Za-z0-9_]*$`, pipelineSpec["name"])
+
+	var collector map[string]any
+	require.NoError(t, json.Unmarshal(collectorExample(), &collector))
+	collectorSpec, ok := collector["spec"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "my-collector-id", collectorSpec["id"])
+}
+
+func TestCollectorSchemaExposesID(t *testing.T) {
+	var schema map[string]any
+	require.NoError(t, json.Unmarshal(collectorSchema(), &schema))
+
+	properties, ok := schema["properties"].(map[string]any)
+	require.True(t, ok)
+	spec, ok := properties["spec"].(map[string]any)
+	require.True(t, ok)
+	specProperties, ok := spec["properties"].(map[string]any)
+	require.True(t, ok)
+	id, ok := specProperties["id"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "string", id["type"])
+}
+
+func TestResolveCollectorUsesArbitraryStringIDFirst(t *testing.T) {
+	const collectorID = "collector-prod-eu-a"
+	var requestedIDs []string
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case pathGetCollector:
+			var request map[string]string
+			if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&request)) {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			requestedIDs = append(requestedIDs, request["id"])
+			if request["id"] != collectorID {
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+			writeContractJSON(t, w, map[string]any{"id": collectorID, "name": "renamed"})
+		case pathListCollectors:
+			t.Error("resolver listed collectors after an exact ID match")
+			writeContractJSON(t, w, map[string]any{"collectors": []any{}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	collector, err := resolveCollector(context.Background(), NewClient(context.Background(), server.URL, server.Client()), collectorID)
+	require.NoError(t, err)
+	assert.Equal(t, collectorID, collector.ID)
+	assert.Equal(t, []string{collectorID}, requestedIDs)
+}
+
+func TestResolveCollectorFallbacks(t *testing.T) {
+	const stringID = "collector-prod-eu-a"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case pathGetCollector:
+			var request map[string]string
+			if !assert.NoError(t, json.NewDecoder(r.Body).Decode(&request)) {
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+			if request["id"] == "202" {
+				writeContractJSON(t, w, map[string]any{"id": "202", "name": "legacy"})
+				return
+			}
+			w.WriteHeader(http.StatusNotFound)
+		case pathListCollectors:
+			writeContractJSON(t, w, map[string]any{
+				"collectors": []map[string]any{{"id": stringID, "name": "renamed"}},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+	client := NewClient(context.Background(), server.URL, server.Client())
+
+	tests := []struct {
+		name   string
+		ref    string
+		wantID string
+	}{
+		{name: "collector name", ref: "renamed", wantID: stringID},
+		{name: "rendered string ID", ref: "renamed-" + stringID, wantID: stringID},
+		{name: "legacy numeric composite", ref: "legacy-202", wantID: "202"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			collector, err := resolveCollector(context.Background(), client, tt.ref)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantID, collector.ID)
+		})
+	}
+}
+
+func writeContractJSON(t *testing.T, w http.ResponseWriter, value any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	assert.NoError(t, json.NewEncoder(w).Encode(value))
+}

--- a/internal/providers/fleet/mutation_contract_test.go
+++ b/internal/providers/fleet/mutation_contract_test.go
@@ -79,7 +79,7 @@ func newFleetAPIServer(t *testing.T) *httptest.Server {
 		writeJSON(w, map[string]any{})
 	})
 	mux.HandleFunc("/collector.v1.CollectorService/CreateCollector", func(w http.ResponseWriter, _ *http.Request) {
-		writeJSON(w, map[string]any{"id": "202", "name": "col-a"})
+		writeJSON(w, map[string]any{})
 	})
 	mux.HandleFunc("/collector.v1.CollectorService/GetCollector", func(w http.ResponseWriter, _ *http.Request) {
 		writeJSON(w, map[string]any{"id": "202", "name": "col-a"})
@@ -127,6 +127,7 @@ kind: Collector
 metadata:
   name: col-a
 spec:
+  id: "202"
   name: col-a
   collector_type: alloy
 `)
@@ -299,4 +300,22 @@ func TestFleetMutations_ExplicitOutputOverride(t *testing.T) {
 			assert.NotContains(t, stdout, "✔", "explicit -o yaml must not carry the styled human line")
 		})
 	}
+}
+
+func TestCollectorCreateRequiresID(t *testing.T) {
+	manifest := writeManifest(t, "collector-without-id.yaml", `apiVersion: fleet.ext.grafana.app/v1alpha1
+kind: Collector
+metadata:
+  name: col-a
+spec:
+  name: col-a
+  collector_type: alloy
+`)
+
+	stdout, err := runCommand(t, func(h *fleetHelper) *cobra.Command {
+		return h.newCollectorCreateCommand()
+	}, []string{"-f", manifest})
+
+	require.ErrorContains(t, err, "collector spec.id is required for create")
+	assert.NotContains(t, stdout, "gcx.mutation")
 }

--- a/internal/providers/fleet/mutation_contract_test.go
+++ b/internal/providers/fleet/mutation_contract_test.go
@@ -10,8 +10,8 @@ package fleet //nolint:testpackage // Drives the unexported command constructors
 //   - explicit -o json / -o yaml overrides are honored.
 //
 // The commands are driven end-to-end (cobra Execute) against a fake Fleet
-// Management API server, with the cloud config loader stubbed through the
-// CloudConfigLoader seam.
+// Management API server, with the stack config loader stubbed through the
+// RESTConfigLoader seam.
 
 import (
 	"bytes"
@@ -27,24 +27,24 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/grafana/gcx/internal/agent"
-	"github.com/grafana/gcx/internal/cloud"
-	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/config"
 	"github.com/spf13/cobra"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
 )
 
-// fakeCloudLoader satisfies CloudConfigLoader, pointing the fleet base client
-// at a test server.
-type fakeCloudLoader struct{ url string }
+// fleetProxyPrefix is the collector app plugin proxy prefix that production
+// code prepends to every Fleet Management RPC path.
+const fleetProxyPrefix = "/api/plugin-proxy/grafana-collector-app/fleet-management-api"
 
-func (f *fakeCloudLoader) LoadCloudConfig(context.Context) (providers.CloudRESTConfig, error) {
-	return providers.CloudRESTConfig{
-		Token: "test-token",
-		Stack: cloud.StackInfo{
-			AgentManagementInstanceURL: f.url,
-			AgentManagementInstanceID:  42,
-		},
+// fakeRESTLoader satisfies RESTConfigLoader, pointing the fleet base client at
+// a test server.
+type fakeRESTLoader struct{ url string }
+
+func (f *fakeRESTLoader) LoadGrafanaConfig(context.Context) (config.NamespacedRESTConfig, error) {
+	return config.NamespacedRESTConfig{
+		Config:    rest.Config{Host: f.url},
 		Namespace: "stack-1",
 	}, nil
 }
@@ -94,7 +94,9 @@ func newFleetAPIServer(t *testing.T) *httptest.Server {
 		writeJSON(w, map[string]any{})
 	})
 
-	server := httptest.NewServer(mux)
+	// Production prepends the plugin proxy prefix, so the test server mounts the
+	// bare RPC mux under that prefix.
+	server := httptest.NewServer(http.StripPrefix(fleetProxyPrefix, mux))
 	t.Cleanup(server.Close)
 	return server
 }
@@ -202,7 +204,7 @@ func fleetMutationCases(t *testing.T) []struct {
 func runCommand(t *testing.T, build func(h *fleetHelper) *cobra.Command, args []string) (string, error) {
 	t.Helper()
 	server := newFleetAPIServer(t)
-	h := &fleetHelper{loader: &fakeCloudLoader{url: server.URL}}
+	h := &fleetHelper{loader: &fakeRESTLoader{url: server.URL}}
 	cmd := build(h)
 	var stdout, stderr bytes.Buffer
 	cmd.SetOut(&stdout)

--- a/internal/providers/fleet/provider.go
+++ b/internal/providers/fleet/provider.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/grafana/gcx/internal/config"
 	fleetbase "github.com/grafana/gcx/internal/fleet"
 	"github.com/grafana/gcx/internal/format"
 	"github.com/grafana/gcx/internal/gcxerrors"
@@ -166,9 +167,9 @@ func (p *FleetProvider) TypedRegistrations() []adapter.Registration {
 // ---------------------------------------------------------------------------
 
 type fleetHelper struct {
-	// loader is the narrow cloud-config interface (satisfied by
+	// loader is the narrow stack-config interface (satisfied by
 	// *providers.ConfigLoader) so tests can inject a fake loader.
-	loader CloudConfigLoader
+	loader RESTConfigLoader
 }
 
 func (h *fleetHelper) loadClient(ctx context.Context) (*Client, string, error) {
@@ -1195,13 +1196,15 @@ func readCollectorFromFile(filename string, stdin io.Reader) (*Collector, error)
 // Resource adapter factories
 // ---------------------------------------------------------------------------
 
-// CloudConfigLoader can load Grafana Cloud configuration from the active context.
-type CloudConfigLoader interface {
-	LoadCloudConfig(ctx context.Context) (providers.CloudRESTConfig, error)
+// RESTConfigLoader can load the Grafana stack configuration from the active
+// context. Fleet Management reaches its API through the collector app plugin
+// proxy on the stack, so it needs no grafana.com token.
+type RESTConfigLoader interface {
+	LoadGrafanaConfig(ctx context.Context) (config.NamespacedRESTConfig, error)
 }
 
 // NewPipelineTypedCRUD creates a TypedCRUD for Fleet pipelines.
-func NewPipelineTypedCRUD(ctx context.Context, loader CloudConfigLoader) (*adapter.TypedCRUD[Pipeline], string, error) {
+func NewPipelineTypedCRUD(ctx context.Context, loader RESTConfigLoader) (*adapter.TypedCRUD[Pipeline], string, error) {
 	base, namespace, err := fleetbase.LoadClient(ctx, loader)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to load Fleet config for pipelines: %w", err)
@@ -1248,7 +1251,7 @@ func NewPipelineTypedCRUD(ctx context.Context, loader CloudConfigLoader) (*adapt
 }
 
 // NewPipelineAdapterFactory returns a lazy adapter.Factory for fleet pipelines.
-func NewPipelineAdapterFactory(loader CloudConfigLoader) adapter.Factory {
+func NewPipelineAdapterFactory(loader RESTConfigLoader) adapter.Factory {
 	return func(ctx context.Context) (adapter.ResourceAdapter, error) {
 		crud, _, err := NewPipelineTypedCRUD(ctx, loader)
 		if err != nil {
@@ -1259,7 +1262,7 @@ func NewPipelineAdapterFactory(loader CloudConfigLoader) adapter.Factory {
 }
 
 // NewCollectorTypedCRUD creates a TypedCRUD for Fleet collectors.
-func NewCollectorTypedCRUD(ctx context.Context, loader CloudConfigLoader) (*adapter.TypedCRUD[Collector], string, error) {
+func NewCollectorTypedCRUD(ctx context.Context, loader RESTConfigLoader) (*adapter.TypedCRUD[Collector], string, error) {
 	base, namespace, err := fleetbase.LoadClient(ctx, loader)
 	if err != nil {
 		return nil, "", fmt.Errorf("failed to load Fleet config for collectors: %w", err)
@@ -1307,7 +1310,7 @@ func NewCollectorTypedCRUD(ctx context.Context, loader CloudConfigLoader) (*adap
 }
 
 // NewCollectorAdapterFactory returns a lazy adapter.Factory for fleet collectors.
-func NewCollectorAdapterFactory(loader CloudConfigLoader) adapter.Factory {
+func NewCollectorAdapterFactory(loader RESTConfigLoader) adapter.Factory {
 	return func(ctx context.Context) (adapter.ResourceAdapter, error) {
 		crud, _, err := NewCollectorTypedCRUD(ctx, loader)
 		if err != nil {

--- a/internal/providers/fleet/provider.go
+++ b/internal/providers/fleet/provider.go
@@ -339,8 +339,14 @@ func resolvePipeline(ctx context.Context, client *Client, ref string) (*Pipeline
 
 // resolveCollector looks up a collector by slug-id, plain ID, or name.
 func resolveCollector(ctx context.Context, client *Client, ref string) (*Collector, error) {
-	// Try extracting a numeric ID from the reference (handles "name-123" and "123").
-	if id, ok := extractIDFromSlug(ref); ok {
+	// Collector IDs are arbitrary strings. Try the input as the canonical ID
+	// before interpreting it as a rendered resource name or collector name.
+	if collector, err := client.GetCollector(ctx, ref); err == nil {
+		return collector, nil
+	}
+
+	// Older rendered resources encode a numeric ID as a slug suffix.
+	if id, ok := extractIDFromSlug(ref); ok && id != ref {
 		c, err := client.GetCollector(ctx, id)
 		if err == nil {
 			return c, nil
@@ -352,7 +358,7 @@ func resolveCollector(ctx context.Context, client *Client, ref string) (*Collect
 		return nil, fmt.Errorf("fleet: resolve collector %q: %w", ref, err)
 	}
 	for i := range collectors {
-		if collectors[i].Name == ref {
+		if collectors[i].ID == ref || collectors[i].Name == ref || collectors[i].GetResourceName() == ref {
 			return &collectors[i], nil
 		}
 	}
@@ -692,6 +698,9 @@ func (h *fleetHelper) newCollectorCreateCommand() *cobra.Command {
 
 			collector, err := readCollectorFromFile(opts.File, cmd.InOrStdin())
 			if err != nil {
+				return err
+			}
+			if err := validateCollectorForCreate(collector); err != nil {
 				return err
 			}
 
@@ -1078,9 +1087,6 @@ func CollectorToResource(col Collector, namespace string) (*resources.Resource, 
 		return nil, fmt.Errorf("failed to unmarshal collector to map: %w", err)
 	}
 
-	// Strip the ID from spec — it lives in metadata.name.
-	delete(specMap, "id")
-
 	// Build slug-id name for unique identification.
 	name := slugifyName(col.Name)
 	if col.ID != "" {
@@ -1124,9 +1130,12 @@ func CollectorFromResource(res *resources.Resource) (*Collector, error) {
 		return nil, fmt.Errorf("failed to unmarshal spec to collector: %w", err)
 	}
 
-	// Restore ID from metadata.name slug.
-	if id, ok := extractIDFromSlug(res.Raw.GetName()); ok {
-		col.ID = id
+	// New manifests retain the canonical string ID in spec.id. Older manifests
+	// can still restore a numeric ID from metadata.name.
+	if col.ID == "" {
+		if id, ok := extractIDFromSlug(res.Raw.GetName()); ok {
+			col.ID = id
+		}
 	}
 
 	return &col, nil
@@ -1190,6 +1199,13 @@ func readCollectorFromFile(filename string, stdin io.Reader) (*Collector, error)
 	}
 
 	return CollectorFromResource(res)
+}
+
+func validateCollectorForCreate(collector *Collector) error {
+	if strings.TrimSpace(collector.ID) == "" {
+		return errors.New("collector spec.id is required for create")
+	}
+	return nil
 }
 
 // ---------------------------------------------------------------------------
@@ -1275,12 +1291,19 @@ func NewCollectorTypedCRUD(ctx context.Context, loader RESTConfigLoader) (*adapt
 			return resolveCollector(ctx, client, name)
 		},
 		CreateFn: func(ctx context.Context, col *Collector) (*Collector, error) {
+			if err := validateCollectorForCreate(col); err != nil {
+				return nil, err
+			}
 			return client.CreateCollector(ctx, *col)
 		},
 		UpdateFn: func(ctx context.Context, name string, col *Collector) (*Collector, error) {
-			id, ok := extractIDFromSlug(name)
-			if !ok {
-				return nil, fmt.Errorf("cannot determine collector ID from name %q: expected format \"<slug>-<id>\" or numeric ID", name)
+			id := col.ID
+			if id == "" {
+				existing, err := resolveCollector(ctx, client, name)
+				if err != nil {
+					return nil, fmt.Errorf("cannot resolve collector %q for update: %w", name, err)
+				}
+				id = existing.ID
 			}
 			col.ID = id
 			if err := client.UpdateCollector(ctx, *col); err != nil {
@@ -1296,15 +1319,14 @@ func NewCollectorTypedCRUD(ctx context.Context, loader RESTConfigLoader) (*adapt
 			return updated, nil
 		},
 		DeleteFn: func(ctx context.Context, name string) error {
-			id, ok := extractIDFromSlug(name)
-			if !ok {
-				return fmt.Errorf("cannot determine collector ID from name %q: expected format \"<slug>-<id>\" or numeric ID", name)
+			collector, err := resolveCollector(ctx, client, name)
+			if err != nil {
+				return fmt.Errorf("cannot resolve collector %q for delete: %w", name, err)
 			}
-			return client.DeleteCollector(ctx, id)
+			return client.DeleteCollector(ctx, collector.ID)
 		},
-		Namespace:   namespace,
-		StripFields: []string{"id"},
-		Descriptor:  collectorDescriptorVar,
+		Namespace:  namespace,
+		Descriptor: collectorDescriptorVar,
 	}
 	return crud, namespace, nil
 }
@@ -1368,7 +1390,7 @@ func pipelineExample() json.RawMessage {
 			"name": "my-pipeline",
 		},
 		"spec": map[string]any{
-			"name":       "my-pipeline",
+			"name":       "my_pipeline",
 			"enabled":    true,
 			"configType": "CONFIG_TYPE_ALLOY",
 			"contents":   "logging { level = \"info\" }",
@@ -1400,6 +1422,7 @@ func collectorSchema() json.RawMessage {
 			"spec": map[string]any{
 				"type": "object",
 				"properties": map[string]any{
+					"id":                map[string]any{"type": "string"},
 					"name":              map[string]any{"type": "string"},
 					"collector_type":    map[string]any{"type": "string"},
 					"enabled":           map[string]any{"type": "boolean"},
@@ -1425,6 +1448,7 @@ func collectorExample() json.RawMessage {
 			"name": "my-collector",
 		},
 		"spec": map[string]any{
+			"id":             "my-collector-id",
 			"name":           "my-collector",
 			"collector_type": "alloy",
 			"enabled":        true,

--- a/internal/providers/fleet/provider_test.go
+++ b/internal/providers/fleet/provider_test.go
@@ -90,6 +90,25 @@ func TestCollectorToResource_RoundTrip(t *testing.T) {
 	assert.Equal(t, original.LocalAttributes, roundTripped.LocalAttributes)
 }
 
+func TestCollectorToResource_RoundTripStringID(t *testing.T) {
+	original := fleet.Collector{
+		ID:            "collector-prod-eu-a",
+		Name:          "my-collector",
+		CollectorType: "alloy",
+	}
+
+	res, err := fleet.CollectorToResource(original, "stack-123")
+	require.NoError(t, err)
+
+	spec, ok := res.Object.Object["spec"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, original.ID, spec["id"])
+
+	roundTripped, err := fleet.CollectorFromResource(res)
+	require.NoError(t, err)
+	assert.Equal(t, original.ID, roundTripped.ID)
+}
+
 // TestPipelineToResource_PreservesConfigType is a regression test for the OTel
 // pipeline bug: configType must survive the Pipeline -> Resource (pull/render) and
 // Resource -> Pipeline (manifest read/push) round-trips, and must appear as
@@ -171,7 +190,7 @@ func TestPipelineToResource_StripsID(t *testing.T) {
 	assert.Equal(t, "test-pipeline-99999", res.Object.GetName(), "metadata.name should be slug-id")
 }
 
-func TestCollectorToResource_StripsID(t *testing.T) {
+func TestCollectorToResource_RetainsID(t *testing.T) {
 	col := fleet.Collector{
 		ID:            "88888",
 		Name:          "test-collector",
@@ -183,7 +202,7 @@ func TestCollectorToResource_StripsID(t *testing.T) {
 
 	spec, ok := res.Object.Object["spec"].(map[string]any)
 	require.True(t, ok, "spec should be a map")
-	assert.NotContains(t, spec, "id", "ID should be stripped from spec")
+	assert.Equal(t, "88888", spec["id"], "collector ID should remain in spec")
 	assert.Equal(t, "test-collector-88888", res.Object.GetName(), "metadata.name should be slug-id")
 }
 

--- a/internal/providers/fleet/provider_test.go
+++ b/internal/providers/fleet/provider_test.go
@@ -441,7 +441,7 @@ func TestPipelineProtectionGuard(t *testing.T) {
 			}))
 			defer server.Close()
 
-			client := fleet.NewClient(context.Background(), server.URL, "inst", "token", true, nil)
+			client := fleet.NewClient(context.Background(), server.URL, nil)
 			pipeline, err := client.GetPipeline(context.Background(), "123")
 			require.NoError(t, err)
 			require.NotNil(t, pipeline)

--- a/internal/providers/fleet/types.go
+++ b/internal/providers/fleet/types.go
@@ -46,10 +46,14 @@ func (c Collector) GetResourceName() string {
 
 // SetResourceName restores the collector ID from a slug-id composite name.
 func (c *Collector) SetResourceName(name string) {
+	// Collector IDs are arbitrary strings. Preserve the canonical ID when the
+	// manifest includes spec.id. Older manifests encoded numeric IDs only in
+	// metadata.name, so keep that fallback for compatibility.
+	if c.ID != "" {
+		return
+	}
 	if id, ok := extractIDFromSlug(name); ok {
 		c.ID = id
-	} else {
-		c.ID = name
 	}
 }
 

--- a/internal/providers/fleet/types_identity_test.go
+++ b/internal/providers/fleet/types_identity_test.go
@@ -49,15 +49,31 @@ func TestCollector_ResourceIdentity(t *testing.T) {
 		t.Errorf("GetResourceName() (no name) = %q, want %q", got, "42")
 	}
 
-	// SetResourceName extracts the numeric ID from a slug-id composite.
-	c.SetResourceName("my-collector-2")
-	if c.ID != "2" {
-		t.Errorf("SetResourceName (slug-id): ID = %q, want %q", c.ID, "2")
+	// SetResourceName extracts the numeric ID from a legacy slug-id composite.
+	legacyComposite := &fleet.Collector{}
+	legacyComposite.SetResourceName("my-collector-2")
+	if legacyComposite.ID != "2" {
+		t.Errorf("SetResourceName (slug-id): ID = %q, want %q", legacyComposite.ID, "2")
 	}
 
 	// SetResourceName stores the value directly when it's a plain numeric ID.
-	c.SetResourceName("99")
-	if c.ID != "99" {
-		t.Errorf("SetResourceName (numeric): ID = %q, want %q", c.ID, "99")
+	legacyNumeric := &fleet.Collector{}
+	legacyNumeric.SetResourceName("99")
+	if legacyNumeric.ID != "99" {
+		t.Errorf("SetResourceName (numeric): ID = %q, want %q", legacyNumeric.ID, "99")
+	}
+
+	// SetResourceName preserves a canonical string ID from spec.id.
+	stringID := &fleet.Collector{ID: "collector-prod-eu-a"}
+	stringID.SetResourceName("my-collector-123")
+	if stringID.ID != "collector-prod-eu-a" {
+		t.Errorf("SetResourceName (canonical ID): ID = %q, want %q", stringID.ID, "collector-prod-eu-a")
+	}
+
+	// A legacy nonnumeric metadata name cannot recover a canonical ID.
+	legacyStringID := &fleet.Collector{}
+	legacyStringID.SetResourceName("my-collector")
+	if legacyStringID.ID != "" {
+		t.Errorf("SetResourceName (legacy string name): ID = %q, want empty", legacyStringID.ID)
 	}
 }

--- a/internal/providers/instrumentation/client_test.go
+++ b/internal/providers/instrumentation/client_test.go
@@ -18,7 +18,7 @@ import (
 
 // newTestClient creates an instrumentation Client pointed at the given test server URL.
 func newTestClient(serverURL string) *instrumentation.Client {
-	f := fleet.NewClient(context.Background(), serverURL, "inst-id", "api-token", true, nil)
+	f := fleet.NewClient(context.Background(), serverURL, nil)
 	return instrumentation.NewClient(f)
 }
 


### PR DESCRIPTION
## Why

Fleet Management was the only gcx product that needed a grafana.com Cloud Access Policy token. `internal/fleet/config.go` read `AgentManagementInstanceURL` and `AgentManagementInstanceID` from the grafana.com stack record, then called the Fleet Management API directly with Basic authentication.

That cost a user three things:

- A `gcx login` to the stack was not enough. A user also needed `gcx cloud login`, or a Cloud Access Policy token.
- gcx requested the `fleet-management:read` and `fleet-management:write` scopes for every user, whether or not they used Fleet.
- Every fleet command paid for a grafana.com stack lookup, even the commands that never read the stack record.

The `grafana-collector-app` plugin proxies the same API for its own user interface, and adds the credentials server-side. This pull request moves gcx onto that path, with no fallback.

**Outcome:** a Grafana stack login alone drives `gcx fleet` and `gcx instrumentation`.

## What changed

- `internal/fleet/client.go` carries no credentials. It takes an `*http.Client` built with `rest.HTTPClientFor` from the stack REST config.
- `internal/fleet/config.go` composes the prefix `/api/plugin-proxy/grafana-collector-app/fleet-management-api` and takes a `LoadGrafanaConfig` loader. `LoadClientWithStack` reads `cloud.StackInfo` through the bounded `grafanacom-api/instances/` proxy route. Each call performs one lookup, so a transient failure cannot affect a later call. `LoadClient` performs no stack lookup.
- `internal/fleet/preflight.go` owns collector app state and route-action checks. `cmd/gcx/setup` only renders the result.
- `internal/providers/fleet/client.go` returns the typed `fleet.HTTPError` from every method. Before this change `convertFleetHTTPErrors` never fired for pipeline or collector errors.
- `GetPipeline` and `GetCollector` test the body for `plugin route match not found` before they report a missing resource. Behind the proxy a 404 has two meanings.
- `cmd/gcx/fail` reports an absent plugin with the approved `Endpoint not available` summary. A 403 explains named read routes and wildcard admin routes.
- `internal/auth/gcom.go` and `internal/login/login.go` no longer name the Fleet scopes.
- `gcx setup status` reports the plugin state and both route actions. A missing or disabled plugin emits the complete status document and exits with code 1.

`providers.CloudRESTConfig`, `LoadCloudConfig`, and `cloud.GCOMClient` stay. k6, Synthetic Monitoring, the Faro sourcemap upload, Adaptive telemetry, `gcx cloud stacks`, and login validation still use them.

## Breaking change

A Cloud Access Policy token with `fleet-management` scopes no longer authenticates Fleet commands. Users need a Grafana stack login and the enabled collector app. Older stack tokens can require a new `gcx login` to obtain `grafana-api:write`.

Permission follows the matched plugin route, not the command intent. Named routes need `grafana-collector-app:read`. Wildcard routes need the Admin role or `grafana-collector-app:admin`. Some read-only commands, including `tenant get-limits` and `RunK8sMonitoring`, use wildcard routes.

## Compliance

- **CONSTITUTION** — the invariant named Fleet as an external-domain API that must use `httputils.NewDefaultClient`. Fleet now calls `cfg.Host`, so the rule inverts. This pull request amends the invariant and adds a Fleet paragraph next to the synth carve-out. **This is an invariant change and needs a reviewer's explicit approval.**
- **ADR-023** records the decision, the measurements, the route-based permission model, and the rejected fallback option.
- **DESIGN** — no new command or grammar change. The `gcx setup status` document gains one product row. Error summaries use the closed vocabulary.
- **ARCHITECTURE** — Fleet-specific preflight logic lives in `internal/fleet`. The setup command owns presentation only.

## Verification

`GCX_AGENT_MODE=false mise run all` passes: lint reports 0 issues, the full test suite passes, and the build, reference checks, skill checks, and documentation build succeed.

Focused tests cover:

- Retry after a transient stack lookup failure.
- The 1 MiB response limit.
- Missing, disabled, and unknown plugin states.
- All route-action combinations.
- The missing-plugin exit code and single-document output contract.
- The approved error summary and route-based 403 suggestions.

Live verification against a Grafana Cloud stack with plugin version 4.27.0 before the review fixes:

- `gcx fleet pipelines list`, `collectors list`, `tenant get-limits`, `gcx instrumentation status`, and `gcx resources get pipelines` returned data.
- A create, get, update, and delete round trip through `gcx fleet pipelines` succeeded.
- `gcx fleet tenant get-limits --context <stack-only-context>` worked without a cloud entry.

## What a reviewer must know

1. Route permissions are part of `plugin.json`. They do not follow read-only or write command intent.
2. `plugin.json` is not a stable contract. A plugin release can change the route set. `gcx setup status` reports effective actions, and the real RPC remains authoritative.
3. Fleet Management is a Grafana Cloud product. A self-hosted Grafana never had it, and still does not.
4. A stack token that predates `grafana-api:write` fails with HTTP 403 because Fleet RPCs use POST. Run `gcx login` again to replace that token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
