### PR TITLE
docs(changelog): document incident severity migration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Unreleased
 
+**Breaking changes**
+
+- IRM incident reads no longer include `spec.severityID`. The field remains valid for writes. Update scripts that read `.spec.severityID` to read `.spec.severity` instead. The severity label is portable across Grafana stacks, but the severity ID is specific to one organization (#1191).
+
 **New Features**
 
 - Added `--fix-plan` to `gcx instrumentation check`, with two explicit modes: `--fix-plan=local` produces a deterministic aggregation of the explanation docs' "How to fix" sections (offline, no billing, works on OSS/Enterprise), and `--fix-plan=assistant` synthesizes a prioritized plan with Grafana Assistant (BILLABLE, requires a Grafana Cloud context — see the Assistant pricing docs). The two modes are disjoint: assistant mode returns a clear error when preconditions aren't met rather than silently falling back to local. `--fix-plan` alone is rejected; users must specify a mode.


### PR DESCRIPTION
## Summary

Add the breaking change from #1191 to the Unreleased changelog.

Tell users to replace reads of `spec.severityID` with `spec.severity`. Explain that the label is portable across Grafana stacks.

## Compliance

- CONSTITUTION: Pass. This change only updates release guidance.
- VISION: Pass. This guidance supports an existing gcx capability.
- DESIGN: Pass. The changelog gives direct migration guidance for a breaking output change.
- ARCHITECTURE: Pass. This change does not modify code or structure.

## Test plan

- [x] `GCX_AGENT_MODE=false mise run all`
- [x] Documentation maintenance check
- [x] `git diff --check`