### PR TITLE
fix(config)!: fail closed when the OS keychain is unavailable

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -166,9 +166,10 @@ precedence but remain ephemeral.
 are redacted in `gcx config view`. Undeclared keys and unknown providers are
 redacted by default. Keychain references are bound to their canonical source
 file, exact owner/field, and destination so another layer cannot redirect or
-overwrite a stored credential. A missing native keychain may permit a warned
-plaintext fallback for a brand-new credential; a reachable but locked or
-interaction-disabled keychain fails closed with `Keychain locked`.
+overwrite a stored credential. An unavailable native keychain fails closed,
+same as a reachable but locked or interaction-disabled keychain (`Keychain
+locked`); the only plaintext fallback path is the explicit `GCX_KEYCHAIN=off`
+opt-out.
 
 **Deep-dive:** [config-system.md](docs/architecture/config-system.md).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 **Breaking changes**
 
+- An unavailable OS keychain no longer falls back to a plaintext write. A first login (or any credential-consuming command) on a machine with no working OS credential store now fails instead of silently storing the token in plaintext. Set `GCX_KEYCHAIN=off` to keep the previous plaintext-storage behavior as an explicit opt-out.
 - Fleet Management and Instrumentation now use the `grafana-collector-app` plugin proxy instead of direct Cloud Access Policy authentication. A Cloud Access Policy token with `fleet-management` scopes is no longer sufficient. Use a Grafana stack login and ensure that the plugin is enabled. Older stack tokens can require a new `gcx login` to obtain `grafana-api:write`. Named plugin routes need `grafana-collector-app:read`. Wildcard routes need `grafana-collector-app:admin`, including some read-only commands. The default `gcx cloud login --scope` list no longer includes `fleet-management:read` or `fleet-management:write`.
 - Fleet collector resource manifests now include `spec.id`. Collector creation requires this field. Existing numeric-ID manifests continue to work for update and delete. Add `spec.id` before you reuse an older manifest to create a collector.
 - `gcx setup status` now adds `fleet-management` as the first item in `products`. Select entries by `.product` instead of their array position. The command returns exit code 1 when the plugin is missing or disabled. It returns exit code 4 when the Instrumentation check fails. In both cases, it emits the status document before it exits.

--- a/cmd/gcx/cloud/command_test.go
+++ b/cmd/gcx/cloud/command_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/grafana/gcx/internal/auth"
 	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/credentials"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -18,6 +19,20 @@ type gcomOAuthFlowFunc func(context.Context) (*auth.GCOMResult, error)
 
 func (f gcomOAuthFlowFunc) Run(ctx context.Context) (*auth.GCOMResult, error) {
 	return f(ctx)
+}
+
+func TestMain(m *testing.M) {
+	previous, wasSet := os.LookupEnv("GCX_KEYCHAIN")
+	if err := os.Setenv("GCX_KEYCHAIN", "off"); err != nil {
+		panic(err)
+	}
+	code := m.Run()
+	if wasSet {
+		_ = os.Setenv("GCX_KEYCHAIN", previous)
+	} else {
+		_ = os.Unsetenv("GCX_KEYCHAIN")
+	}
+	os.Exit(code)
 }
 
 // `gcx cloud login` and the `gcx login` cloud followup must request the same
@@ -465,6 +480,25 @@ func TestCloudTokenLoginCreatesMissingExplicitConfig(t *testing.T) {
 	assert.Contains(t, string(raw), "new-cap")
 	assert.Contains(t, string(raw), "api-url: https://grafana.com")
 	assert.Contains(t, string(raw), "oauth-url: https://grafana.com")
+}
+
+// A cloud token is a fresh credential, so an unavailable credential store
+// must fail the actual command before plaintext reaches its selected config.
+func TestCloudTokenLoginFailsClosedWhenKeychainUnavailable(t *testing.T) {
+	t.Setenv("GCX_KEYCHAIN", "")
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte("version: 1\ncontexts:\n  default: {}\ncurrent-context: default\n"), 0o600))
+
+	cmd := loginCmd()
+	cmd.SilenceErrors = true
+	cmd.SilenceUsage = true
+	cmd.SetArgs([]string{"--config", path, "--cloud-token", "must-not-be-plaintext"})
+	err := cmd.ExecuteContext(t.Context())
+	require.ErrorIs(t, err, credentials.ErrUnavailable)
+
+	raw, readErr := os.ReadFile(path)
+	require.NoError(t, readErr)
+	assert.NotContains(t, string(raw), "must-not-be-plaintext")
 }
 
 func TestCloudLoginRejectsUnsupportedConfigBeforeStartingOAuth(t *testing.T) {

--- a/cmd/gcx/config/command_test.go
+++ b/cmd/gcx/config/command_test.go
@@ -748,6 +748,7 @@ current-context: default
 	testutils.CommandTestCase{
 		Cmd:     config.Command(),
 		Command: []string{"set", "--config", configFile, "cloud.shared.token", "new-cap"},
+		Env:     map[string]string{"GCX_KEYCHAIN": "off"},
 		Assertions: []testutils.CommandAssertion{
 			testutils.CommandSuccess(),
 		},
@@ -763,6 +764,7 @@ current-context: default
 	testutils.CommandTestCase{
 		Cmd:     config.Command(),
 		Command: []string{"set", "--config", configFile, "cloud.shared.oauth-token", "new-oauth"},
+		Env:     map[string]string{"GCX_KEYCHAIN": "off"},
 		Assertions: []testutils.CommandAssertion{
 			testutils.CommandSuccess(),
 		},
@@ -781,6 +783,7 @@ current-context: default
 		testutils.CommandTestCase{
 			Cmd:     config.Command(),
 			Command: command,
+			Env:     map[string]string{"GCX_KEYCHAIN": "off"},
 			Assertions: []testutils.CommandAssertion{
 				testutils.CommandSuccess(),
 			},

--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -212,22 +212,35 @@ func convertAuthErrors(err error) (*gcxerrors.DetailedError, bool) {
 	return nil, false
 }
 
-// convertCredentialsErrors converts credentials.ErrLocked into an actionable
-// message. A locked keychain proves that a real secret backend exists, so gcx
-// keeps the error fatal instead of a fallback to a plaintext write. The
-// suggestions depend on the operating system and its session model.
+// convertCredentialsErrors converts unavailable and locked keychain errors
+// into actionable messages. Both conditions remain fatal so gcx never falls
+// back to a plaintext write unless the user explicitly selects that policy.
 func convertCredentialsErrors(err error) (*gcxerrors.DetailedError, bool) {
-	if !errors.Is(err, credentials.ErrLocked) {
-		return nil, false
+	if errors.Is(err, credentials.ErrLocked) {
+		return &gcxerrors.DetailedError{
+			Summary:     "Keychain locked",
+			Details:     "The OS keychain is reachable, but it is locked or cannot be unlocked in this session. gcx does not fall back to a plaintext credential.",
+			Parent:      err,
+			Suggestions: keychainLockedSuggestions(runtime.GOOS),
+			DocsLink:    docs.Keychain,
+		}, true
 	}
 
-	return &gcxerrors.DetailedError{
-		Summary:     "Keychain locked",
-		Details:     "The OS keychain is reachable, but it is locked or cannot be unlocked in this session. gcx does not fall back to a plaintext credential.",
-		Parent:      err,
-		Suggestions: keychainLockedSuggestions(runtime.GOOS),
-		DocsLink:    docs.Keychain,
-	}, true
+	if errors.Is(err, credentials.ErrUnavailable) && !errors.Is(err, credentials.ErrDisabled) {
+		return &gcxerrors.DetailedError{
+			Summary: "Keychain unavailable",
+			Details: "The OS keychain is unavailable. gcx did not fall back to plaintext credential storage.",
+			Parent:  err,
+			Suggestions: []string{
+				"Restore access to the OS keychain and retry",
+				"To allow plaintext storage, explicitly set GCX_KEYCHAIN=off",
+				"Plaintext credentials are stored on disk and are less secure than OS keychain storage",
+			},
+			DocsLink: docs.Keychain,
+		}, true
+	}
+
+	return nil, false
 }
 
 // keychainLockedSuggestions returns the remedies for a locked keychain on the

--- a/cmd/gcx/fail/convert_internal_test.go
+++ b/cmd/gcx/fail/convert_internal_test.go
@@ -9,20 +9,20 @@ import (
 )
 
 // TestKeychainLockedSuggestions checks the remedies on the platforms where gcx
-// can classify a locked native keychain. Secret Service commands vary by
-// session, while macOS has a stable command with security-session scope.
+// can classify a locked native keychain, including safe session diagnostics.
 func TestKeychainLockedSuggestions(t *testing.T) {
 	tests := map[string]struct {
-		goos          string
-		wantLockState bool
-		wantSecurity  bool
+		goos                string
+		wantSessionGuidance bool
+		wantLockStateCheck  bool
+		wantUnlockCommand   bool
 	}{
-		"linux":     {goos: "linux", wantLockState: true},
-		"freebsd":   {goos: "freebsd", wantLockState: true},
-		"netbsd":    {goos: "netbsd", wantLockState: true},
-		"openbsd":   {goos: "openbsd", wantLockState: true},
-		"dragonfly": {goos: "dragonfly", wantLockState: true},
-		"darwin":    {goos: "darwin", wantSecurity: true},
+		"linux":     {goos: "linux", wantSessionGuidance: true, wantLockStateCheck: true},
+		"freebsd":   {goos: "freebsd", wantSessionGuidance: true, wantLockStateCheck: true},
+		"netbsd":    {goos: "netbsd", wantSessionGuidance: true, wantLockStateCheck: true},
+		"openbsd":   {goos: "openbsd", wantSessionGuidance: true, wantLockStateCheck: true},
+		"dragonfly": {goos: "dragonfly", wantSessionGuidance: true, wantLockStateCheck: true},
+		"darwin":    {goos: "darwin", wantSessionGuidance: true, wantUnlockCommand: true},
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
@@ -33,8 +33,9 @@ func TestKeychainLockedSuggestions(t *testing.T) {
 			assert.NotContains(t, joined, "gnome-keyring-daemon")
 			assert.NotContains(t, joined, "systemd-ask-password")
 			assert.Contains(t, joined, "GRAFANA_TOKEN")
-			assert.Equal(t, test.wantLockState, strings.Contains(joined, "busctl"))
-			assert.Equal(t, test.wantSecurity, strings.Contains(joined, "security unlock-keychain"))
+			assert.Equal(t, test.wantSessionGuidance, strings.Contains(joined, "session"))
+			assert.Equal(t, test.wantLockStateCheck, strings.Contains(joined, "busctl"))
+			assert.Equal(t, test.wantUnlockCommand, strings.Contains(joined, "security unlock-keychain"))
 		})
 	}
 }

--- a/cmd/gcx/fail/convert_test.go
+++ b/cmd/gcx/fail/convert_test.go
@@ -1333,9 +1333,10 @@ func TestErrorToDetailedError_KeychainLocked(t *testing.T) {
 		"failed to unlock correct collection '/org/freedesktop/secrets/collection/login'")
 
 	tests := []struct {
-		name       string
-		err        error
-		wantLocked bool
+		name        string
+		err         error
+		wantLocked  bool
+		wantSummary string
 	}{
 		{
 			name:       "bare ErrLocked",
@@ -1350,9 +1351,19 @@ func TestErrorToDetailedError_KeychainLocked(t *testing.T) {
 			wantLocked: true,
 		},
 		{
-			name:       "ErrUnavailable is an actionable unavailable keychain",
-			err:        fmt.Errorf("writing config: %w", credentials.ErrUnavailable),
-			wantLocked: false,
+			name:        "ErrUnavailable is an actionable unavailable keychain",
+			err:         fmt.Errorf("writing config: %w", credentials.ErrUnavailable),
+			wantSummary: "Keychain unavailable",
+		},
+		{
+			// ErrDisabled wraps ErrUnavailable, so it must be checked ahead of
+			// ErrUnavailable or it silently gets the "Keychain unavailable"
+			// envelope that convert.go deliberately refuses it. A deliberate
+			// GCX_KEYCHAIN=off opt-out still falls back to plaintext, so it
+			// must fall through to the generic error envelope instead.
+			name:        "ErrDisabled must not shadow into the unavailable-keychain envelope",
+			err:         fmt.Errorf("writing config: %w", credentials.ErrDisabled),
+			wantSummary: "Writing config",
 		},
 		{
 			name:       "ErrNotFound is not a locked keychain",
@@ -1366,8 +1377,22 @@ func TestErrorToDetailedError_KeychainLocked(t *testing.T) {
 			got := fail.ErrorToDetailedError(tt.err)
 			require.NotNil(t, got)
 
+			// ErrDisabled must be tested for explicitly, and ahead of
+			// ErrUnavailable: ErrDisabled wraps ErrUnavailable, so a check
+			// that only tests errors.Is(err, ErrUnavailable) would also match
+			// ErrDisabled and assert the wrong envelope.
+			if errors.Is(tt.err, credentials.ErrDisabled) {
+				require.NotEmpty(t, tt.wantSummary, "test row must pin an exact summary")
+				assert.Equal(t, tt.wantSummary, got.Summary)
+				assert.NotEqual(t, "Keychain unavailable", got.Summary,
+					"a deliberate GCX_KEYCHAIN=off opt-out must get the generic error envelope, not the unavailable-keychain one")
+				require.ErrorIs(t, got.Parent, credentials.ErrDisabled)
+				return
+			}
+
 			if errors.Is(tt.err, credentials.ErrUnavailable) {
-				assert.Equal(t, "Keychain unavailable", got.Summary)
+				require.NotEmpty(t, tt.wantSummary, "test row must pin an exact summary")
+				assert.Equal(t, tt.wantSummary, got.Summary)
 				assert.Equal(t,
 					"The OS keychain is unavailable. gcx did not fall back to plaintext credential storage.",
 					got.Details)

--- a/cmd/gcx/fail/convert_test.go
+++ b/cmd/gcx/fail/convert_test.go
@@ -1350,7 +1350,7 @@ func TestErrorToDetailedError_KeychainLocked(t *testing.T) {
 			wantLocked: true,
 		},
 		{
-			name:       "ErrUnavailable is not a locked keychain",
+			name:       "ErrUnavailable is an actionable unavailable keychain",
 			err:        fmt.Errorf("writing config: %w", credentials.ErrUnavailable),
 			wantLocked: false,
 		},
@@ -1366,6 +1366,18 @@ func TestErrorToDetailedError_KeychainLocked(t *testing.T) {
 			got := fail.ErrorToDetailedError(tt.err)
 			require.NotNil(t, got)
 
+			if errors.Is(tt.err, credentials.ErrUnavailable) {
+				assert.Equal(t, "Keychain unavailable", got.Summary)
+				assert.Equal(t,
+					"The OS keychain is unavailable. gcx did not fall back to plaintext credential storage.",
+					got.Details)
+				require.ErrorIs(t, got.Parent, credentials.ErrUnavailable)
+				assert.NotErrorIs(t, got.Parent, credentials.ErrLocked)
+				assert.Contains(t, strings.Join(got.Suggestions, "\n"), "GCX_KEYCHAIN=off")
+				assert.Contains(t, strings.Join(got.Suggestions, "\n"), "Plaintext credentials are stored on disk")
+				return
+			}
+
 			if !tt.wantLocked {
 				assert.NotEqual(t, "Keychain locked", got.Summary)
 				return
@@ -1380,6 +1392,7 @@ func TestErrorToDetailedError_KeychainLocked(t *testing.T) {
 			assert.Equal(t, docs.Keychain, got.DocsLink)
 			// convert_internal_test.go pins the per-platform suggestions.
 			assert.NotEmpty(t, got.Suggestions)
+			assert.NotContains(t, strings.Join(got.Suggestions, "\n"), "GCX_KEYCHAIN=off")
 		})
 	}
 }

--- a/cmd/gcx/login/command_test.go
+++ b/cmd/gcx/login/command_test.go
@@ -367,6 +367,7 @@ func TestUseExistingCloudEntryEndpointChangeFailsClosed(t *testing.T) {
 
 func TestServerChangeRejectsStoredGrafanaTokenBeforeNetwork(t *testing.T) {
 	t.Setenv("GCX_AGENT_MODE", "false")
+	t.Setenv("GCX_KEYCHAIN", "off")
 	t.Setenv("GRAFANA_TOKEN", " \t ")
 	agent.ResetForTesting()
 	t.Cleanup(agent.ResetForTesting)
@@ -407,6 +408,7 @@ func TestServerChangeRejectsStoredGrafanaTokenBeforeNetwork(t *testing.T) {
 }
 
 func TestProxyOrTLSChangeRejectsStoredGrafanaTokenBeforeNetwork(t *testing.T) {
+	t.Setenv("GCX_KEYCHAIN", "off")
 	tests := []struct {
 		name      string
 		configure func(*testing.T, *config.GrafanaConfig)
@@ -565,6 +567,7 @@ func TestRuntimeOnlyDestinationRejectsFreshTokenBeforeNonDurablePersistence(t *t
 
 func TestRuntimeOnlyTLSRecoveryCommandsInitializeFreshExplicitConfigAndUnblockLogin(t *testing.T) {
 	disableAgentMode(t)
+	t.Setenv("GCX_KEYCHAIN", "off")
 	for _, key := range []string{
 		"GCX_CONFIG",
 		"GRAFANA_SERVER",
@@ -735,6 +738,7 @@ func TestRuntimeOnlyDestinationRecoveryHandlesDottedNamesWithoutInvalidDotPaths(
 }
 
 func TestExistingGrafanaTokenIsOfferedOnlyForMatchingCompleteBinding(t *testing.T) {
+	t.Setenv("GCX_KEYCHAIN", "off")
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	seed := config.Config{}
 	seed.SetStack("default", config.StackConfig{Grafana: &config.GrafanaConfig{
@@ -811,6 +815,7 @@ func TestWhitespaceEnvironmentTokensAreNotExplicitOrSelected(t *testing.T) {
 }
 
 func TestLoadLoginSourceContextAppliesEnvToPositionalTarget(t *testing.T) {
+	t.Setenv("GCX_KEYCHAIN", "off")
 	t.Setenv("GRAFANA_TOKEN", "target-env-token")
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	seed := config.Config{}
@@ -937,6 +942,7 @@ func TestLoginNewContextWithoutServerReportsNoTarget(t *testing.T) {
 
 func TestLoginRejectedStoredTokenReportsRequestedTarget(t *testing.T) {
 	t.Setenv("GCX_AGENT_MODE", "false")
+	t.Setenv("GCX_KEYCHAIN", "off")
 	unsetEnvForTest(t, "GRAFANA_SERVER")
 	unsetEnvForTest(t, "GRAFANA_TOKEN")
 	unsetEnvForTest(t, "GRAFANA_CLOUD_API_URL")
@@ -1212,6 +1218,7 @@ func TestLoginEnvironmentServerChangeRequiresPreflightConfirmation(t *testing.T)
 }
 
 func TestSchemelessServerReauthMatchesStoredHTTPSDestination(t *testing.T) {
+	t.Setenv("GCX_KEYCHAIN", "off")
 	server, caFile := newLoginTLSServer(t)
 	bareServer := strings.TrimPrefix(server.URL, "https://")
 
@@ -1509,6 +1516,7 @@ contexts:
 
 func TestLoginCopyOnWritesCloudEntrySharedByAnotherLayer(t *testing.T) {
 	t.Setenv("GCX_AGENT_MODE", "false")
+	t.Setenv("GCX_KEYCHAIN", "off")
 	t.Setenv("HOME", t.TempDir())
 	userDir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", userDir)

--- a/cmd/gcx/main_test.go
+++ b/cmd/gcx/main_test.go
@@ -201,9 +201,8 @@ const (
 	configSetFallbackProcessHelper = "GCX_CONFIG_SET_FALLBACK_PROCESS_HELPER"
 )
 
-func TestConfigSetPlaintextFallbackWarningProcess(t *testing.T) {
-	const token = "synthetic-plaintext-fallback-token"
-	const warning = "Warning: credential store could not securely store the credential; credentials remain in plaintext on disk; verify your OS credential store (Keychain, Credential Manager, or Secret Service) is available and working to enable encrypted credential storage"
+func TestConfigSetUnavailableKeychainFailsClosedProcess(t *testing.T) {
+	const token = "synthetic-unavailable-keychain-token"
 
 	for _, agentMode := range []string{"false", "true"} {
 		t.Run("agent-mode="+agentMode, func(t *testing.T) {
@@ -251,24 +250,27 @@ current-context: smoke
 				"GRAFANA_STACK_ID=",
 			)
 
-			if err := cmd.Run(); err != nil {
-				t.Fatalf("config set failed: %v; stdout=%q stderr=%q", err, stdout.String(), stderr.String())
+			if err := cmd.Run(); err == nil {
+				t.Fatalf("config set unexpectedly succeeded; stdout=%q stderr=%q", stdout.String(), stderr.String())
 			}
-			// The agent output contract makes config set emit one JSON
-			// mutation document; the human default stays silent.
+			// The typed error envelope must be emitted in agent mode; the human
+			// diagnostic belongs on stderr without corrupting stdout.
 			if agentMode == "true" {
 				var doc map[string]any
 				if err := json.Unmarshal(stdout.Bytes(), &doc); err != nil {
-					t.Fatalf("agent stdout is not one JSON document: %v; stdout=%q", err, stdout.String())
+					t.Fatalf("agent stdout is not one JSON error document: %v; stdout=%q", err, stdout.String())
 				}
-				if doc["type"] != "gcx.config.mutation" {
-					t.Fatalf("agent stdout document type = %v, want gcx.config.mutation", doc["type"])
+				if doc["type"] != "gcx.error" {
+					t.Fatalf("agent stdout document type = %v, want gcx.error", doc["type"])
+				}
+				if stderr.Len() != 0 {
+					t.Fatalf("agent error wrote unexpected stderr: %q", stderr.String())
 				}
 			} else if stdout.Len() != 0 {
 				t.Fatalf("config set wrote unexpected stdout: %q", stdout.String())
 			}
-			if got := bytes.Count(stderr.Bytes(), []byte(warning)); got != 1 {
-				t.Fatalf("plaintext fallback warning count = %d, want 1; stderr=%q", got, stderr.String())
+			if agentMode == "false" && !bytes.Contains(stderr.Bytes(), []byte("Keychain unavailable")) {
+				t.Fatalf("human output did not name the unavailable keychain: %q", stderr.String())
 			}
 			if bytes.Contains(stdout.Bytes(), []byte(token)) || bytes.Contains(stderr.Bytes(), []byte(token)) {
 				t.Fatalf("plaintext token appeared in command output; stdout=%q stderr=%q", stdout.String(), stderr.String())
@@ -278,8 +280,8 @@ current-context: smoke
 			if err != nil {
 				t.Fatal(err)
 			}
-			if !bytes.Contains(raw, []byte(token)) || bytes.Contains(raw, []byte("keychain:gcx:v2:")) {
-				t.Fatalf("expected deliberate plaintext fallback without a sentinel: %q", raw)
+			if bytes.Contains(raw, []byte(token)) || bytes.Contains(raw, []byte("keychain:gcx:v2:")) {
+				t.Fatalf("unavailable keychain wrote a credential unexpectedly: %q", raw)
 			}
 			info, err := os.Stat(configPath)
 			if err != nil {

--- a/cmd/gcx/root/appo11y_config_routing_test.go
+++ b/cmd/gcx/root/appo11y_config_routing_test.go
@@ -363,6 +363,7 @@ func TestAppO11y_OverridesGetEnvelopeNamespace(t *testing.T) {
 // datasource wins and its UID is persisted — into the explicitly selected
 // config file, never the default one.
 func TestAppO11y_DatasourceDiscoverySaveBack(t *testing.T) {
+	t.Setenv("GCX_KEYCHAIN", "off")
 	home := testutils.SandboxConfigEnv(t)
 	// Two prometheus datasources force the canonical stack-slug match (a
 	// single match would resolve without arming persistence).

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -298,9 +298,10 @@ Two loading modes:
 Keychain references are source-bound: the canonical config path, exact
 owner/field, and normalized destination must match before a secret is resolved.
 Write-back loads only its raw target file, so environment overrides and values
-from other layers are never flattened into that file. A missing native keychain
-may permit a warned plaintext fallback for a brand-new credential, while a
-reachable but locked or interaction-disabled keychain fails closed.
+from other layers are never flattened into that file. An unavailable native
+keychain fails closed, same as a reachable but locked or interaction-disabled
+keychain; the only plaintext fallback path is the explicit `GCX_KEYCHAIN=off`
+opt-out.
 
 ### Namespace Semantics
 

--- a/docs/architecture/config-system.md
+++ b/docs/architecture/config-system.md
@@ -262,12 +262,14 @@ Loading steps (in `Load`):
    file is rewritten with
    `keychain:gcx:v2:<binding-digest>:<random-generation>`. The binding covers
    the canonical source, exact owner kind/name, exact field, and normalized
-   destination. An incomplete binding or unavailable keychain leaves the value
-   in plaintext with a warning. A locked keychain stops the migration write with
-   the same warning, but it never authorizes a plaintext fallback elsewhere: an
-   explicit write, such as `gcx login` or `gcx config set`, fails on a locked
-   backend. The user must unlock the keychain, or must run gcx from a desktop
-   session that can answer the unlock prompt.
+   destination. An incomplete binding leaves the value in plaintext with a
+   warning. An unavailable or locked keychain stops the migration write with the
+   same warning, but neither authorizes a plaintext fallback elsewhere: an
+   explicit write, such as `gcx login` or `gcx config set`, fails on an
+   unavailable or locked backend. The user must restore access to the
+   keychain, unlock it, or run gcx from a desktop session that can answer the
+   unlock prompt. Setting `GCX_KEYCHAIN=off` remains the one condition that
+   still authorizes a plaintext write.
 9. Apply each `Override` function in order, then lazily resolve a context selected
    by an override
 10. On `ValidationError`, annotate the error with YAML source information

--- a/docs/design/errors.md
+++ b/docs/design/errors.md
@@ -164,6 +164,7 @@ Adding a new summary requires a PR amending this list.
 | `Invalid configuration` | Bad config file, unresolvable context |
 | `Authentication failed` | Token expired or missing |
 | `Keychain locked` | The OS keychain answers, but it is locked or the current session cannot unlock it, so gcx cannot store or use the credential |
+| `Keychain unavailable` | The OS keychain cannot be reached, so gcx cannot store or use the credential without an explicit plaintext-storage opt-out |
 | `Authorization failed` | Permission denied (403) |
 | `Resource not found` | 404 or client-side not-found detection |
 | `Resource conflict` | Optimistic lock / RMW conflict, or an API-reported conflict whose exact cause is not machine-discriminable (e.g. GCOM stack 409s) |

--- a/docs/reference/configuration/keychain.md
+++ b/docs/reference/configuration/keychain.md
@@ -24,7 +24,8 @@ gcx does not use plaintext fallback for these conditions:
 
 - An unavailable credential store.
 - A locked credential store.
-- A replacement or deletion of an existing credential.
+- A deletion of an existing credential.
+- A replacement of an existing credential, unless you have set `GCX_KEYCHAIN=off`.
 - A missing or rejected credential reference.
 - A value that is too large for the credential store.
 - An unknown credential store error.

--- a/docs/reference/configuration/keychain.md
+++ b/docs/reference/configuration/keychain.md
@@ -16,19 +16,18 @@ copied file separately.
 
 ## Plaintext fallback
 
-gcx can keep a new credential in a mode-`0600` configuration file when no
-credential store is available. gcx writes a warning when it does this.
+gcx keeps a new credential in a mode-`0600` configuration file only when you
+have set `GCX_KEYCHAIN=off`. gcx writes a warning when it does this. See
+[Disable the credential store](#disable-the-credential-store).
 
 gcx does not use plaintext fallback for these conditions:
 
+- An unavailable credential store.
 - A locked credential store.
 - A replacement or deletion of an existing credential.
 - A missing or rejected credential reference.
 - A value that is too large for the credential store.
 - An unknown credential store error.
-
-gcx uses plaintext fallback for a replacement when you disable the credential
-store. See [Disable the credential store](#disable-the-credential-store).
 
 ## Disable the credential store
 

--- a/docs/sources/keychain.md
+++ b/docs/sources/keychain.md
@@ -28,19 +28,18 @@ copied file separately.
 
 ## Plaintext fallback
 
-gcx can keep a new credential in a mode-`0600` configuration file when no
-credential store is available. gcx writes a warning when it does this.
+gcx keeps a new credential in a mode-`0600` configuration file only when you
+have set `GCX_KEYCHAIN=off`. gcx writes a warning when it does this. See
+[Disable the credential store](#disable-the-credential-store).
 
 gcx does not use plaintext fallback for these conditions:
 
+- An unavailable credential store.
 - A locked credential store.
 - A replacement or deletion of an existing credential.
 - A missing or rejected credential reference.
 - A value that is too large for the credential store.
 - An unknown credential store error.
-
-gcx uses plaintext fallback for a replacement when you disable the credential
-store. See [Disable the credential store](#disable-the-credential-store).
 
 ## Disable the credential store
 

--- a/docs/sources/keychain.md
+++ b/docs/sources/keychain.md
@@ -36,7 +36,8 @@ gcx does not use plaintext fallback for these conditions:
 
 - An unavailable credential store.
 - A locked credential store.
-- A replacement or deletion of an existing credential.
+- A deletion of an existing credential.
+- A replacement of an existing credential, unless you have set `GCX_KEYCHAIN=off`.
 - A missing or rejected credential reference.
 - A value that is too large for the credential store.
 - An unknown credential store error.

--- a/internal/config/cloud_login_test.go
+++ b/internal/config/cloud_login_test.go
@@ -17,9 +17,10 @@ import (
 
 func TestLoginPersistsCredentialByKeychainPolicy(t *testing.T) {
 	tests := []struct {
-		name      string
-		storeErr  error
-		wantStore bool
+		name          string
+		storeErr      error
+		wantStore     bool
+		wantPlaintext bool
 	}{
 		{
 			name:      "default stores the token in the keychain",
@@ -32,6 +33,11 @@ func TestLoginPersistsCredentialByKeychainPolicy(t *testing.T) {
 		{
 			name:     "default fails closed when the keychain is locked",
 			storeErr: credentials.ErrLocked,
+		},
+		{
+			name:          "disabled falls back to plaintext",
+			storeErr:      credentials.ErrDisabled,
+			wantPlaintext: true,
 		},
 	}
 
@@ -81,6 +87,16 @@ current-context: default
 				assert.NotContains(t, string(raw), "new-service-token")
 				assert.True(t, store.containsValue("new-service-token"), "the fake credential store must hold the persisted secret")
 				assert.Positive(t, opened, "enabled storage must open the configured store")
+				return
+			}
+			if test.wantPlaintext {
+				require.NoError(t, err)
+				info, statErr := os.Stat(path)
+				require.NoError(t, statErr)
+				assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+				assert.Contains(t, string(raw), "token: new-service-token")
+				assert.NotContains(t, string(raw), "token: keychain:gcx:")
+				assert.Positive(t, opened, "a deliberate opt-out must still be opened and consulted before falling back to plaintext")
 				return
 			}
 

--- a/internal/config/cloud_login_test.go
+++ b/internal/config/cloud_login_test.go
@@ -15,6 +15,82 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestLoginPersistsCredentialByKeychainPolicy(t *testing.T) {
+	tests := []struct {
+		name      string
+		storeErr  error
+		wantStore bool
+	}{
+		{
+			name:      "default stores the token in the keychain",
+			wantStore: true,
+		},
+		{
+			name:     "default fails closed when the keychain is unavailable",
+			storeErr: credentials.ErrUnavailable,
+		},
+		{
+			name:     "default fails closed when the keychain is locked",
+			storeErr: credentials.ErrLocked,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			store := newFakeStore()
+			store.setErr = test.storeErr
+			var opened int
+			restore := config.SetKeychainStoreFnForTest(func() credentials.Store {
+				opened++
+				return store
+			})
+			t.Cleanup(restore)
+
+			path := filepath.Join(t.TempDir(), "config.yaml")
+			require.NoError(t, os.WriteFile(path, []byte(`version: 1
+stacks:
+  default:
+    grafana:
+      server: https://grafana.example.invalid
+contexts:
+  default:
+    stack: default
+current-context: default
+`), 0o600))
+
+			_, err := login.Run(t.Context(), &login.Options{
+				Inputs: login.Inputs{
+					Server:       "https://grafana.example.invalid",
+					ContextName:  "default",
+					Target:       login.TargetOnPrem,
+					GrafanaToken: "new-service-token",
+				},
+				Hooks: login.Hooks{
+					ConfigSource: config.ExplicitConfigFile(path),
+					ValidateFn: func(context.Context, login.Options, config.NamespacedRESTConfig) (string, error) {
+						return "12.0.0", nil
+					},
+				},
+			})
+
+			raw, readErr := os.ReadFile(path)
+			require.NoError(t, readErr)
+			if test.wantStore {
+				require.NoError(t, err)
+				assert.Contains(t, string(raw), "token: keychain:gcx:v2:")
+				assert.NotContains(t, string(raw), "new-service-token")
+				assert.True(t, store.containsValue("new-service-token"), "the fake credential store must hold the persisted secret")
+				assert.Positive(t, opened, "enabled storage must open the configured store")
+				return
+			}
+
+			require.ErrorIs(t, err, test.storeErr)
+			assert.NotContains(t, string(raw), "new-service-token")
+			assert.Positive(t, opened, "fail-closed modes must attempt secure storage")
+		})
+	}
+}
+
 func TestSaveCloudConfigDoesNotReplaceConcurrentCreate(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	external := []byte("version: 1\ncontexts:\n  external: {}\ncurrent-context: external\n")
@@ -40,6 +116,7 @@ func TestSaveCloudConfigDoesNotReplaceConcurrentCreate(t *testing.T) {
 // writes fresh cloud auth fields) refreshes the context's existing cloud entry
 // in place and does not drop the previously configured stack selection.
 func TestSaveCloudConfigPreservesStack(t *testing.T) {
+	withFakeStore(t)
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	source := config.ExplicitConfigFile(path)
@@ -91,6 +168,7 @@ func TestSaveCloudConfigPreservesStack(t *testing.T) {
 }
 
 func TestSaveCloudConfigCollisionDoesNotReplaceSharedEntry(t *testing.T) {
+	withFakeStore(t)
 	// Two different CAPs against the same host: a login from a context with
 	// no cloud binding must not quietly replace the host-named entry other
 	// contexts share — it gets a context-suffixed entry instead. A login with
@@ -116,6 +194,7 @@ func TestSaveCloudConfigCollisionDoesNotReplaceSharedEntry(t *testing.T) {
 	got.ResolveContext("prod")
 	assert.Equal(t, "org-wide-cap", got.Contexts["prod"].CloudEntry.Token,
 		"shared entry must not be replaced by another context's login")
+	got.ResolveContext("ci")
 	assert.Equal(t, "stack-scoped-cap", got.Contexts["ci"].CloudEntry.Token)
 
 	// Same credential from yet another context → dedups onto the shared entry.
@@ -125,6 +204,7 @@ func TestSaveCloudConfigCollisionDoesNotReplaceSharedEntry(t *testing.T) {
 }
 
 func TestSaveCloudConfigSharedEntryUsesCopyOnWrite(t *testing.T) {
+	withFakeStore(t)
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	source := config.ExplicitConfigFile(path)
@@ -158,6 +238,7 @@ func TestSaveCloudConfigSharedEntryUsesCopyOnWrite(t *testing.T) {
 }
 
 func TestSaveCloudConfigSafetyReservesEffectiveLayerNames(t *testing.T) {
+	withFakeStore(t)
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	source := config.ExplicitConfigFile(path)
@@ -190,12 +271,14 @@ func TestSaveCloudConfigSafetyReservesEffectiveLayerNames(t *testing.T) {
 
 	got, err := config.Load(ctx, source)
 	require.NoError(t, err)
-	assert.Equal(t, "shared-cap", got.Cloud["grafana-com"].Token)
-	assert.Equal(t, "prod-cap", got.Cloud[entryName].Token)
+	assert.True(t, credentials.IsBoundSentinel(got.Cloud["grafana-com"].Token))
+	got.ResolveContext("prod")
+	assert.Equal(t, "prod-cap", got.Contexts["prod"].CloudEntry.Token)
 	assert.Equal(t, entryName, got.Contexts["prod"].Cloud)
 }
 
 func TestSaveCloudConfigSafetyReservesUnboundEffectiveLayerName(t *testing.T) {
+	withFakeStore(t)
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	source := config.ExplicitConfigFile(path)
@@ -221,11 +304,13 @@ func TestSaveCloudConfigSafetyReservesUnboundEffectiveLayerName(t *testing.T) {
 	got, err := config.Load(ctx, source)
 	require.NoError(t, err)
 	assert.Nil(t, got.Cloud["grafana-com"], "a name owned by another effective layer must not be shadowed")
-	assert.Equal(t, "prod-cap", got.Cloud[entryName].Token)
+	got.ResolveContext("prod")
+	assert.Equal(t, "prod-cap", got.Contexts["prod"].CloudEntry.Token)
 	assert.Equal(t, entryName, got.Contexts["prod"].Cloud)
 }
 
 func TestSaveCloudConfigSafetyDoesNotReuseShadowedRawEntry(t *testing.T) {
+	withFakeStore(t)
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	source := config.ExplicitConfigFile(path)
@@ -254,11 +339,12 @@ func TestSaveCloudConfigSafetyDoesNotReuseShadowedRawEntry(t *testing.T) {
 
 	got, err := config.Load(ctx, source)
 	require.NoError(t, err)
-	assert.Equal(t, "same-cap", got.Cloud["grafana-com"].Token)
+	assert.True(t, credentials.IsBoundSentinel(got.Cloud["grafana-com"].Token))
 	assert.Equal(t, entryName, got.Contexts["prod"].Cloud)
 }
 
 func TestSaveCloudConfigEndpointChangeUsesCopyOnWrite(t *testing.T) {
+	withFakeStore(t)
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	source := config.ExplicitConfigFile(path)
@@ -288,6 +374,7 @@ func TestSaveCloudConfigEndpointChangeUsesCopyOnWrite(t *testing.T) {
 }
 
 func TestSaveCloudConfigOAuthMetadataChangeUsesCopyOnWrite(t *testing.T) {
+	withFakeStore(t)
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	source := config.ExplicitConfigFile(path)
@@ -323,6 +410,7 @@ func TestSaveCloudConfigOAuthMetadataChangeUsesCopyOnWrite(t *testing.T) {
 }
 
 func TestSaveCloudConfigOAuthScopeOrderDoesNotTriggerCopyOnWrite(t *testing.T) {
+	withFakeStore(t)
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	source := config.ExplicitConfigFile(path)
@@ -355,6 +443,7 @@ func TestSaveCloudConfigOAuthScopeOrderDoesNotTriggerCopyOnWrite(t *testing.T) {
 }
 
 func TestSaveCloudConfigUniqueEntryUpdatesInPlace(t *testing.T) {
+	withFakeStore(t)
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	source := config.ExplicitConfigFile(path)
@@ -375,6 +464,7 @@ func TestSaveCloudConfigUniqueEntryUpdatesInPlace(t *testing.T) {
 }
 
 func TestSaveCloudConfigCopyOnWriteNameCollisionIsSafe(t *testing.T) {
+	withFakeStore(t)
 	ctx := context.Background()
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	source := config.ExplicitConfigFile(path)
@@ -393,8 +483,10 @@ func TestSaveCloudConfigCopyOnWriteNameCollisionIsSafe(t *testing.T) {
 
 	got, err := config.Load(ctx, source)
 	require.NoError(t, err)
-	assert.Equal(t, "occupied-cap", got.Cloud["grafana-com-staging"].Token)
-	assert.Equal(t, "new-cap", got.Cloud[entryName].Token)
+	got.ResolveContext("other")
+	assert.Equal(t, "occupied-cap", got.Contexts["other"].CloudEntry.Token)
+	got.ResolveContext("staging")
+	assert.Equal(t, "new-cap", got.Contexts["staging"].CloudEntry.Token)
 }
 
 func TestMergeCloudIntoSwitchingAuthMethodClearsTheOther(t *testing.T) {

--- a/internal/config/credential_rejection_internal_test.go
+++ b/internal/config/credential_rejection_internal_test.go
@@ -316,6 +316,13 @@ func TestKeychainReadRejectionReasonNamesTheLockedKeychain(t *testing.T) {
 	}
 }
 
+func TestKeychainReadRejectionReasonNamesTheDeliberateOptOut(t *testing.T) {
+	assert.Equal(t, "keychain use is disabled by GCX_KEYCHAIN", keychainReadRejectionReason(credentials.ErrDisabled))
+	assert.Equal(t, "the OS keychain is locked", keychainReadRejectionReason(credentials.ErrLocked),
+		"ErrDisabled wraps ErrUnavailable, so its branch must not shadow the locked one")
+	assert.Equal(t, "the OS keychain could not be read", keychainReadRejectionReason(credentials.ErrUnavailable))
+}
+
 func TestLockedKeychainReadPreservesCauseInCredentialRejection(t *testing.T) {
 	store := newBoundTestStore()
 	useBoundTestStore(t, store)

--- a/internal/config/keychain.go
+++ b/internal/config/keychain.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/grafana/gcx/internal/credentials"
 	"github.com/grafana/gcx/internal/gcxerrors"
+	"github.com/grafana/gcx/internal/output"
 	"github.com/grafana/grafana-app-sdk/logging"
 )
 
@@ -1362,14 +1363,15 @@ func (txn *keychainWriteTransaction) stageBoundSet(binding credentials.Binding, 
 		}
 		if errors.Is(err, credentials.ErrNotFound) {
 			if err := txn.store.Set(boundRef.Account, value); err != nil {
+				if errors.Is(err, credentials.ErrDisabled) {
+					txn.fallbackErr = err
+					return credentials.BoundReference{}, false, nil
+				}
 				if !errors.Is(err, credentials.ErrUnavailable) {
 					txn.log.Warn("could not write keychain entry",
 						"owner", owner,
 						"field", string(field),
 						"error", err.Error())
-				}
-				if errors.Is(err, credentials.ErrUnavailable) {
-					return credentials.BoundReference{}, false, nil
 				}
 				return credentials.BoundReference{}, false, fmt.Errorf("write keychain entry for %q field %q: %w", owner, field, err)
 			}
@@ -1387,13 +1389,6 @@ func (txn *keychainWriteTransaction) stageBoundSet(binding credentials.Binding, 
 				if cleanupErr := txn.discardLastStagedWrite(); cleanupErr != nil {
 					return credentials.BoundReference{}, false, errors.Join(verifyErr, cleanupErr)
 				}
-				// A newly created credential has no prior reference to preserve. If
-				// the store cannot read it back (or has already lost it) and cleanup
-				// is confirmed, keep this one value in the config instead of writing
-				// a sentinel that the next command cannot resolve.
-				if errors.Is(err, credentials.ErrUnavailable) || errors.Is(err, credentials.ErrNotFound) {
-					return credentials.BoundReference{}, false, nil
-				}
 				return credentials.BoundReference{}, false, verifyErr
 			}
 			if stored != value {
@@ -1408,16 +1403,15 @@ func (txn *keychainWriteTransaction) stageBoundSet(binding credentials.Binding, 
 			}
 			return boundRef, true, nil
 		}
-		if errors.Is(err, credentials.ErrUnavailable) {
+		if errors.Is(err, credentials.ErrDisabled) {
 			txn.fallbackErr = err
 			return credentials.BoundReference{}, false, nil
-		} else {
-			txn.log.Warn("could not inspect keychain entry before write",
-				"owner", owner,
-				"field", string(field),
-				"error", err.Error())
-			return credentials.BoundReference{}, false, fmt.Errorf("inspect keychain entry for %q field %q: %w", owner, field, err)
 		}
+		txn.log.Warn("could not inspect keychain entry before write",
+			"owner", owner,
+			"field", string(field),
+			"error", err.Error())
+		return credentials.BoundReference{}, false, fmt.Errorf("inspect keychain entry for %q field %q: %w", owner, field, err)
 	}
 	txn.log.Warn("could not allocate unique keychain reference", "owner", owner, "field", string(field))
 	return credentials.BoundReference{}, false, errors.New("could not allocate unique keychain reference")
@@ -1520,7 +1514,7 @@ func (txn *keychainWriteTransaction) commit(warningWriter io.Writer) error {
 		deleted = append(deleted, pending)
 	}
 	if txn.plaintextFallback {
-		txn.warnUnavailableOnce(func() {
+		emitWarning := func() {
 			message := "credential store could not securely store the credential; credentials remain in plaintext on disk"
 			hint := "verify your OS credential store (Keychain, Credential Manager, or Secret Service) is available and working to enable encrypted credential storage"
 			if errors.Is(txn.fallbackErr, credentials.ErrDisabled) {
@@ -1536,11 +1530,18 @@ func (txn *keychainWriteTransaction) commit(warningWriter io.Writer) error {
 				}
 			}
 			if warningWriter != nil {
-				fmt.Fprintf(warningWriter, "Warning: %s; %s\n", message, hint)
+				output.EmitWarn(warningWriter, fmt.Sprintf("%s; %s", message, hint))
 				return
 			}
 			txn.log.Warn(message, "hint", hint)
-		})
+		}
+		// A stale generation needs a concrete repair. A prior generic warning in
+		// this process must not suppress that more actionable guidance.
+		if txn.abandonedGeneration {
+			emitWarning()
+		} else {
+			txn.warnUnavailableOnce(emitWarning)
+		}
 	}
 	return nil
 }

--- a/internal/config/keychain_bound_internal_test.go
+++ b/internal/config/keychain_bound_internal_test.go
@@ -1163,7 +1163,7 @@ func TestBoundKeychainGenericStoreFailuresLeaveDiskAndCallerUntouched(t *testing
 	}
 }
 
-func TestBoundKeychainUnreadableNewCredentialFallsBackAfterConfirmedCleanup(t *testing.T) {
+func TestBoundKeychainUnreadableNewCredentialFailsClosedAfterConfirmedCleanup(t *testing.T) {
 	store := newBoundTestStore()
 	store.getErrAfterSet = credentials.ErrUnavailable
 	store.getErrAfterSetAt = 1
@@ -1171,12 +1171,11 @@ func TestBoundKeychainUnreadableNewCredentialFallsBackAfterConfirmedCleanup(t *t
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	cfg := boundStackTestConfig("https://example.invalid", "api-token")
 
-	require.NoError(t, Write(context.Background(), ExplicitConfigFile(path), cfg))
-	raw, err := os.ReadFile(path)
-	require.NoError(t, err)
-	assert.Contains(t, string(raw), "api-token")
-	assert.NotContains(t, string(raw), "keychain:gcx:v2:")
-	assert.Empty(t, store.entries, "the unverifiable keychain generation must be removed before plaintext fallback")
+	err := Write(context.Background(), ExplicitConfigFile(path), cfg)
+	require.ErrorIs(t, err, credentials.ErrUnavailable)
+	_, readErr := os.ReadFile(path)
+	require.ErrorIs(t, readErr, os.ErrNotExist)
+	assert.Empty(t, store.entries, "the unverifiable keychain generation must be removed before the failed write returns")
 	assert.Equal(t, 1, store.deleteCalls, "the failed verification must perform its own confirmed cleanup")
 }
 
@@ -1205,23 +1204,18 @@ func TestBoundKeychainVerifyAndCleanupFailureRollsBackStagedWrite(t *testing.T) 
 	assert.Empty(t, cfg.Stacks["default"].sourceIdentity)
 }
 
-func TestBoundKeychainWriteUnavailableFallsBackOnlyForNewCredential(t *testing.T) {
+func TestBoundKeychainWriteUnavailableFailsClosedForNewCredential(t *testing.T) {
 	store := newBoundTestStore()
 	store.setErr = credentials.ErrUnavailable
 	useBoundTestStore(t, store)
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	cfg := boundStackTestConfig("https://example.invalid", "new-token")
 
-	require.NoError(t, Write(context.Background(), ExplicitConfigFile(path), cfg))
-
-	raw, err := os.ReadFile(path)
-	require.NoError(t, err)
-	assert.Contains(t, string(raw), "new-token")
-	assert.NotContains(t, string(raw), "keychain:gcx:v2:")
+	err := Write(context.Background(), ExplicitConfigFile(path), cfg)
+	require.ErrorIs(t, err, credentials.ErrUnavailable)
+	_, readErr := os.ReadFile(path)
+	require.ErrorIs(t, readErr, os.ErrNotExist)
 	assert.Empty(t, store.entries)
-	info, err := os.Stat(path)
-	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
 }
 
 func TestBoundKeychainWriteUnavailableMissingReferenceRepairFailsClosed(t *testing.T) {
@@ -1243,7 +1237,7 @@ func TestBoundKeychainWriteUnavailableMissingReferenceRepairFailsClosed(t *testi
 
 	err = Write(context.Background(), ExplicitConfigFile(path), cfg)
 	require.ErrorIs(t, err, credentials.ErrUnavailable)
-	require.ErrorContains(t, err, "cannot replace credential")
+	require.ErrorContains(t, err, "write keychain entry")
 	rawAfter, readErr := os.ReadFile(path)
 	require.NoError(t, readErr)
 	assert.Equal(t, rawBefore, rawAfter)
@@ -1275,7 +1269,7 @@ func TestBoundKeychainWriteUnavailableRejectedReferenceRepairFailsClosed(t *test
 
 	err = Write(context.Background(), ExplicitConfigFile(path), cfg)
 	require.ErrorIs(t, err, credentials.ErrUnavailable)
-	require.ErrorContains(t, err, "cannot replace credential")
+	require.ErrorContains(t, err, "write keychain entry")
 	rawAfter, readErr := os.ReadFile(path)
 	require.NoError(t, readErr)
 	assert.Equal(t, rawBefore, rawAfter)
@@ -1285,7 +1279,7 @@ func TestBoundKeychainWriteUnavailableRejectedReferenceRepairFailsClosed(t *test
 	assert.Equal(t, "replacement-token", cfg.Stacks["default"].Grafana.APIToken)
 }
 
-func TestBoundKeychainPartialWriteUnavailableCommitsSentinelAndPlaintextSafely(t *testing.T) {
+func TestBoundKeychainPartialWriteUnavailableFailsClosed(t *testing.T) {
 	store := newBoundTestStore()
 	store.setErr = credentials.ErrUnavailable
 	store.setFailAt = 2
@@ -1295,18 +1289,11 @@ func TestBoundKeychainPartialWriteUnavailableCommitsSentinelAndPlaintextSafely(t
 	cfg.Stacks["default"].Grafana.User = "alice"
 	cfg.Stacks["default"].Grafana.Password = "new-password"
 
-	require.NoError(t, Write(context.Background(), ExplicitConfigFile(path), cfg))
-
-	raw, err := os.ReadFile(path)
-	require.NoError(t, err)
-	disk := string(raw)
-	assert.Len(t, store.entries, 1)
-	assert.NotEqual(t, strings.Contains(disk, "new-token"), strings.Contains(disk, "new-password"),
-		"exactly one credential should use the plaintext fallback")
-	assert.Equal(t, 1, strings.Count(disk, "keychain:gcx:v2:"))
-	info, err := os.Stat(path)
-	require.NoError(t, err)
-	assert.Equal(t, os.FileMode(0o600), info.Mode().Perm())
+	err := Write(context.Background(), ExplicitConfigFile(path), cfg)
+	require.ErrorIs(t, err, credentials.ErrUnavailable)
+	_, readErr := os.ReadFile(path)
+	require.ErrorIs(t, readErr, os.ErrNotExist)
+	assert.Empty(t, store.entries, "the staged generation must roll back with the failed write")
 }
 
 func TestBoundKeychainWriteUnavailableRotationAbortsWithoutWarning(t *testing.T) {
@@ -1338,7 +1325,8 @@ func TestBoundKeychainWriteUnavailableRotationAbortsWithoutWarning(t *testing.T)
 	ctx := logging.Context(context.Background(), logger)
 
 	err = Write(ctx, ExplicitConfigFile(path), loaded)
-	require.ErrorContains(t, err, "cannot replace credential")
+	require.ErrorIs(t, err, credentials.ErrUnavailable)
+	require.ErrorContains(t, err, "write keychain entry")
 	assert.Empty(t, logger.warnings, "an aborted rotation must not claim plaintext was committed")
 	rawAfter, readErr := os.ReadFile(path)
 	require.NoError(t, readErr)
@@ -1356,7 +1344,7 @@ func TestBoundKeychainFallbackWarningRunsOnlyAfterSuccessfulCommit(t *testing.T)
 	txn.plaintextFallback = true
 
 	require.NoError(t, txn.commit(&warnings))
-	assert.Equal(t, "Warning: credential store could not securely store the credential; credentials remain in plaintext on disk; verify your OS credential store (Keychain, Credential Manager, or Secret Service) is available and working to enable encrypted credential storage\n", warnings.String())
+	assert.Equal(t, "warn: credential store could not securely store the credential; credentials remain in plaintext on disk; verify your OS credential store (Keychain, Credential Manager, or Secret Service) is available and working to enable encrypted credential storage\n", warnings.String())
 	assert.Empty(t, logger.warnings, "the request-scoped warning must not be duplicated through structured logging")
 
 	txn = newKeychainWriteTransaction(newBoundTestStore(), logger)
@@ -1395,7 +1383,8 @@ func TestBoundKeychainUnavailableReplacementPreservesOldGeneration(t *testing.T)
 	cfg.Stacks["default"].Grafana.APIToken = "new-token"
 	store.getErr = credentials.ErrUnavailable
 	err = Write(context.Background(), ExplicitConfigFile(path), cfg)
-	require.ErrorContains(t, err, "cannot replace credential")
+	require.ErrorIs(t, err, credentials.ErrUnavailable)
+	require.ErrorContains(t, err, "inspect keychain entry")
 	rawAfter, readErr := os.ReadFile(path)
 	require.NoError(t, readErr)
 	assert.Equal(t, rawBefore, rawAfter)

--- a/internal/config/keychain_disabled_internal_test.go
+++ b/internal/config/keychain_disabled_internal_test.go
@@ -1,12 +1,15 @@
 package config
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/grafana/gcx/internal/agent"
 	"github.com/grafana/gcx/internal/credentials"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -70,27 +73,44 @@ func TestReconcileMarksTheAbandonedGenerationWhenDisabled(t *testing.T) {
 	assert.Empty(t, txn.deletes, "a disabled store cannot delete the old account")
 }
 
-// Section 2 of the review: the replaced generation cannot be deleted through a
-// disabled store, so the warning has to disclose that it stays behind.
+// A disabled store cannot delete the replaced generation, so the warning must
+// disclose that it remains in the OS credential store.
 func TestBoundKeychainDisabledWarningDisclosesTheAbandonedGeneration(t *testing.T) {
 	logger := &boundTestLogger{}
 	var warnings strings.Builder
 	txn := newKeychainWriteTransaction(newBoundTestStore(), logger)
-	txn.warnUnavailableOnce = func(emit func()) { emit() }
+	// Suppress the generic availability warning. The abandoned-generation
+	// repair must still reach the caller because it is more actionable.
+	txn.warnUnavailableOnce = func(func()) {}
 	txn.plaintextFallback = true
 	txn.fallbackErr = credentials.ErrDisabled
 	txn.abandonedGeneration = true
 
 	require.NoError(t, txn.commit(&warnings))
-	assert.Contains(t, warnings.String(), "is still in the OS credential store and gcx can no longer reach it")
-	assert.Contains(t, warnings.String(), "delete the stale gcx entry")
+	assert.Equal(t, "warn: keychain storage is disabled; the replaced credential is still in the OS credential store and gcx can no longer reach it; "+
+		"delete the stale gcx entry through your OS credential store to finish rotating the credential\n", warnings.String())
 }
 
-func TestKeychainReadRejectionReasonNamesTheDeliberateOptOut(t *testing.T) {
-	assert.Equal(t, "keychain use is disabled by GCX_KEYCHAIN", keychainReadRejectionReason(credentials.ErrDisabled))
-	assert.Equal(t, "the OS keychain is locked", keychainReadRejectionReason(credentials.ErrLocked),
-		"ErrDisabled wraps ErrUnavailable, so its branch must not shadow the locked one")
-	assert.Equal(t, "the OS keychain could not be read", keychainReadRejectionReason(credentials.ErrUnavailable))
+func TestBoundKeychainDisabledWarningUsesTypedAgentEvent(t *testing.T) {
+	previousAgentMode := agent.IsAgentMode()
+	agent.SetFlag(true)
+	t.Cleanup(func() { agent.SetFlag(previousAgentMode) })
+
+	var warnings bytes.Buffer
+	txn := newKeychainWriteTransaction(newBoundTestStore(), &boundTestLogger{})
+	txn.warnUnavailableOnce = func(func()) {}
+	txn.plaintextFallback = true
+	txn.fallbackErr = credentials.ErrDisabled
+	txn.abandonedGeneration = true
+
+	require.NoError(t, txn.commit(&warnings))
+	var event struct {
+		Class   string `json:"class"`
+		Summary string `json:"summary"`
+	}
+	require.NoError(t, json.Unmarshal(warnings.Bytes(), &event))
+	assert.Equal(t, "warning", event.Class)
+	assert.Contains(t, event.Summary, "is still in the OS credential store and gcx can no longer reach it")
 }
 
 // Deleting cannot silently succeed while the store is disabled, but the error
@@ -140,11 +160,9 @@ func TestBoundKeychainDisabledFallbackWarningOmitsTroubleshootingHint(t *testing
 	txn.fallbackErr = credentials.ErrDisabled
 
 	require.NoError(t, txn.commit(&warnings))
-	assert.Equal(t, "Warning: keychain storage is disabled; credentials remain in plaintext on disk; "+
+	assert.Equal(t, "warn: keychain storage is disabled; credentials remain in plaintext on disk; "+
 		"unset GCX_KEYCHAIN to store credentials in the OS credential store\n",
 		warnings.String())
-	assert.NotContains(t, warnings.String(), "is available and working",
-		"a deliberate opt-out must not be reported as a broken credential store")
 	assert.NotContains(t, warnings.String(), "is available and working",
 		"a deliberate opt-out must not be reported as a broken credential store")
 }

--- a/internal/config/keychain_mode_internal_test.go
+++ b/internal/config/keychain_mode_internal_test.go
@@ -129,3 +129,16 @@ func TestKeychainStoreForDisabledModeNeverTouchesTheOSKeychain(t *testing.T) {
 	require.ErrorIs(t, store.Set("any-account", "value"), credentials.ErrDisabled)
 	require.ErrorIs(t, store.Delete("any-account"), credentials.ErrDisabled)
 }
+
+// defaultKeychainStore must resolve GCX_KEYCHAIN before the go-test
+// short-circuit. Every test binary runs under testing.Testing(), so if that
+// check came first, an explicit GCX_KEYCHAIN=off could never be exercised by
+// an in-process test — it would always resolve to the bare "unavailable"
+// no-op store instead of the disabled one.
+func TestDefaultKeychainStoreHonoursDisabledModeBeforeTestingShortCircuit(t *testing.T) {
+	t.Setenv(envKeychain, "off")
+
+	err := defaultKeychainStore().Set("a", "b")
+
+	require.ErrorIs(t, err, credentials.ErrDisabled)
+}

--- a/internal/config/keychain_test.go
+++ b/internal/config/keychain_test.go
@@ -27,6 +27,10 @@ type fakeStore struct {
 	// that is reachable for writes but cannot resolve reads (e.g. a locked
 	// session). Tests set it to credentials.ErrUnavailable.
 	getErr error
+	// setErr simulates a store that opens successfully but refuses new
+	// credential generations. Keeping this distinct from getErr lets tests
+	// prove that fresh-login failures never fall back to plaintext.
+	setErr error
 }
 
 func newFakeStore() *fakeStore {
@@ -55,6 +59,9 @@ func (s *fakeStore) setGetErr(err error) {
 func (s *fakeStore) Set(key, value string) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.setErr != nil {
+		return s.setErr
+	}
 	s.entries[key] = value
 	s.setCalls++
 	return nil
@@ -84,6 +91,17 @@ func (s *fakeStore) len() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return len(s.entries)
+}
+
+func (s *fakeStore) containsValue(value string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, stored := range s.entries {
+		if stored == value {
+			return true
+		}
+	}
+	return false
 }
 
 // withFakeStore installs a fakeStore for the duration of the test and returns

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -32,11 +32,15 @@ import (
 // uses credentials.Open() which probes the OS keychain, unless the resolved
 // keychain mode is disabled, in which case credentials stay in plaintext.
 //
-// Under `go test` (detected via testing.Testing()), the default is a no-op
-// store that reports ErrUnavailable for every operation. This prevents any
-// test in any package from triggering OS-keychain prompts when it loads a
-// config file. Tests that need to exercise the keychain code path must
-// explicitly install their own store by overriding this variable.
+// GCX_KEYCHAIN=off is checked before the test short-circuit below, so a
+// deliberate opt-out is honoured even under `go test`: ErrDisabled must
+// remain reachable in-process, or no test could exercise the one path that
+// still falls back to plaintext. Otherwise, under `go test` (detected via
+// testing.Testing()), the default is a no-op store that reports
+// ErrUnavailable for every operation. This prevents any test in any package
+// from triggering OS-keychain prompts when it loads a config file. Tests that
+// need to exercise the keychain code path must explicitly install their own
+// store by overriding this variable.
 //
 //nolint:gochecknoglobals // test injection seam for the keychain backend.
 var keychainStoreFn = defaultKeychainStore
@@ -79,10 +83,13 @@ var (
 )
 
 func defaultKeychainStore() credentials.Store {
+	if keychainModeForProcess() == keychainModeDisabled {
+		return disabledStore{}
+	}
 	if testing.Testing() {
 		return testingNoopStore{}
 	}
-	return keychainStoreForMode(keychainModeForProcess())
+	return keychainStoreForMode(keychainModeEnabled)
 }
 
 func keychainStoreForMode(mode keychainMode) credentials.Store {

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -149,6 +149,7 @@ this-field-is-invalid: []`
 }
 
 func TestLoad_withProviders(t *testing.T) {
+	withFakeStore(t)
 	req := require.New(t)
 
 	configYAML := `version: 1

--- a/internal/config/rest_persistence_test.go
+++ b/internal/config/rest_persistence_test.go
@@ -190,6 +190,7 @@ current-context: default
 }
 
 func TestWireTokenPersistence_ExplicitModeWritesToExplicitSource(t *testing.T) {
+	store := withFakeStore(t)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/cli/v1/auth/refresh":
@@ -290,8 +291,10 @@ contexts:
 	explicitRaw, err := os.ReadFile(explicitFile)
 	require.NoError(t, err)
 	explicitContents := string(explicitRaw)
-	assert.Contains(t, explicitContents, "gat_explicit_new")
-	assert.Contains(t, explicitContents, "gar_explicit_new")
+	assert.NotContains(t, explicitContents, "gat_explicit_new")
+	assert.NotContains(t, explicitContents, "gar_explicit_new")
+	assert.True(t, store.containsValue("gat_explicit_new"))
+	assert.True(t, store.containsValue("gar_explicit_new"))
 
 	userRaw, err := os.ReadFile(userFile)
 	require.NoError(t, err)
@@ -318,6 +321,7 @@ func refresher(t *testing.T, rc config.NamespacedRESTConfig) func(previousRefres
 // rotated refresh token is issued by the server but never written to disk,
 // leaving the user locked out on the next invocation.
 func TestWireTokenPersistence_WritesAfterContextCancelled(t *testing.T) {
+	store := withFakeStore(t)
 	dir := t.TempDir()
 	explicitFile := filepath.Join(dir, "explicit.yaml")
 	writeTestConfigFile(t, explicitFile, `
@@ -370,8 +374,10 @@ current-context: default
 
 	raw, err := os.ReadFile(explicitFile)
 	require.NoError(t, err)
-	assert.Contains(t, string(raw), "gat_rotated")
-	assert.Contains(t, string(raw), "gar_rotated")
+	assert.NotContains(t, string(raw), "gat_rotated")
+	assert.NotContains(t, string(raw), "gar_rotated")
+	assert.True(t, store.containsValue("gat_rotated"))
+	assert.True(t, store.containsValue("gar_rotated"))
 
 	// Retrying after a write that committed but reported uncertain durability
 	// is an idempotent success only when every persisted field is the exact new
@@ -978,6 +984,7 @@ current-context: default
 // observe the freshly-written tokens on disk and adopt them without calling
 // the refresh endpoint a second time.
 func TestWireTokenPersistence_ConcurrentRefreshesSerializeViaFileLock(t *testing.T) {
+	store := withFakeStore(t)
 	var refreshCalls atomic.Int32
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/cli/v1/auth/refresh" {
@@ -1069,14 +1076,17 @@ current-context: default
 	}
 	raw, err := os.ReadFile(file)
 	require.NoError(t, err)
-	assert.Contains(t, string(raw), "gat_new")
-	assert.Contains(t, string(raw), "gar_new")
+	assert.NotContains(t, string(raw), "gat_new")
+	assert.NotContains(t, string(raw), "gar_new")
+	assert.True(t, store.containsValue("gat_new"))
+	assert.True(t, store.containsValue("gar_new"))
 	assert.Equal(t, int32(1), refreshCalls.Load())
 }
 
 // Bug 5 — Tokens persisted in one "invocation" must be re-loadable and usable
 // for the next. Simulates two sequential gcx invocations sharing a config file.
 func TestWireTokenPersistence_RoundTripAcrossInvocations(t *testing.T) {
+	withFakeStore(t)
 	var refreshCalls atomic.Int32
 	var presentedRefresh atomic.Value // string
 	presentedRefresh.Store("")

--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -71,8 +71,10 @@ var AllFields = []Field{
 // ErrNotFound is returned by Store.Get when no entry exists for the given key.
 var ErrNotFound = errors.New("credentials: entry not found")
 
-// ErrUnavailable is returned when the OS keychain cannot be reached. Callers
-// should fall back to plaintext.
+// ErrUnavailable is returned when the OS keychain cannot be reached. This is
+// fatal: callers must not fall back to plaintext for it. credentials.ErrDisabled
+// (the deliberate GCX_KEYCHAIN=off opt-out) is the one exception, and it must be
+// tested for explicitly, since it wraps ErrUnavailable.
 var ErrUnavailable = errors.New("credentials: keychain unavailable")
 
 // ErrLocked is returned when the OS keychain is reachable but locked, or when
@@ -84,9 +86,10 @@ var ErrLocked = errors.New("credentials: keychain locked")
 
 // ErrDisabled is reported by a store that stands in for a keychain the user has
 // deliberately turned off. Unlike ErrLocked it wraps ErrUnavailable, because no
-// keychain is in play at all: every existing fallback path keeps treating it as
-// an unreachable backend, and only the decisions that differ for a deliberate
-// opt-out test for it specifically.
+// keychain is in play at all, but callers must not rely on that wrapping: since
+// plain ErrUnavailable is now fatal, every fallback-to-plaintext path must test
+// for ErrDisabled specifically, ahead of any ErrUnavailable check, or it will
+// wrongly treat a deliberate opt-out as a fatal unreachable backend.
 var ErrDisabled = fmt.Errorf("%w: disabled by configuration", ErrUnavailable)
 
 // Store is the minimal interface for a secret backend.

--- a/internal/credentials/keychain.go
+++ b/internal/credentials/keychain.go
@@ -25,13 +25,15 @@ type keychainStore struct{}
 
 // Open returns a Store backed by the OS keychain. If no working backend is
 // reachable (unsupported platform, headless box, missing DBus), it returns a
-// Store that reports ErrUnavailable on every operation so callers can fall
-// back to plaintext. If the backend is reachable but locked, every operation
-// reports ErrLocked instead, so no secret ever falls back to plaintext.
+// Store that reports ErrUnavailable on every operation; callers must
+// propagate that failure rather than fall back to plaintext. If the backend
+// is reachable but locked, every operation reports ErrLocked instead, so no
+// secret ever falls back to plaintext either. Plaintext is only ever chosen
+// through the separate, explicit GCX_KEYCHAIN=off opt-out, not through Open.
 func Open() Store {
 	// Probe with a read for an account we never write. A working backend
 	// returns ErrNotFound; an unreachable one returns a transport/platform
-	// error, which means we should fall back to plaintext.
+	// error, which the caller must treat as fatal.
 	if _, err := keyring.Get(service, probeAccount); err != nil && !errors.Is(err, keyring.ErrNotFound) {
 		err = normalizeKeyringError(err)
 		if errors.Is(err, ErrUnavailable) {
@@ -198,7 +200,9 @@ func darwinKeychainLockedExitCode(code int) bool {
 }
 
 // unavailableStore is returned by Open when no working backend was found.
-// Every operation returns ErrUnavailable so callers fall back to plaintext.
+// Every operation returns ErrUnavailable; callers must propagate the failure
+// rather than fall back to plaintext. Plaintext is selected separately, only
+// through the explicit GCX_KEYCHAIN=off opt-out.
 type unavailableStore struct{}
 
 func (unavailableStore) Get(string) (string, error) { return "", ErrUnavailable }

--- a/internal/login/login_internal_test.go
+++ b/internal/login/login_internal_test.go
@@ -81,6 +81,8 @@ func TestRuntimeOnlyOAuthDestinationChecksBeforeAndAfterFlow(t *testing.T) {
 	})
 
 	t.Run("issuer endpoint matching runtime override remains persistable", func(t *testing.T) {
+		t.Setenv("GCX_KEYCHAIN", "off")
+
 		const runtimeProxy = "https://runtime-proxy.example.invalid"
 		source := config.ExplicitConfigFile(t.TempDir() + "/config.yaml")
 		_, err := Run(t.Context(), &Options{

--- a/internal/login/login_test.go
+++ b/internal/login/login_test.go
@@ -49,6 +49,11 @@ func configSource(dir string) config.Source {
 	return config.ExplicitConfigFile(filepath.Join(dir, "config.yaml"))
 }
 
+func usePlaintextCredentialStorage(t *testing.T) {
+	t.Helper()
+	t.Setenv("GCX_KEYCHAIN", "off")
+}
+
 func TestRunRejectsNonTargetLayerChangeDuringAuthentication(t *testing.T) {
 	home := t.TempDir()
 	userDir := filepath.Join(home, ".config")
@@ -141,7 +146,7 @@ contexts:
 }
 
 func TestRun(t *testing.T) { //nolint:maintidx // 8 table-driven cases; complexity is inherent to spec-required coverage
-	t.Parallel()
+	usePlaintextCredentialStorage(t)
 
 	oauthResult := &auth.Result{
 		Token:            "gat_test",
@@ -674,8 +679,6 @@ func TestRun(t *testing.T) { //nolint:maintidx // 8 table-driven cases; complexi
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
-
 			dir := t.TempDir()
 			opts := tc.opts(dir)
 			src := opts.ConfigSource
@@ -765,7 +768,7 @@ func TestResolveCloudEndpoints(t *testing.T) {
 }
 
 func TestTrustedCAPIsPersistedAsCAP(t *testing.T) {
-	t.Parallel()
+	usePlaintextCredentialStorage(t)
 
 	dir := t.TempDir()
 	source := configSource(dir)
@@ -842,7 +845,7 @@ func TestRuntimeTLSOverrideRejectsNonDurableBearerCredential(t *testing.T) {
 }
 
 func TestStoredProxyTokenReauthPreservesDestinationBinding(t *testing.T) {
-	t.Parallel()
+	usePlaintextCredentialStorage(t)
 
 	const (
 		server = "https://grafana.example.invalid"
@@ -947,6 +950,7 @@ func TestRunAgentModeMissingServer(t *testing.T) {
 // on-prem without returning ErrNeedClarification (D17, NC-007, AC-008).
 // Cannot be parallel: calls t.Setenv, which is incompatible with parallel parent tests.
 func TestRunAgentModeAmbiguousURL(t *testing.T) {
+	usePlaintextCredentialStorage(t)
 	t.Setenv("GCX_AGENT_MODE", "1")
 	agent.ResetForTesting()
 	t.Cleanup(func() {
@@ -986,6 +990,8 @@ func (c *countingAuthFlow) Run(_ context.Context) (*auth.Result, error) {
 }
 
 func TestRun_OAuthRunsOnceAcrossRetries(t *testing.T) {
+	usePlaintextCredentialStorage(t)
+
 	// Ensure agent mode is off so resolveCloudAuth returns ErrNeedInput instead of skipping.
 	t.Setenv("GCX_AGENT_MODE", "0")
 	agent.ResetForTesting()
@@ -1041,6 +1047,8 @@ func TestRun_OAuthRunsOnceAcrossRetries(t *testing.T) {
 }
 
 func TestRun_PersistsOAuthRotationPerformedDuringValidation(t *testing.T) {
+	usePlaintextCredentialStorage(t)
+
 	dir := t.TempDir()
 	var refreshCalls atomic.Int32
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -1111,6 +1119,8 @@ func TestRun_PersistsOAuthRotationPerformedDuringValidation(t *testing.T) {
 }
 
 func TestPersist_ServerMismatch_EmitsClarification(t *testing.T) {
+	usePlaintextCredentialStorage(t)
+
 	dir := t.TempDir()
 
 	// Seed an existing context with a different server.
@@ -1165,6 +1175,8 @@ func TestPersist_ServerMismatch_EmitsClarification(t *testing.T) {
 }
 
 func TestPersist_ServerMismatch_AllowOverrideBypasses(t *testing.T) {
+	usePlaintextCredentialStorage(t)
+
 	dir := t.TempDir()
 
 	seed := config.Config{}
@@ -1218,6 +1230,8 @@ func TestPersist_ServerMismatch_AllowOverrideBypasses(t *testing.T) {
 }
 
 func TestPersist_UnboundContextSameNamedStackStillRequiresServerOverride(t *testing.T) {
+	usePlaintextCredentialStorage(t)
+
 	dir := t.TempDir()
 	seed := config.Config{}
 	seed.SetStack("prod", config.StackConfig{
@@ -1258,6 +1272,8 @@ func TestPersist_UnboundContextSameNamedStackStillRequiresServerOverride(t *test
 }
 
 func TestPersist_ServerMismatch_YesDoesNotBypass(t *testing.T) {
+	usePlaintextCredentialStorage(t)
+
 	dir := t.TempDir()
 
 	seed := config.Config{}
@@ -1353,6 +1369,7 @@ func TestRun_ValidationFailure_EmitsSaveUnvalidatedClarification(t *testing.T) {
 // context (including the token), and returns no error. Other validation failures
 // still hard-fail / prompt (covered by the save-unvalidated test above).
 func TestRun_OptionalCloudTokenRejected_WarnsAndPersists(t *testing.T) {
+	usePlaintextCredentialStorage(t)
 	t.Setenv("GCX_AGENT_MODE", "0")
 	agent.ResetForTesting()
 
@@ -1393,6 +1410,8 @@ func TestRun_OptionalCloudTokenRejected_WarnsAndPersists(t *testing.T) {
 }
 
 func TestRun_ForceSave_BypassesValidation(t *testing.T) {
+	usePlaintextCredentialStorage(t)
+
 	dir := t.TempDir()
 	validatorCalled := false
 	opts := login.Options{
@@ -1467,6 +1486,8 @@ func TestRun_ValidationFailure_YesFlagBypassesPrompt(t *testing.T) {
 }
 
 func TestRun_NormalizesServerScheme(t *testing.T) {
+	usePlaintextCredentialStorage(t)
+
 	dir := t.TempDir()
 	opts := login.Options{
 		Inputs: login.Inputs{
@@ -1507,6 +1528,8 @@ func TestRun_NormalizesServerScheme(t *testing.T) {
 }
 
 func TestRun_TLSPropagatedToContext(t *testing.T) {
+	usePlaintextCredentialStorage(t)
+
 	dir := t.TempDir()
 
 	tlsCfg := &config.TLS{
@@ -1544,6 +1567,8 @@ func TestRun_TLSPropagatedToContext(t *testing.T) {
 }
 
 func TestRun_ReauthPreservesTLS(t *testing.T) {
+	usePlaintextCredentialStorage(t)
+
 	dir := t.TempDir()
 
 	// Seed config with TLS settings
@@ -1595,6 +1620,8 @@ func TestRun_ReauthPreservesTLS(t *testing.T) {
 }
 
 func TestRun_TLSPassedToDetectFn(t *testing.T) {
+	usePlaintextCredentialStorage(t)
+
 	dir := t.TempDir()
 
 	var detectCalled bool
@@ -1625,6 +1652,8 @@ func TestRun_TLSPassedToDetectFn(t *testing.T) {
 }
 
 func TestRun_TLSPassedToValidateFn(t *testing.T) {
+	usePlaintextCredentialStorage(t)
+
 	dir := t.TempDir()
 
 	var validatedTLS *config.TLS
@@ -1742,7 +1771,7 @@ func TestRun_CloudTokenHintGuidance(t *testing.T) {
 // while building the REST config (via /bootdata) is written to the saved
 // context, so later commands skip the discovery round-trip.
 func TestRun_PersistsDiscoveredStackID(t *testing.T) {
-	t.Parallel()
+	usePlaintextCredentialStorage(t)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path == "/bootdata" {
@@ -1829,6 +1858,7 @@ func TestRun_OAuthSuccess_AnnouncesSignInBeforeCloudTokenPrompt(t *testing.T) {
 // TestRun_OAuthSuccess_AnnouncesSignInWithoutEmail verifies the success line
 // degrades gracefully when the OAuth result carries no email.
 func TestRun_OAuthSuccess_AnnouncesSignInWithoutEmail(t *testing.T) {
+	usePlaintextCredentialStorage(t)
 	t.Setenv("GCX_AGENT_MODE", "0")
 	agent.ResetForTesting()
 
@@ -1865,6 +1895,8 @@ func TestRun_OAuthSuccess_AnnouncesSignInWithoutEmail(t *testing.T) {
 }
 
 func TestRun_ManualOAuthReachesAuthOptions(t *testing.T) {
+	usePlaintextCredentialStorage(t)
+
 	var buf bytes.Buffer
 	reader := strings.NewReader("")
 	var got auth.Options

--- a/internal/providers/configloader_test.go
+++ b/internal/providers/configloader_test.go
@@ -732,6 +732,7 @@ current-context: default
 // TestConfigLoader_SaveProviderConfig_ExistingProvider verifies that saving a key
 // to an already-configured provider preserves other keys.
 func TestConfigLoader_SaveProviderConfig_ExistingProvider(t *testing.T) {
+	t.Setenv("GCX_KEYCHAIN", "off")
 	cfgFile := writeConfigFile(t, `
 version: 1
 stacks:
@@ -786,6 +787,7 @@ current-context: default
 }
 
 func TestConfigLoader_SaveProviderConfig_DoesNotPersistEnvOverrides(t *testing.T) {
+	t.Setenv("GCX_KEYCHAIN", "off")
 	cfgFile := writeConfigFile(t, `
 version: 1
 stacks:
@@ -998,6 +1000,7 @@ current-context: default
 // LoadGrafanaConfig wires SetOnRefresh so that a token refresh persists the
 // new tokens back to the config file on disk.
 func TestConfigLoader_LoadGrafanaConfig_PersistsRefreshedTokens(t *testing.T) {
+	t.Setenv("GCX_KEYCHAIN", "off")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/cli/v1/auth/refresh":
@@ -1088,6 +1091,7 @@ current-context: default
 }
 
 func TestLoadGrafanaConfig_PersistsRefreshToLocalOAuthLayer(t *testing.T) {
+	t.Setenv("GCX_KEYCHAIN", "off")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/cli/v1/auth/refresh":
@@ -1186,6 +1190,7 @@ contexts:
 }
 
 func TestLoadGrafanaConfig_PersistsRefreshToStackOwningLayer(t *testing.T) {
+	t.Setenv("GCX_KEYCHAIN", "off")
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api/cli/v1/auth/refresh":

--- a/internal/providers/synth/configloader_test.go
+++ b/internal/providers/synth/configloader_test.go
@@ -188,6 +188,7 @@ current-context: default
 // TestConfigLoader_LoadSMConfig_AutoDiscoveryPersistsToConfig verifies that an
 // auto-discovered SM URL is saved to the config file for subsequent runs.
 func TestConfigLoader_LoadSMConfig_AutoDiscoveryPersistsToConfig(t *testing.T) {
+	t.Setenv("GCX_KEYCHAIN", "off")
 	const wantURL = "https://synthetic-monitoring-api-eu-west-2.grafana.net"
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -405,6 +406,7 @@ current-context: default
 // TestConfigLoader_LoadSMConfig_TokenPersistsToConfig verifies that an
 // auto-discovered SM token is saved to the config file for subsequent runs.
 func TestConfigLoader_LoadSMConfig_TokenPersistsToConfig(t *testing.T) {
+	t.Setenv("GCX_KEYCHAIN", "off")
 	const wantToken = "sm-access-token-persisted"
 
 	smSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## What

Removes the plaintext fallback for an unavailable OS keychain. `stageBoundSet` in `internal/config/keychain.go` had three paths that signalled the caller to write a credential in plaintext instead, all reachable on a bare `credentials.ErrUnavailable`. Two are now gated on `credentials.ErrDisabled` and the third is deleted, so an unreachable credential store returns a hard error.

`GCX_KEYCHAIN=off` becomes the only path that writes plaintext. A locked store already failed closed and is unchanged.

Adds a `Keychain unavailable` summary in `cmd/gcx/fail/convert.go`, with its row in the error-summary table. A deliberately disabled store keeps the generic envelope rather than gaining a summary of its own, because the guard that distinguishes the two cases is `errors.Is(err, ErrUnavailable) && !errors.Is(err, ErrDisabled)` and adding a second summary would duplicate that decision in two places.

Corrects the credential-storage documentation, which promised the removed fallback in five places across the keychain reference pages, the architecture pages, and the `credentials` package doc comments. The keychain reference page is what the new error's own docs link resolves to, so a user hitting the error and following the link previously read that gcx would have fallen back.

**Breaking:** the removed behaviour is the `ErrUnavailable` plaintext-fallback return in `stageBoundSet`. A first login on a machine with no working credential store now fails where it previously succeeded with a warning.

## Why

A silent plaintext fallback hides the fact that a secret just landed on disk unencrypted. The two situations — a store that is momentarily unreachable, and a user who deliberately opted out — were indistinguishable, so a transient probe failure produced the same outcome as an explicit decision. Failing closed on the first while still honouring the second keeps them apart.

The opt-out has to exist before the fallback can be taken away, which is why this is a follow-up to #1242 and must merge after it. Users on CI runners and headless machines are precisely this change's blast radius, and `GCX_KEYCHAIN=off` is their remedy.

Extracted from #1266, which bundled this with a config field and a refactor. It is separated because it is the only genuinely breaking change in that set, it wants its own release note and its own decision, and it must stay revertable on its own if it lands badly.

## How it was tested

- [x] `GCX_AGENT_MODE=false mise run gate` passed — lint 0 issues, linter suite 44/44, install suite 16/16, full test suite green, build succeeded
- [x] Both fallback sites in `stageBoundSet` read directly on the branch to confirm each is `ErrDisabled`-only and that the deleted verify-readback fallback is gone
- [x] Confirmed `ErrDisabled` still reaches `plaintextFallback`, and that `fallbackErr` is only ever assigned from an `ErrDisabled` branch, so the deliberate opt-out still writes plaintext
- [x] Confirmed `ErrLocked` does not wrap `ErrUnavailable`, so the locked class is unaffected by the new guard
- [x] `TestCloudTokenLoginFailsClosedWhenKeychainUnavailable` asserts the token is absent from the config file, not merely that the command failed
- [x] The disabled-store discriminator in `convert.go` mutation-verified: removing `&& !errors.Is(err, credentials.ErrDisabled)` fails the new table row with `expected: "Writing config" / actual: "Keychain unavailable"`
- [x] Store-selection reordering mutation-verified: swapping the two checks fails the new test in `keychain_mode_internal_test.go`
- [x] The two hand-mirrored keychain pages confirmed byte-identical below their front matter, matching the baseline on `main`
- [x] Confirmed no reference to `credentials.keychain`, `CredentialsConfig`, or `keychainPolicy` appears anywhere on the branch — those belong to #1266 and do not exist on `main`

## Related

- Follow-up to #1242
- Extracted from #1266

---
**Generated by Claude Code**
