### PR TITLE
refactor(config): make load and write parameters explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 - Correct Fleet resource examples, preserve string collector IDs in resource manifests, and include the collector name and ID in successful create output.
 - Accept the Kubernetes envelope (`apiVersion`/`kind`/`metadata`/`spec`) in the manifest that `create -f` and `update -f` read. The commands decoded the envelope into an empty object before this change, so they lost every field that the manifest set. This repairs the round trip for `gcx irm oncall`, where `gcx resources list-examples` prints that envelope. For `gcx alert` it adds tolerance for a hand-written envelope, because the alert provider registers no adapter.
 - Stop sending the local zone name of the host as `user_tz` in `gcx irm oncall schedules list-final-shifts`. A host that does not set `TZ` sent the literal string `Local`, and the API answered "Invalid timezone".
+- Config write locks are now bound to the config file they were taken for. A held lock for one config file no longer lets a write to a different file skip locking, which could let concurrent gcx invocations write the same file at once.
 
 ## v1.2.0 (2026-08-25)
 

--- a/cmd/gcx/config/command.go
+++ b/cmd/gcx/config/command.go
@@ -199,17 +199,6 @@ func (opts *Options) MutationConfigSource() config.Source {
 	}
 }
 
-// MutationConfigContext carries the sole discovered source's trust provenance
-// into raw login/provider mutations. Explicit --config and GCX_CONFIG paths
-// remain explicit user intent (including symlink support).
-func (opts *Options) MutationConfigContext(ctx context.Context) context.Context {
-	target, err := opts.resolveMutationConfigTarget()
-	if err != nil || target.Type == "explicit" || target.Type == "" {
-		return ctx
-	}
-	return config.ContextWithConfigSource(ctx, target)
-}
-
 // MutationConfigTarget returns the exact raw config document selected for a
 // mutation together with its discovery provenance. Credential-accepting
 // commands use the provenance to require an explicit --config/GCX_CONFIG trust

--- a/internal/config/cloud_login.go
+++ b/internal/config/cloud_login.go
@@ -304,7 +304,7 @@ func SaveCloudConfigGuarded(
 		return "", "", err
 	}
 
-	if err := Write(ctx, source, cfg); err != nil {
+	if err := write(ctx, source, cfg, writeOptions{}); err != nil {
 		return "", "", &gcxerrors.DetailedError{
 			Summary: "Failed to save config",
 			Parent:  err,

--- a/internal/config/cloud_login.go
+++ b/internal/config/cloud_login.go
@@ -304,7 +304,7 @@ func SaveCloudConfigGuarded(
 		return "", "", err
 	}
 
-	if err := write(ctx, source, cfg, writeOptions{}); err != nil {
+	if err := write(ctx, source, cfg, writeOptions{layer: configLayerFromCtx(ctx)}); err != nil {
 		return "", "", &gcxerrors.DetailedError{
 			Summary: "Failed to save config",
 			Parent:  err,

--- a/internal/config/keychain_bound_internal_test.go
+++ b/internal/config/keychain_bound_internal_test.go
@@ -1515,6 +1515,21 @@ func TestRawLocalSymlinkLoadIsRejectedBeforeKeychainAccess(t *testing.T) {
 	assert.Empty(t, store.deletes)
 }
 
+func TestRawLocalSymlinkLoginMutationGuardedLoadIsRejectedBeforeKeychainAccess(t *testing.T) {
+	store := newBoundTestStore()
+	useBoundTestStore(t, store)
+	target := filepath.Join(t.TempDir(), "victim.yaml")
+	require.NoError(t, os.WriteFile(target, []byte("version: 1\ncontexts: {}\ncurrent-context: \"\"\n"), 0o600))
+	link := filepath.Join(t.TempDir(), LocalConfigFileName)
+	require.NoError(t, os.Symlink(target, link))
+	ctx := ContextWithConfigSource(context.Background(), ConfigSource{Path: link, Type: "local"})
+	_, err := LoadLoginMutationGuarded(ctx, ExplicitConfigFile(link), LoginMutationGuard{})
+	require.ErrorContains(t, err, "symlinks are not allowed")
+	assert.Empty(t, store.gets)
+	assert.Empty(t, store.sets)
+	assert.Empty(t, store.deletes)
+}
+
 func TestCredentialDestinationURLNormalizationPreservesSecurityRelevantBytes(t *testing.T) {
 	assert.NotEqual(t, normalizeCredentialURL("https://example.invalid/a%2Fb", ""), normalizeCredentialURL("https://example.invalid/a/b", ""))
 	assert.NotEqual(t, normalizeCredentialURL("https://example.invalid/path?tenant=a", ""), normalizeCredentialURL("https://example.invalid/path?tenant=b", ""))

--- a/internal/config/load_snapshot_internal_test.go
+++ b/internal/config/load_snapshot_internal_test.go
@@ -1,0 +1,147 @@
+package config
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const snapshotOnDiskConfig = `version: 1
+contexts:
+  ondisk: {}
+current-context: ondisk
+`
+
+const snapshotFrozenConfig = `version: 1
+contexts:
+  frozen: {}
+current-context: frozen
+`
+
+// TestLoadSourceSnapshotIsBoundToItsPath pins the path binding of the load
+// source snapshot.
+//
+// A snapshot lets a caller that already inspected a config document hand the
+// exact bytes it approved to the load, so a concurrent rewrite cannot make the
+// load act on content nobody preflighted. The bytes alone do not say which
+// file they came from, so the snapshot carries its path and the load only
+// honors it for that path. Dropping the binding would let a snapshot taken
+// from one layer satisfy the load of another — feeding a load content from a
+// different config document entirely — which is the same class of bug as a
+// write lock held for one source authorizing a write to another.
+//
+// The three cases are observably different because the frozen bytes and the
+// bytes on disk name different contexts.
+func TestLoadSourceSnapshotIsBoundToItsPath(t *testing.T) {
+	tests := []struct {
+		name string
+		// snapshot builds the load options under test from the path being
+		// loaded and an unrelated config path.
+		snapshot    func(targetPath, otherPath string) loadOptions
+		wantContext string
+	}{
+		{
+			name:        "no snapshot reads the file from disk",
+			snapshot:    func(_, _ string) loadOptions { return loadOptions{} },
+			wantContext: "ondisk",
+		},
+		{
+			name: "snapshot taken from the loaded path replaces the disk read",
+			snapshot: func(target, _ string) loadOptions {
+				return loadOptions{}.withSourceSnapshot(target, []byte(snapshotFrozenConfig))
+			},
+			wantContext: "frozen",
+		},
+		{
+			name: "snapshot taken from another path is ignored",
+			snapshot: func(_, other string) loadOptions {
+				return loadOptions{}.withSourceSnapshot(other, []byte(snapshotFrozenConfig))
+			},
+			wantContext: "ondisk",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			withFakeKeychain(t)
+			targetPath := writeTestConfig(t, snapshotOnDiskConfig)
+			otherPath := writeTestConfig(t, snapshotFrozenConfig)
+			require.NotEqual(t, targetPath, otherPath)
+
+			cfg, err := load(t.Context(), ExplicitConfigFile(targetPath), tc.snapshot(targetPath, otherPath))
+			require.NoError(t, err)
+
+			assert.Equal(t, tc.wantContext, cfg.CurrentContext)
+			require.NotNil(t, cfg.Contexts[tc.wantContext])
+		})
+	}
+}
+
+// TestLoadSourceSnapshotDoesNotLeakBetweenDerivedLoads pins the value
+// semantics that make the snapshot a per-target option.
+//
+// loadLayered derives one option value per source and sets the frozen bytes on
+// that copy. Setting them on the shared value instead would carry one layer's
+// snapshot into the next layer's load, so withSourceSnapshot must return a
+// copy and leave its receiver untouched.
+func TestLoadSourceSnapshotDoesNotLeakBetweenDerivedLoads(t *testing.T) {
+	base := loadOptions{layer: "user"}
+
+	derived := base.withSourceSnapshot("/layer-a.yaml", []byte(snapshotFrozenConfig))
+
+	_, ok := base.snapshotFor("/layer-a.yaml")
+	assert.False(t, ok, "deriving a load must not attach the snapshot to the shared options")
+	contents, ok := derived.snapshotFor("/layer-a.yaml")
+	require.True(t, ok)
+	assert.Equal(t, snapshotFrozenConfig, string(contents))
+}
+
+// TestMigrationRejectsSourceChangedAfterPreflight pins the second reader of
+// the load source snapshot, in migrateLegacyConfig.
+//
+// A legacy migration is decided from bytes read before the migration lock is
+// held. Under the lock the file is read again, and the frozen bytes are what
+// makes the comparison meaningful: they are the content the caller preflighted
+// and consented to migrate. If the snapshot never reaches the migration, the
+// comparison silently degrades into "the file equals itself" and gcx migrates
+// and rewrites a document it never inspected.
+//
+// The stale snapshot here stands in for a rewrite between preflight and load:
+// the load is told to migrate one legacy document while a different legacy
+// document is on disk.
+func TestMigrationRejectsSourceChangedAfterPreflight(t *testing.T) {
+	withFakeKeychain(t)
+	const onDiskLegacy = `contexts:
+  ondisk:
+    grafana:
+      server: https://ondisk.example
+current-context: ondisk
+`
+	const preflightedLegacy = `contexts:
+  preflighted:
+    grafana:
+      server: https://preflighted.example
+current-context: preflighted
+`
+	path := writeTestConfig(t, onDiskLegacy)
+	require.True(t, isLegacyConfig([]byte(onDiskLegacy)))
+	require.True(t, isLegacyConfig([]byte(preflightedLegacy)))
+
+	// Persistence stays enabled: the re-read under the migration lock only
+	// happens for a migration that is allowed to write.
+	opts := loadOptions{}.withSourceSnapshot(path, []byte(preflightedLegacy))
+	_, err := load(t.Context(), ExplicitConfigFile(path), opts)
+
+	require.Error(t, err)
+	require.ErrorContains(t, err, "changed after migration preflight")
+	require.ErrorContains(t, err, "no config files or credentials were changed")
+
+	// The error's promise must hold: nothing was migrated, replaced, or backed up.
+	onDisk, readErr := os.ReadFile(path)
+	require.NoError(t, readErr)
+	assert.Equal(t, onDiskLegacy, string(onDisk))
+	_, statErr := os.Stat(path + legacyBackupSuffix)
+	require.ErrorIs(t, statErr, os.ErrNotExist)
+}

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -494,8 +494,11 @@ func CreateDefaultConfigFile(file string) error {
 	return nil
 }
 
+// Load reads the config document named by source. It reads the ambient config
+// layer, if a caller set one through ContextWithConfigSource, once here and
+// passes it down as an explicit option.
 func Load(ctx context.Context, source Source, overrides ...Override) (Config, error) {
-	return load(ctx, source, loadOptions{}, overrides...)
+	return load(ctx, source, loadOptions{layer: configLayerFromCtx(ctx)}, overrides...)
 }
 
 //nolint:gocyclo,nestif // Loading keeps versioning, legacy migration, source binding, and keychain migration in one ordered trust pipeline.
@@ -506,12 +509,12 @@ func load(ctx context.Context, source Source, opts loadOptions, overrides ...Ove
 	if err != nil {
 		return config, err
 	}
-	layer, err := configLayerForPath(filename, configLayerFromCtx(ctx))
+	layer, err := configLayerForPath(filename, opts.layer)
 	if err != nil {
 		return config, err
 	}
 	if layer != "" {
-		ctx = withConfigLayer(ctx, layer)
+		opts.layer = layer
 	}
 
 	logging.FromContext(ctx).Debug("Loading config", slog.String("filename", filename))
@@ -519,14 +522,14 @@ func load(ctx context.Context, source Source, opts loadOptions, overrides ...Ove
 
 	contents, snapshotted := configSnapshotFromContext(ctx, filename)
 	if !snapshotted {
-		contents, err = readConfigFileForLayer(filename, configLayerFromCtx(ctx))
+		contents, err = readConfigFileForLayer(filename, opts.layer)
 		if err != nil {
 			if os.IsNotExist(err) {
-				sourceIdentity, identityErr := canonicalConfigSourceForLayer(filename, configLayerFromCtx(ctx))
+				sourceIdentity, identityErr := canonicalConfigSourceForLayer(filename, opts.layer)
 				if identityErr != nil {
 					return config, identityErr
 				}
-				config.sourceLayer = configLayerFromCtx(ctx)
+				config.sourceLayer = opts.layer
 				config.bindSourceIdentity(sourceIdentity)
 				config.expectSourceAbsent = true
 			}
@@ -539,13 +542,13 @@ func load(ctx context.Context, source Source, opts loadOptions, overrides ...Ove
 
 	loadedLegacy := isLegacyConfig(contents)
 	if loadedLegacy {
-		config, err = migrateLegacyConfig(ctx, source, filename, contents)
+		config, err = migrateLegacyConfig(ctx, source, filename, contents, opts)
 		if err != nil {
 			return config, err
 		}
 		config.Source = filename
 		if !config.migrationDeferred {
-			persisted, readErr := readConfigFileForLayer(filename, configLayerFromCtx(ctx))
+			persisted, readErr := readConfigFileForLayer(filename, opts.layer)
 			if readErr != nil {
 				return config, readErr
 			}
@@ -563,15 +566,15 @@ func load(ctx context.Context, source Source, opts loadOptions, overrides ...Ove
 		}
 	}
 
-	sourceIdentity, err := canonicalConfigSourceForLayer(filename, configLayerFromCtx(ctx))
+	sourceIdentity, err := canonicalConfigSourceForLayer(filename, opts.layer)
 	if err != nil {
 		return config, err
 	}
-	config.sourceLayer = configLayerFromCtx(ctx)
+	config.sourceLayer = opts.layer
 	config.bindSourceIdentity(sourceIdentity)
 	config.sourceRevision = sha256.Sum256(contents)
 	config.hasSourceRevision = true
-	if migrationPersistenceSuppressed(ctx) {
+	if opts.suppressMigrationPersistence {
 		config.migrationDeferred = true
 	}
 
@@ -606,11 +609,11 @@ func load(ctx context.Context, source Source, opts loadOptions, overrides ...Ove
 	}
 
 	if !config.migrationDeferred && config.hasPlaintextSecrets() {
-		migrated, writeErr := writeConfig(ctx, source, config, opts.write, true)
+		migrated, writeErr := writeConfig(ctx, source, config, opts.forWrite(opts.layer), true)
 		var durabilityErr *configDurabilityError
 		switch {
 		case errors.As(writeErr, &durabilityErr) && migrated > 0:
-			if err := refreshKeychainRuntimeAfterWrite(&config, filename, sourceIdentity, configLayerFromCtx(ctx), store); err != nil {
+			if err := refreshKeychainRuntimeAfterWrite(&config, filename, sourceIdentity, opts.layer, store); err != nil {
 				return config, err
 			}
 			log.Warn("config was replaced but its directory durability barrier failed; old and new keychain generations were retained",
@@ -624,7 +627,7 @@ func load(ctx context.Context, source Source, opts loadOptions, overrides ...Ove
 			log.Info("migrated plaintext credentials into OS keychain",
 				"count", migrated,
 				"file", filename)
-			if err := refreshKeychainRuntimeAfterWrite(&config, filename, sourceIdentity, configLayerFromCtx(ctx), store); err != nil {
+			if err := refreshKeychainRuntimeAfterWrite(&config, filename, sourceIdentity, opts.layer, store); err != nil {
 				return config, err
 			}
 		}
@@ -656,8 +659,10 @@ type configDurabilityError struct {
 func (e *configDurabilityError) Error() string { return e.err.Error() }
 func (e *configDurabilityError) Unwrap() error { return e.err }
 
+// Write persists cfg to the document named by source. Like Load, it reads the
+// ambient config layer once here and passes it down as an explicit option.
 func Write(ctx context.Context, source Source, cfg Config) error {
-	return write(ctx, source, cfg, writeOptions{})
+	return write(ctx, source, cfg, writeOptions{layer: configLayerFromCtx(ctx)})
 }
 
 func write(ctx context.Context, source Source, cfg Config, opts writeOptions) error {
@@ -729,7 +734,7 @@ func writeConfig(ctx context.Context, source Source, cfg Config, opts writeOptio
 	}
 	layer := cfg.sourceLayer
 	if layer == "" {
-		layer = configLayerFromCtx(ctx)
+		layer = opts.layer
 	}
 	layer, err = configLayerForPath(filename, layer)
 	if err != nil {
@@ -1077,7 +1082,7 @@ func configWriteTarget(filename, canonicalSource string, allowSymlink bool) (str
 // bypasses layering entirely and loads that single file.
 // Every load also records the effective context's telemetry target kind.
 func LoadLayered(ctx context.Context, explicitFile string, overrides ...Override) (Config, error) {
-	return loadLayeredTracked(ctx, explicitFile, loadOptions{}, overrides...)
+	return loadLayeredTracked(ctx, explicitFile, loadOptions{layer: configLayerFromCtx(ctx)}, overrides...)
 }
 
 // loadLayeredTracked is LoadLayered with explicit options.
@@ -1145,15 +1150,21 @@ func loadLayered(ctx context.Context, explicitFile string, opts loadOptions, ove
 	// Load and merge in priority order (system → user → local).
 	var merged Config
 	for i, src := range sources {
-		loadCtx := withConfigLayer(ctx, src.Type)
+		// Derive this layer's options from opts per iteration. Every field set
+		// here is a property of this source alone, so inheriting one layer's
+		// value into the next would silently load a layer under another
+		// layer's rules.
+		layerOpts := opts
+		layerOpts.layer = src.Type
 		if hasLegacyLayer && len(sources) > 1 && isLegacyConfig(src.snapshot) {
-			loadCtx = withMigrationPersistenceSuppressed(loadCtx)
-			loadCtx = withInMemoryMigrationWarningCollector(loadCtx, migrationWarnings)
+			layerOpts.suppressMigrationPersistence = true
+			layerOpts.migrationWarnings = migrationWarnings
 		}
+		loadCtx := ctx
 		if src.snapshot != nil {
-			loadCtx = withConfigSnapshot(loadCtx, src.Path, src.snapshot)
+			loadCtx = withConfigSnapshot(ctx, src.Path, src.snapshot)
 		}
-		loaded, err := load(loadCtx, ExplicitConfigFile(src.Path), opts)
+		loaded, err := load(loadCtx, ExplicitConfigFile(src.Path), layerOpts)
 		if err != nil {
 			return Config{}, err
 		}
@@ -1211,7 +1222,7 @@ func loadLayered(ctx context.Context, explicitFile string, opts loadOptions, ove
 // explicitFile is the value of the --config flag; fileType is the value of
 // the --file flag. Both may be empty.
 func LoadForWrite(ctx context.Context, explicitFile, fileType string) (Config, Source, error) {
-	return loadForWrite(ctx, explicitFile, fileType, loadOptions{})
+	return loadForWrite(ctx, explicitFile, fileType, loadOptions{layer: configLayerFromCtx(ctx)})
 }
 
 //nolint:nestif // Legacy-layer preflight and interrupted-migration recovery are one ordered, fail-before-write selection flow.
@@ -1238,7 +1249,8 @@ func loadForWrite(ctx context.Context, explicitFile, fileType string, opts loadO
 		for _, s := range sources {
 			if s.Type == fileType {
 				src := ExplicitConfigFile(s.Path)
-				loadCtx := withConfigLayer(ctx, s.Type)
+				layerOpts := opts
+				layerOpts.layer = s.Type
 				contents, readErr := readConfigSource(s)
 				if readErr != nil {
 					return Config{}, nil, readErr
@@ -1248,7 +1260,7 @@ func loadForWrite(ctx context.Context, explicitFile, fileType string, opts loadO
 				// back to legacy before Load runs, loading the snapshot prevents an
 				// un-preflighted migration; the eventual Write revision check rejects
 				// the intervening change.
-				loadCtx = withConfigSnapshot(loadCtx, s.Path, contents)
+				loadCtx := withConfigSnapshot(ctx, s.Path, contents)
 				targetWasLegacy := isLegacyConfig(contents)
 				if targetWasLegacy && len(sources) > 1 {
 					preflightErr := preflightLayeredSources(sources)
@@ -1269,7 +1281,7 @@ func loadForWrite(ctx context.Context, explicitFile, fileType string, opts loadO
 						}
 					}
 				}
-				cfg, err := load(loadCtx, src, opts)
+				cfg, err := load(loadCtx, src, layerOpts)
 				if err == nil && targetWasLegacy {
 					remaining := remainingLegacySourceSnapshots(sources, fileType, cfg.migrationDeferred)
 					warnIncompleteLayeredMigration(ctx, remaining, nil)
@@ -1366,12 +1378,12 @@ func loadExplicit(ctx context.Context, path string, opts loadOptions, overrides 
 	// migration; constructing an ExplicitConfigFile Source and calling Load
 	// directly is only a path resolver and does not itself grant legacy-keychain
 	// authority.
-	var err error
-	ctx, err = withExplicitLegacyMigrationConsent(ctx, path)
+	consentIdentity, err := canonicalConfigSource(path)
 	if err != nil {
 		return Config{}, err
 	}
-	ctx = withConfigLayer(ctx, "explicit")
+	opts.explicitLegacyMigrationConsent = consentIdentity
+	opts.layer = "explicit"
 	cfg, err := load(ctx, ExplicitConfigFile(path), opts, overrides...)
 	if err != nil {
 		return cfg, err

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -744,8 +744,12 @@ func writeConfig(ctx context.Context, source Source, cfg Config, opts writeOptio
 	if err != nil {
 		return 0, err
 	}
-	if !opts.writeLockCovers() {
-		writeLockPath, err := configLockFile(sourceIdentity, "write")
+	writeLockCovered, err := opts.writeLockCovers(sourceIdentity)
+	if err != nil {
+		return 0, err
+	}
+	if !writeLockCovered {
+		writeLockPath, err := configLockFile(sourceIdentity)
 		if err != nil {
 			return 0, err
 		}
@@ -904,7 +908,10 @@ func configLayerForPath(filename, declared string) (string, error) {
 	return declared, nil
 }
 
-func configLockFile(sourceIdentity, purpose string) (string, error) {
+// configLockFile returns the path of the write lock for one config source.
+// Locks are per-source: two config files never contend, and a lock held for
+// one says nothing about another.
+func configLockFile(sourceIdentity string) (string, error) {
 	stateHome := xdg.StateHome()
 	if testing.Testing() {
 		stateHome = filepath.Join(os.TempDir(), "gcx-test-state")
@@ -927,7 +934,7 @@ func configLockFile(sourceIdentity, purpose string) (string, error) {
 		return "", fmt.Errorf("secure config lock directory: %w", err)
 	}
 	digest := sha256.Sum256([]byte(sourceIdentity))
-	return filepath.Join(lockDir, fmt.Sprintf("%x.%s.lock", digest, purpose)), nil
+	return filepath.Join(lockDir, fmt.Sprintf("%x.write.lock", digest)), nil
 }
 
 func validateConfigWriteSnapshot(filename, sourceIdentity string, cfg *Config) error {

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -520,7 +520,7 @@ func load(ctx context.Context, source Source, opts loadOptions, overrides ...Ove
 	logging.FromContext(ctx).Debug("Loading config", slog.String("filename", filename))
 	config.Source = filename
 
-	contents, snapshotted := configSnapshotFromContext(ctx, filename)
+	contents, snapshotted := opts.snapshotFor(filename)
 	if !snapshotted {
 		contents, err = readConfigFileForLayer(filename, opts.layer)
 		if err != nil {
@@ -1151,20 +1151,20 @@ func loadLayered(ctx context.Context, explicitFile string, opts loadOptions, ove
 	var merged Config
 	for i, src := range sources {
 		// Derive this layer's options from opts per iteration. Every field set
-		// here is a property of this source alone, so inheriting one layer's
-		// value into the next would silently load a layer under another
-		// layer's rules.
+		// here — the layer, the migration-persistence suppression, the frozen
+		// source bytes — is a property of this source alone, so inheriting one
+		// layer's value into the next would silently load a layer under
+		// another layer's rules, or from another layer's content.
 		layerOpts := opts
 		layerOpts.layer = src.Type
 		if hasLegacyLayer && len(sources) > 1 && isLegacyConfig(src.snapshot) {
 			layerOpts.suppressMigrationPersistence = true
 			layerOpts.migrationWarnings = migrationWarnings
 		}
-		loadCtx := ctx
 		if src.snapshot != nil {
-			loadCtx = withConfigSnapshot(ctx, src.Path, src.snapshot)
+			layerOpts = layerOpts.withSourceSnapshot(src.Path, src.snapshot)
 		}
-		loaded, err := load(loadCtx, ExplicitConfigFile(src.Path), layerOpts)
+		loaded, err := load(ctx, ExplicitConfigFile(src.Path), layerOpts)
 		if err != nil {
 			return Config{}, err
 		}
@@ -1260,7 +1260,7 @@ func loadForWrite(ctx context.Context, explicitFile, fileType string, opts loadO
 				// back to legacy before Load runs, loading the snapshot prevents an
 				// un-preflighted migration; the eventual Write revision check rejects
 				// the intervening change.
-				loadCtx := withConfigSnapshot(ctx, s.Path, contents)
+				layerOpts = layerOpts.withSourceSnapshot(s.Path, contents)
 				targetWasLegacy := isLegacyConfig(contents)
 				if targetWasLegacy && len(sources) > 1 {
 					preflightErr := preflightLayeredSources(sources)
@@ -1276,12 +1276,12 @@ func loadForWrite(ctx context.Context, explicitFile, fileType string, opts loadO
 					}
 					for _, preflightSource := range sources {
 						if preflightSource.Type == fileType && preflightSource.snapshot != nil {
-							loadCtx = withConfigSnapshot(loadCtx, s.Path, preflightSource.snapshot) //nolint:fatcontext // One immutable snapshot is attached to the selected layer.
+							layerOpts = layerOpts.withSourceSnapshot(s.Path, preflightSource.snapshot)
 							break
 						}
 					}
 				}
-				cfg, err := load(loadCtx, src, layerOpts)
+				cfg, err := load(ctx, src, layerOpts)
 				if err == nil && targetWasLegacy {
 					remaining := remainingLegacySourceSnapshots(sources, fileType, cfg.migrationDeferred)
 					warnIncompleteLayeredMigration(ctx, remaining, nil)

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -609,7 +609,7 @@ func load(ctx context.Context, source Source, opts loadOptions, overrides ...Ove
 	}
 
 	if !config.migrationDeferred && config.hasPlaintextSecrets() {
-		migrated, writeErr := writeConfig(ctx, source, config, opts.forWrite(opts.layer), true)
+		migrated, writeErr := writeConfig(ctx, source, config, opts.forWrite(), true)
 		var durabilityErr *configDurabilityError
 		switch {
 		case errors.As(writeErr, &durabilityErr) && migrated > 0:

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -400,17 +400,6 @@ type Override func(cfg *Config) error
 
 type Source func() (string, error)
 
-type configWriteLockHeldKey struct{}
-
-func withConfigWriteLockHeld(ctx context.Context) context.Context {
-	return context.WithValue(ctx, configWriteLockHeldKey{}, true)
-}
-
-func configWriteLockIsHeld(ctx context.Context) bool {
-	held, _ := ctx.Value(configWriteLockHeldKey{}).(bool)
-	return held
-}
-
 func ExplicitConfigFile(path string) Source {
 	return func() (string, error) {
 		return path, nil
@@ -505,8 +494,12 @@ func CreateDefaultConfigFile(file string) error {
 	return nil
 }
 
-//nolint:gocyclo,nestif // Loading keeps versioning, legacy migration, source binding, and keychain migration in one ordered trust pipeline.
 func Load(ctx context.Context, source Source, overrides ...Override) (Config, error) {
+	return load(ctx, source, loadOptions{}, overrides...)
+}
+
+//nolint:gocyclo,nestif // Loading keeps versioning, legacy migration, source binding, and keychain migration in one ordered trust pipeline.
+func load(ctx context.Context, source Source, opts loadOptions, overrides ...Override) (Config, error) {
 	config := Config{}
 
 	filename, err := source()
@@ -613,7 +606,7 @@ func Load(ctx context.Context, source Source, overrides ...Override) (Config, er
 	}
 
 	if !config.migrationDeferred && config.hasPlaintextSecrets() {
-		migrated, writeErr := writeConfig(ctx, source, config, true)
+		migrated, writeErr := writeConfig(ctx, source, config, opts.write, true)
 		var durabilityErr *configDurabilityError
 		switch {
 		case errors.As(writeErr, &durabilityErr) && migrated > 0:
@@ -664,7 +657,11 @@ func (e *configDurabilityError) Error() string { return e.err.Error() }
 func (e *configDurabilityError) Unwrap() error { return e.err }
 
 func Write(ctx context.Context, source Source, cfg Config) error {
-	_, err := writeConfig(ctx, source, cfg, false)
+	return write(ctx, source, cfg, writeOptions{})
+}
+
+func write(ctx context.Context, source Source, cfg Config, opts writeOptions) error {
+	_, err := writeConfig(ctx, source, cfg, opts, false)
 	return err
 }
 
@@ -712,7 +709,7 @@ func readConfigFileForLayer(filename, layer string) ([]byte, error) {
 // could be staged (for example while the keychain is unavailable).
 //
 //nolint:gocyclo,nestif // The filesystem rename, durability barrier, and keychain commit/rollback are one atomic write protocol.
-func writeConfig(ctx context.Context, source Source, cfg Config, autoMigrationOnly bool) (int, error) {
+func writeConfig(ctx context.Context, source Source, cfg Config, opts writeOptions, autoMigrationOnly bool) (int, error) {
 	// Config contains pointer-backed stack, cloud, and context maps. Work on an
 	// isolated copy so validation failures and temporary keychain sentinel swaps
 	// cannot mutate the caller's in-memory configuration.
@@ -747,7 +744,7 @@ func writeConfig(ctx context.Context, source Source, cfg Config, autoMigrationOn
 	if err != nil {
 		return 0, err
 	}
-	if !configWriteLockIsHeld(ctx) {
+	if !opts.writeLockCovers() {
 		writeLockPath, err := configLockFile(sourceIdentity, "write")
 		if err != nil {
 			return 0, err
@@ -1073,7 +1070,12 @@ func configWriteTarget(filename, canonicalSource string, allowSymlink bool) (str
 // bypasses layering entirely and loads that single file.
 // Every load also records the effective context's telemetry target kind.
 func LoadLayered(ctx context.Context, explicitFile string, overrides ...Override) (Config, error) {
-	cfg, err := loadLayered(ctx, explicitFile, overrides...)
+	return loadLayeredTracked(ctx, explicitFile, loadOptions{}, overrides...)
+}
+
+// loadLayeredTracked is LoadLayered with explicit options.
+func loadLayeredTracked(ctx context.Context, explicitFile string, opts loadOptions, overrides ...Override) (Config, error) {
+	cfg, err := loadLayered(ctx, explicitFile, opts, overrides...)
 	// Capture even when err is non-nil: the validation and credential-binding
 	// override paths below return a fully merged config, so the target is known
 	// even though the command will fail. Gating on success attributed those
@@ -1092,15 +1094,15 @@ func LoadLayered(ctx context.Context, explicitFile string, overrides ...Override
 	return cfg, err
 }
 
-func loadLayered(ctx context.Context, explicitFile string, overrides ...Override) (Config, error) {
+func loadLayered(ctx context.Context, explicitFile string, opts loadOptions, overrides ...Override) (Config, error) {
 	// --config flag bypasses layering.
 	if explicitFile != "" {
-		return loadExplicit(ctx, explicitFile, overrides...)
+		return loadExplicit(ctx, explicitFile, opts, overrides...)
 	}
 
 	// GCX_CONFIG env var also bypasses layering (preserving existing behavior).
 	if envPath := os.Getenv(ConfigFileEnvVar); envPath != "" {
-		return loadExplicit(ctx, envPath, overrides...)
+		return loadExplicit(ctx, envPath, opts, overrides...)
 	}
 
 	// Warn when configs exist in both $HOME/.config and the platform XDG dir.
@@ -1116,7 +1118,7 @@ func loadLayered(ctx context.Context, explicitFile string, overrides ...Override
 
 	// No config files — auto-create user config (current behavior).
 	if len(sources) == 0 {
-		cfg, err := Load(ctx, StandardLocation(), overrides...)
+		cfg, err := load(ctx, StandardLocation(), opts, overrides...)
 		if err != nil {
 			return cfg, err
 		}
@@ -1144,7 +1146,7 @@ func loadLayered(ctx context.Context, explicitFile string, overrides ...Override
 		if src.snapshot != nil {
 			loadCtx = withConfigSnapshot(loadCtx, src.Path, src.snapshot)
 		}
-		loaded, err := Load(loadCtx, ExplicitConfigFile(src.Path))
+		loaded, err := load(loadCtx, ExplicitConfigFile(src.Path), opts)
 		if err != nil {
 			return Config{}, err
 		}
@@ -1201,12 +1203,15 @@ func loadLayered(ctx context.Context, explicitFile string, overrides ...Override
 //
 // explicitFile is the value of the --config flag; fileType is the value of
 // the --file flag. Both may be empty.
-//
-//nolint:nestif // Legacy-layer preflight and interrupted-migration recovery are one ordered, fail-before-write selection flow.
 func LoadForWrite(ctx context.Context, explicitFile, fileType string) (Config, Source, error) {
+	return loadForWrite(ctx, explicitFile, fileType, loadOptions{})
+}
+
+//nolint:nestif // Legacy-layer preflight and interrupted-migration recovery are one ordered, fail-before-write selection flow.
+func loadForWrite(ctx context.Context, explicitFile, fileType string, opts loadOptions) (Config, Source, error) {
 	if explicitFile != "" {
 		src := ExplicitConfigFile(explicitFile)
-		cfg, err := loadExplicit(ctx, explicitFile)
+		cfg, err := loadExplicit(ctx, explicitFile, opts)
 		return cfg, src, err
 	}
 
@@ -1257,7 +1262,7 @@ func LoadForWrite(ctx context.Context, explicitFile, fileType string) (Config, S
 						}
 					}
 				}
-				cfg, err := Load(loadCtx, src)
+				cfg, err := load(loadCtx, src, opts)
 				if err == nil && targetWasLegacy {
 					remaining := remainingLegacySourceSnapshots(sources, fileType, cfg.migrationDeferred)
 					warnIncompleteLayeredMigration(ctx, remaining, nil)
@@ -1269,13 +1274,13 @@ func LoadForWrite(ctx context.Context, explicitFile, fileType string) (Config, S
 		// LoadLayered only ever created the user layer, so --file user creates and
 		// returns it; other layer types have nothing to auto-create and still error.
 		if fileType == "user" && len(sources) == 0 {
-			cfg, err := Load(ctx, StandardLocation())
+			cfg, err := load(ctx, StandardLocation(), opts)
 			return cfg, StandardLocation(), err
 		}
 		return Config{}, nil, fmt.Errorf("no %s config file found", fileType)
 	}
 
-	layered, err := LoadLayered(ctx, "")
+	layered, err := loadLayeredTracked(ctx, "", opts)
 	if err != nil {
 		return Config{}, nil, err
 	}
@@ -1348,7 +1353,7 @@ func warnIncompleteLayeredMigration(ctx context.Context, remaining []ConfigSourc
 }
 
 // loadExplicit loads a single explicit config file, bypassing layered discovery.
-func loadExplicit(ctx context.Context, path string, overrides ...Override) (Config, error) {
+func loadExplicit(ctx context.Context, path string, opts loadOptions, overrides ...Override) (Config, error) {
 	// Reaching this function means the caller explicitly selected one document
 	// through --config or GCX_CONFIG. Preserve that provenance through legacy
 	// migration; constructing an ExplicitConfigFile Source and calling Load
@@ -1360,7 +1365,7 @@ func loadExplicit(ctx context.Context, path string, overrides ...Override) (Conf
 		return Config{}, err
 	}
 	ctx = withConfigLayer(ctx, "explicit")
-	cfg, err := Load(ctx, ExplicitConfigFile(path), overrides...)
+	cfg, err := load(ctx, ExplicitConfigFile(path), opts, overrides...)
 	if err != nil {
 		return cfg, err
 	}

--- a/internal/config/login_mutation.go
+++ b/internal/config/login_mutation.go
@@ -105,11 +105,10 @@ func LoadLoginMutationGuarded(ctx context.Context, source Source, guard LoginMut
 		layer:                        configLayerFromCtx(ctx),
 		suppressMigrationPersistence: true,
 	}
-	loadCtx := ctx
 	if snapshot != nil {
-		loadCtx = withConfigSnapshot(ctx, guard.sourcePath, snapshot)
+		loadOpts = loadOpts.withSourceSnapshot(guard.sourcePath, snapshot)
 	}
-	cfg, loadErr := load(loadCtx, source, loadOpts)
+	cfg, loadErr := load(ctx, source, loadOpts)
 	if loadErr != nil && !errors.Is(loadErr, os.ErrNotExist) {
 		return cfg, loadErr
 	}

--- a/internal/config/login_mutation.go
+++ b/internal/config/login_mutation.go
@@ -87,7 +87,7 @@ func (config *Config) NewLoginMutationGuard(contextName string, intent LoginMuta
 // CAS then protects the selected owner after this function returns.
 func LoadLoginMutationGuarded(ctx context.Context, source Source, guard LoginMutationGuard) (Config, error) {
 	if !guard.enabled {
-		return load(ctx, source, loadOptions{})
+		return load(ctx, source, loadOptions{layer: configLayerFromCtx(ctx)})
 	}
 
 	snapshot, err := guard.currentSelectedSourceSnapshot()
@@ -101,11 +101,15 @@ func LoadLoginMutationGuarded(ctx context.Context, source Source, guard LoginMut
 		}
 	}
 
-	loadCtx := withMigrationPersistenceSuppressed(ctx)
-	if snapshot != nil {
-		loadCtx = withConfigSnapshot(loadCtx, guard.sourcePath, snapshot)
+	loadOpts := loadOptions{
+		layer:                        configLayerFromCtx(ctx),
+		suppressMigrationPersistence: true,
 	}
-	cfg, loadErr := load(loadCtx, source, loadOptions{})
+	loadCtx := ctx
+	if snapshot != nil {
+		loadCtx = withConfigSnapshot(ctx, guard.sourcePath, snapshot)
+	}
+	cfg, loadErr := load(loadCtx, source, loadOpts)
 	if loadErr != nil && !errors.Is(loadErr, os.ErrNotExist) {
 		return cfg, loadErr
 	}

--- a/internal/config/login_mutation.go
+++ b/internal/config/login_mutation.go
@@ -87,7 +87,7 @@ func (config *Config) NewLoginMutationGuard(contextName string, intent LoginMuta
 // CAS then protects the selected owner after this function returns.
 func LoadLoginMutationGuarded(ctx context.Context, source Source, guard LoginMutationGuard) (Config, error) {
 	if !guard.enabled {
-		return Load(ctx, source)
+		return load(ctx, source, loadOptions{})
 	}
 
 	snapshot, err := guard.currentSelectedSourceSnapshot()
@@ -105,7 +105,7 @@ func LoadLoginMutationGuarded(ctx context.Context, source Source, guard LoginMut
 	if snapshot != nil {
 		loadCtx = withConfigSnapshot(loadCtx, guard.sourcePath, snapshot)
 	}
-	cfg, loadErr := Load(loadCtx, source)
+	cfg, loadErr := load(loadCtx, source, loadOptions{})
 	if loadErr != nil && !errors.Is(loadErr, os.ErrNotExist) {
 		return cfg, loadErr
 	}

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -669,9 +669,9 @@ func verifyLegacyConversion(input, baseline *legacyConfig, cfg *Config, secrets 
 // legacy per-context entries keep the backup restorable). Every persistence
 // failure degrades to an in-memory migration with a warning, and the next
 // load retries.
-func migrateLegacyConfig(ctx context.Context, source Source, filename string, contents []byte) (Config, error) {
+func migrateLegacyConfig(ctx context.Context, source Source, filename string, contents []byte, opts loadOptions) (Config, error) {
 	log := logging.FromContext(ctx)
-	migrationPath, err := canonicalConfigSourceForLayer(filename, configLayerFromCtx(ctx))
+	migrationPath, err := canonicalConfigSourceForLayer(filename, opts.layer)
 	if err != nil {
 		return Config{}, err
 	}
@@ -679,7 +679,7 @@ func migrateLegacyConfig(ctx context.Context, source Source, filename string, co
 	// Serialize migration for this source. The initial legacy-shape check happens
 	// before entering this function, so reread under the lock: another process may
 	// already have completed the migration while this one was waiting.
-	canPersist := !migrationPersistenceSuppressed(ctx)
+	canPersist := !opts.suppressMigrationPersistence
 	var lockErr error
 	deferredReason := ""
 	if canPersist {
@@ -699,9 +699,9 @@ func migrateLegacyConfig(ctx context.Context, source Source, filename string, co
 	}
 	if !canPersist {
 		reason := layeredMigrationReadOnlyReason
-		if !migrationPersistenceSuppressed(ctx) && lockErr == nil {
+		if !opts.suppressMigrationPersistence && lockErr == nil {
 			reason = "timed out"
-		} else if !migrationPersistenceSuppressed(ctx) && lockErr != nil {
+		} else if !opts.suppressMigrationPersistence && lockErr != nil {
 			reason = lockErr.Error()
 		}
 		deferredReason = reason
@@ -710,7 +710,7 @@ func migrateLegacyConfig(ctx context.Context, source Source, filename string, co
 	}
 
 	if canPersist {
-		freshContents, err := readConfigSource(ConfigSource{Path: filename, Type: configLayerFromCtx(ctx)})
+		freshContents, err := readConfigSource(ConfigSource{Path: filename, Type: opts.layer})
 		if err != nil {
 			return Config{}, err
 		}
@@ -739,11 +739,11 @@ func migrateLegacyConfig(ctx context.Context, source Source, filename string, co
 	}
 
 	store := newLazyStore(keychainStoreFn)
-	layerType := configLayerFromCtx(ctx)
+	layerType := opts.layer
 	// Auto-discovered repository, system, and arbitrary explicit configs cannot
 	// read predictable per-user legacy accounts. Compatibility is limited to the
 	// canonical discovered user config with secure write permissions.
-	allowLegacyGet := trustedLegacyKeychainSource(ctx, layerType, filename)
+	allowLegacyGet := trustedLegacyKeychainSource(opts.explicitLegacyMigrationConsent, layerType, filename)
 	secrets, transientLegacyFailure, err := collectLegacySecrets(&lc, store, allowLegacyGet)
 	if err != nil {
 		return Config{}, err
@@ -786,7 +786,7 @@ func migrateLegacyConfig(ctx context.Context, source Source, filename string, co
 	}
 
 	if !backupOK {
-		warnInMemoryMigration(ctx, filename, deferredReason)
+		warnInMemoryMigration(ctx, opts.migrationWarnings, filename, deferredReason)
 		return *cfg, nil
 	}
 
@@ -802,7 +802,7 @@ func migrateLegacyConfig(ctx context.Context, source Source, filename string, co
 	cfg.hasSourceRevision = true
 	// The migration write runs under the flock this function took above for
 	// migrationPath, so it must not try to acquire that lock a second time.
-	if err := write(ctx, source, *cfg, writeOptions{writeLockHeldFor: migrationPath}); err != nil {
+	if err := write(ctx, source, *cfg, writeOptions{layer: layerType, writeLockHeldFor: migrationPath}); err != nil {
 		var durabilityErr *configDurabilityError
 		if errors.As(err, &durabilityErr) {
 			log.Warn("migrated config was replaced but its directory durability barrier failed; old and new keychain generations were retained",
@@ -812,7 +812,7 @@ func migrateLegacyConfig(ctx context.Context, source Source, filename string, co
 			return *cfg, nil
 		}
 		cfg.migrationDeferred = true
-		warnInMemoryMigration(ctx, filename, err.Error())
+		warnInMemoryMigration(ctx, opts.migrationWarnings, filename, err.Error())
 		return *cfg, nil
 	}
 
@@ -824,8 +824,8 @@ func migrateLegacyConfig(ctx context.Context, source Source, filename string, co
 	return *cfg, nil
 }
 
-func warnInMemoryMigration(ctx context.Context, filename, reason string) {
-	if collector := inMemoryMigrationWarningCollectorFromContext(ctx); collector != nil {
+func warnInMemoryMigration(ctx context.Context, collector *inMemoryMigrationWarningCollector, filename, reason string) {
+	if collector != nil {
 		collector.add(filename, reason)
 		return
 	}
@@ -848,14 +848,21 @@ func prepareLegacyBackup(canPersist bool, deferredReason, filename string, conte
 	return backupOK, deferredReason
 }
 
-func trustedLegacyKeychainSource(ctx context.Context, layerType, filename string) bool {
+// trustedLegacyKeychainSource reports whether a legacy migration of filename
+// may read predictable per-user legacy keychain accounts.
+//
+// consentedIdentity is the canonical identity the high-level explicit loader
+// minted for the document the user selected through --config or GCX_CONFIG;
+// it is empty when no such consent was given. secureLegacyConfigIdentity
+// returns a non-empty canonical identity only together with ok, so an empty
+// consent can never match a verified target.
+func trustedLegacyKeychainSource(consentedIdentity, layerType, filename string) bool {
 	if layerType == "explicit" {
 		canonical, ok := secureLegacyConfigIdentity(filename)
 		if !ok {
 			return false
 		}
-		consent, consented := ctx.Value(explicitLegacyMigrationConsentKey{}).(explicitLegacyMigrationConsent)
-		return consented && consent.sourceIdentity == canonical
+		return consentedIdentity != "" && consentedIdentity == canonical
 	}
 	return layerType == "user" && trustedDiscoveredUserLegacySource(filename)
 }
@@ -944,17 +951,11 @@ func migrationFailedError(summary string, err error, filename string) error {
 }
 
 // configLayerKey carries the config layer type ("system", "user", "local")
-// through context, set by LoadLayered/LoadForWrite when loading a discovered
-// layer. Migration reads it to qualify cloud entry names per layer.
+// through context. It survives only as the transport for the exported
+// ContextWithConfigSource: every load and write inside this package takes the
+// layer as an explicit option, and the exported entry points translate this
+// ambient value into that option exactly once.
 type configLayerKey struct{}
-
-type explicitLegacyMigrationConsentKey struct{}
-
-type explicitLegacyMigrationConsent struct {
-	sourceIdentity string
-}
-
-type migrationPersistenceKey struct{}
 
 const layeredMigrationReadOnlyReason = "layered migration is read-only; migrate each layer explicitly"
 
@@ -995,8 +996,6 @@ func (c *inMemoryMigrationWarningCollector) exceptionalWarnings() []inMemoryMigr
 	return warnings
 }
 
-type migrationWarningCollectorKey struct{}
-
 type configSnapshotKey struct{}
 
 type configSnapshot struct {
@@ -1004,51 +1003,17 @@ type configSnapshot struct {
 	contents []byte
 }
 
-// withExplicitLegacyMigrationConsent mints path-bound consent only for the
-// high-level explicit loader used by --config and GCX_CONFIG. The generic
-// ExplicitConfigFile Source remains a path resolver and cannot authorize reads
-// from predictable legacy keychain accounts.
-func withExplicitLegacyMigrationConsent(ctx context.Context, path string) (context.Context, error) {
-	identity, err := canonicalConfigSource(path)
-	if err != nil {
-		return ctx, err
-	}
-	return context.WithValue(ctx, explicitLegacyMigrationConsentKey{}, explicitLegacyMigrationConsent{sourceIdentity: identity}), nil
-}
-
-func withConfigLayer(ctx context.Context, layer string) context.Context {
-	return context.WithValue(ctx, configLayerKey{}, layer)
-}
-
 // ContextWithConfigSource preserves auto-discovery provenance across raw
 // mutation helpers that pass a Source separately. In particular, local
 // repository sources remain no-symlink even when a provider reloads them by
 // explicit path before writing.
 func ContextWithConfigSource(ctx context.Context, source ConfigSource) context.Context {
-	return withConfigLayer(ctx, source.Type)
+	return context.WithValue(ctx, configLayerKey{}, source.Type)
 }
 
 func configLayerFromCtx(ctx context.Context) string {
 	layer, _ := ctx.Value(configLayerKey{}).(string)
 	return layer
-}
-
-func withMigrationPersistenceSuppressed(ctx context.Context) context.Context {
-	return context.WithValue(ctx, migrationPersistenceKey{}, true)
-}
-
-func migrationPersistenceSuppressed(ctx context.Context) bool {
-	suppressed, _ := ctx.Value(migrationPersistenceKey{}).(bool)
-	return suppressed
-}
-
-func withInMemoryMigrationWarningCollector(ctx context.Context, collector *inMemoryMigrationWarningCollector) context.Context {
-	return context.WithValue(ctx, migrationWarningCollectorKey{}, collector)
-}
-
-func inMemoryMigrationWarningCollectorFromContext(ctx context.Context) *inMemoryMigrationWarningCollector {
-	collector, _ := ctx.Value(migrationWarningCollectorKey{}).(*inMemoryMigrationWarningCollector)
-	return collector
 }
 
 func withConfigSnapshot(ctx context.Context, path string, contents []byte) context.Context {

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -714,7 +714,7 @@ func migrateLegacyConfig(ctx context.Context, source Source, filename string, co
 		if err != nil {
 			return Config{}, err
 		}
-		if snapshot, ok := configSnapshotFromContext(ctx, filename); ok && !bytes.Equal(freshContents, snapshot) {
+		if snapshot, ok := opts.snapshotFor(filename); ok && !bytes.Equal(freshContents, snapshot) {
 			return Config{}, fmt.Errorf("config %s changed after migration preflight; no config files or credentials were changed", filename)
 		}
 		contents = freshContents
@@ -952,9 +952,16 @@ func migrationFailedError(summary string, err error, filename string) error {
 
 // configLayerKey carries the config layer type ("system", "user", "local")
 // through context. It survives only as the transport for the exported
-// ContextWithConfigSource: every load and write inside this package takes the
-// layer as an explicit option, and the exported entry points translate this
-// ambient value into that option exactly once.
+// ContextWithConfigSource, whose out-of-package callers reach this package
+// through Load, Write, LoadLayered, and LoadForWrite — entry points with no
+// options parameter to pass a layer through, and whose signatures are frozen.
+//
+// Every load and write inside this package takes the layer as an explicit
+// option instead. The eight places that read this value
+// (Load, Write, LoadLayered, LoadForWrite, LoadLoginMutationGuarded twice,
+// persistLoad in rest.go, and the cloud login write) are deliberate: they are
+// the package boundary, and each translates the ambient value into an option
+// exactly once so that nothing below them inherits a layer invisibly.
 type configLayerKey struct{}
 
 const layeredMigrationReadOnlyReason = "layered migration is read-only; migrate each layer explicitly"
@@ -996,13 +1003,6 @@ func (c *inMemoryMigrationWarningCollector) exceptionalWarnings() []inMemoryMigr
 	return warnings
 }
 
-type configSnapshotKey struct{}
-
-type configSnapshot struct {
-	path     string
-	contents []byte
-}
-
 // ContextWithConfigSource preserves auto-discovery provenance across raw
 // mutation helpers that pass a Source separately. In particular, local
 // repository sources remain no-symlink even when a provider reloads them by
@@ -1014,20 +1014,6 @@ func ContextWithConfigSource(ctx context.Context, source ConfigSource) context.C
 func configLayerFromCtx(ctx context.Context) string {
 	layer, _ := ctx.Value(configLayerKey{}).(string)
 	return layer
-}
-
-func withConfigSnapshot(ctx context.Context, path string, contents []byte) context.Context {
-	return context.WithValue(ctx, configSnapshotKey{}, configSnapshot{
-		path: path, contents: bytes.Clone(contents),
-	})
-}
-
-func configSnapshotFromContext(ctx context.Context, path string) ([]byte, bool) {
-	snapshot, ok := ctx.Value(configSnapshotKey{}).(configSnapshot)
-	if !ok || snapshot.path != path {
-		return nil, false
-	}
-	return bytes.Clone(snapshot.contents), true
 }
 
 // writeLegacyBackup writes an exact byte-for-byte copy next to the logical

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -953,15 +953,16 @@ func migrationFailedError(summary string, err error, filename string) error {
 // configLayerKey carries the config layer type ("system", "user", "local")
 // through context. It survives only as the transport for the exported
 // ContextWithConfigSource, whose out-of-package callers reach this package
-// through Load, Write, LoadLayered, and LoadForWrite — entry points with no
-// options parameter to pass a layer through, and whose signatures are frozen.
+// through Load, Write, LoadLayered, LoadForWrite, and
+// LoadLoginMutationGuarded — entry points with no options parameter to pass a
+// layer through, and whose signatures are frozen.
 //
 // Every load and write inside this package takes the layer as an explicit
-// option instead. The eight places that read this value
-// (Load, Write, LoadLayered, LoadForWrite, LoadLoginMutationGuarded twice,
-// persistLoad in rest.go, and the cloud login write) are deliberate: they are
-// the package boundary, and each translates the ambient value into an option
-// exactly once so that nothing below them inherits a layer invisibly.
+// option instead. The reads of this value that remain are deliberate, and all
+// of them sit at that package boundary: each entry point translates the
+// ambient value into an option exactly once, so nothing below it inherits a
+// layer invisibly. Adding a read anywhere other than an entry point
+// reintroduces the implicit propagation this option was created to remove.
 type configLayerKey struct{}
 
 const layeredMigrationReadOnlyReason = "layered migration is read-only; migrate each layer explicitly"

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -683,7 +683,7 @@ func migrateLegacyConfig(ctx context.Context, source Source, filename string, co
 	var lockErr error
 	deferredReason := ""
 	if canPersist {
-		lockPath, err := configLockFile(migrationPath, "write")
+		lockPath, err := configLockFile(migrationPath)
 		if err != nil {
 			return Config{}, err
 		}
@@ -802,7 +802,7 @@ func migrateLegacyConfig(ctx context.Context, source Source, filename string, co
 	cfg.hasSourceRevision = true
 	// The migration write runs under the flock this function took above for
 	// migrationPath, so it must not try to acquire that lock a second time.
-	if err := write(ctx, source, *cfg, writeOptions{writeLockHeld: true}); err != nil {
+	if err := write(ctx, source, *cfg, writeOptions{writeLockHeldFor: migrationPath}); err != nil {
 		var durabilityErr *configDurabilityError
 		if errors.As(err, &durabilityErr) {
 			log.Warn("migrated config was replaced but its directory durability barrier failed; old and new keychain generations were retained",

--- a/internal/config/migrate.go
+++ b/internal/config/migrate.go
@@ -800,7 +800,9 @@ func migrateLegacyConfig(ctx context.Context, source Source, filename string, co
 	cfg.bindSourceIdentity(migrationPath)
 	cfg.sourceRevision = sha256.Sum256(contents)
 	cfg.hasSourceRevision = true
-	if err := Write(withConfigWriteLockHeld(ctx), source, *cfg); err != nil {
+	// The migration write runs under the flock this function took above for
+	// migrationPath, so it must not try to acquire that lock a second time.
+	if err := write(ctx, source, *cfg, writeOptions{writeLockHeld: true}); err != nil {
 		var durabilityErr *configDurabilityError
 		if errors.As(err, &durabilityErr) {
 			log.Warn("migrated config was replaced but its directory durability barrier failed; old and new keychain generations were retained",

--- a/internal/config/migrate_internal_test.go
+++ b/internal/config/migrate_internal_test.go
@@ -249,7 +249,7 @@ func TestMigrateLegacyConfig(t *testing.T) {
 	withFakeKeychain(t)
 	path := writeTestConfig(t, legacyFullConfig)
 
-	cfg, err := Load(withConfigLayer(context.Background(), "user"), ExplicitConfigFile(path))
+	cfg, err := load(context.Background(), ExplicitConfigFile(path), loadOptions{layer: "user"})
 	require.NoError(t, err)
 
 	// Contexts became thin references.
@@ -325,7 +325,7 @@ contexts:
 current-context: alpha
 `)
 
-	cfg, err := Load(withConfigLayer(context.Background(), "user"), ExplicitConfigFile(path))
+	cfg, err := load(context.Background(), ExplicitConfigFile(path), loadOptions{layer: "user"})
 	require.NoError(t, err)
 
 	// Two distinct tokens against the same host: the first (sorted) context
@@ -354,7 +354,7 @@ contexts:
 current-context: dev
 `)
 
-	cfg, err := Load(withConfigLayer(context.Background(), "user"), ExplicitConfigFile(path))
+	cfg, err := load(context.Background(), ExplicitConfigFile(path), loadOptions{layer: "user"})
 	require.NoError(t, err)
 
 	// In-memory view holds resolved plaintext.
@@ -432,7 +432,7 @@ current-context: prod
 			withFakeKeychain(t)
 			path := writeTrustedUserTestConfig(t, test.legacyYAML)
 
-			cfg, err := Load(withConfigLayer(t.Context(), "user"), ExplicitConfigFile(path))
+			cfg, err := load(t.Context(), ExplicitConfigFile(path), loadOptions{layer: "user"})
 			require.NoError(t, err)
 			ctx := cfg.Contexts["prod"]
 			require.NotNil(t, ctx)
@@ -472,7 +472,7 @@ current-context: attacker
 
 	before, err := os.ReadFile(path)
 	require.NoError(t, err)
-	_, err = Load(withConfigLayer(context.Background(), "user"), ExplicitConfigFile(path))
+	_, err = load(context.Background(), ExplicitConfigFile(path), loadOptions{layer: "user"})
 	require.ErrorContains(t, err, "invalid legacy keychain reference")
 	assert.Empty(t, store.gets, "legacy YAML must not select another owner or field's keychain account")
 
@@ -624,7 +624,7 @@ contexts:
 current-context: prod
 `)
 
-	_, err := Load(withConfigLayer(t.Context(), "system"), ExplicitConfigFile(path))
+	_, err := load(t.Context(), ExplicitConfigFile(path), loadOptions{layer: "system"})
 	require.ErrorContains(t, err, "untrusted config source")
 	assert.Empty(t, store.gets)
 }
@@ -643,7 +643,7 @@ current-context: prod
 	before, err := os.ReadFile(path)
 	require.NoError(t, err)
 
-	_, err = Load(withConfigLayer(context.Background(), "local"), ExplicitConfigFile(path))
+	_, err = load(context.Background(), ExplicitConfigFile(path), loadOptions{layer: "local"})
 	require.ErrorContains(t, err, "untrusted config source")
 	assert.Empty(t, store.gets)
 	assert.Equal(t, "user-secret", store.entries["prod:grafana-token"])
@@ -668,7 +668,7 @@ current-context: prod
 	link := filepath.Join(t.TempDir(), "config.yaml")
 	require.NoError(t, os.Symlink(target, link))
 
-	_, err := Load(withConfigLayer(context.Background(), "user"), ExplicitConfigFile(link))
+	_, err := load(context.Background(), ExplicitConfigFile(link), loadOptions{layer: "user"})
 	require.ErrorContains(t, err, "untrusted config source")
 	assert.Empty(t, store.gets)
 	assert.Equal(t, "user-secret", store.entries["prod:grafana-token"])
@@ -686,7 +686,7 @@ contexts:
 current-context: prod
 `)
 
-	cfg, err := Load(withConfigLayer(context.Background(), "local"), ExplicitConfigFile(path))
+	cfg, err := load(context.Background(), ExplicitConfigFile(path), loadOptions{layer: "local"})
 	require.NoError(t, err)
 	assert.Equal(t, "repo-token", cfg.Contexts["prod"].Grafana.APIToken)
 	assert.Equal(t, "user-secret", store.entries["prod:grafana-token"])
@@ -743,8 +743,8 @@ current-context: dev
 	path := writeTrustedUserTestConfig(t, legacy)
 
 	var warnings bytes.Buffer
-	ctx := ContextWithWarningWriter(withConfigLayer(context.Background(), "user"), &warnings)
-	cfg, err := Load(ctx, ExplicitConfigFile(path))
+	ctx := ContextWithWarningWriter(context.Background(), &warnings)
+	cfg, err := load(ctx, ExplicitConfigFile(path), loadOptions{layer: "user"})
 	require.NoError(t, err)
 
 	assert.Equal(t, "plaintext-secret", cfg.Contexts["dev"].Grafana.APIToken)
@@ -764,7 +764,7 @@ current-context: dev
 	// keychain is available again.
 	store.getErr = nil
 	store.entries["dev:cloud-token"] = "recovered"
-	recovered, err := Load(withConfigLayer(context.Background(), "user"), ExplicitConfigFile(path))
+	recovered, err := load(context.Background(), ExplicitConfigFile(path), loadOptions{layer: "user"})
 	require.NoError(t, err)
 	assert.Equal(t, "recovered", recovered.Contexts["dev"].CloudEntry.Token)
 	rewritten, err := os.ReadFile(path)
@@ -984,7 +984,7 @@ contexts:
 
 	var merged Config
 	for i, src := range sources {
-		loaded, err := Load(withConfigLayer(context.Background(), src.Type), ExplicitConfigFile(src.Path))
+		loaded, err := load(context.Background(), ExplicitConfigFile(src.Path), loadOptions{layer: src.Type})
 		require.NoError(t, err)
 		if i == 0 {
 			merged = loaded

--- a/internal/config/migrate_preflight_internal_test.go
+++ b/internal/config/migrate_preflight_internal_test.go
@@ -201,6 +201,59 @@ contexts:
 	require.ErrorIs(t, statErr, os.ErrNotExist)
 }
 
+// TestLoadLayeredDerivesPerLayerOptionsIndependently pins the per-iteration
+// option derivation in loadLayered. Migration-persistence suppression and the
+// shared warning collector are set only for the layers that are actually
+// legacy, so a current-format layer loaded beside a legacy one must not
+// inherit them. Reusing one option value across iterations compiles and passes
+// the warning-consolidation tests, but silently marks the current-format layer
+// migrationDeferred and skips its plaintext-credential migration.
+func TestLoadLayeredDerivesPerLayerOptionsIndependently(t *testing.T) {
+	withFakeKeychain(t)
+	fixture := newLayeredMigrationFixture(t)
+	// Disjoint entry names: a legacy layer overlapping a current-format one is
+	// rejected by preflight before the loop under test runs.
+	writeLayeredMigrationFixture(t, fixture.user, `
+contexts:
+  legacyonly:
+    grafana:
+      server: https://legacy.example
+current-context: legacyonly
+`)
+	writeLayeredMigrationFixture(t, fixture.local, `version: 1
+stacks:
+  currentonly:
+    grafana:
+      server: https://current.example
+      token: plaintext-secret
+contexts:
+  currentonly:
+    stack: currentonly
+`)
+
+	var warnings bytes.Buffer
+	ctx := ContextWithWarningWriter(t.Context(), &warnings)
+	cfg, err := LoadLayered(ctx, "")
+	require.NoError(t, err)
+	require.NotNil(t, cfg.Contexts["legacyonly"])
+	require.NotNil(t, cfg.Contexts["currentonly"])
+
+	// The legacy layer was loaded with persistence suppressed: its file is
+	// unchanged and no backup was taken.
+	userOnDisk, readErr := os.ReadFile(fixture.user)
+	require.NoError(t, readErr)
+	assert.True(t, isLegacyConfig(userOnDisk))
+	_, statErr := os.Stat(fixture.user + legacyBackupSuffix)
+	require.ErrorIs(t, statErr, os.ErrNotExist)
+
+	// The current-format layer beside it did not inherit that suppression: its
+	// plaintext credential was migrated into the keychain in place.
+	localOnDisk, readErr := os.ReadFile(fixture.local)
+	require.NoError(t, readErr)
+	assert.Contains(t, string(localOnDisk), "keychain:gcx:v2:")
+	assert.NotContains(t, string(localOnDisk), "plaintext-secret")
+}
+
 func TestLoadLayeredConsolidatesLegacyMigrationWarning(t *testing.T) {
 	withFakeKeychain(t)
 	fixture := newLayeredMigrationFixture(t)

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -112,12 +112,12 @@ func (o loadOptions) snapshotFor(path string) ([]byte, bool) {
 // write the load performs on the caller's behalf. The source snapshot is not
 // among them: it says what a load must read, and no write consults it.
 //
-// It reads o.layer rather than
-// taking a parameter because writeConfig only consults writeOptions.layer when
-// the config being written carries no source layer of its own (cfg.sourceLayer
-// == ""), and a config produced by load always carries one: load's sole
-// caller of forWrite runs after load has set config.sourceLayer, so that
-// field wins and o.layer is never consulted for the layer decision itself.
+// It reads o.layer rather than taking a parameter because writeConfig only
+// consults writeOptions.layer when the config being written carries no source
+// layer of its own (cfg.sourceLayer == ""), and a config produced by load
+// always carries one: load's sole caller of forWrite runs after load has set
+// config.sourceLayer, so that field wins and o.layer is never consulted for
+// the layer decision itself.
 func (o loadOptions) forWrite() writeOptions {
 	return writeOptions{
 		layer:            o.layer,

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -1,6 +1,9 @@
 package config
 
-import "fmt"
+import (
+	"bytes"
+	"fmt"
+)
 
 // This file holds the explicit parameter structs for the config load and write
 // paths. Historically these parameters travelled as context values, which made
@@ -57,10 +60,59 @@ type loadOptions struct {
 	// behalf: loading migrates plaintext credentials into the keychain and
 	// persists legacy config migrations.
 	writeLockHeldFor string
+
+	// sourceSnapshot, when set, freezes the bytes the load must read for one
+	// specific config path, instead of reading that path from disk. A caller
+	// that already inspected a config document — layered preflight, the
+	// targeted --file write selection, the login mutation guard — hands the
+	// exact bytes it approved to the load, so a rewrite between the inspection
+	// and the load cannot make the load act on different content than the one
+	// that was preflighted.
+	//
+	// It is a pointer so that "no snapshot" stays distinguishable from "a
+	// snapshot of an empty file", and it is per-target: a load derived from
+	// another load's options must not silently reuse its snapshot. Set it with
+	// withSourceSnapshot and read it with snapshotFor, never directly — both
+	// clone, and snapshotFor enforces the path binding below.
+	sourceSnapshot *configSnapshot
+}
+
+// configSnapshot is a frozen copy of one config document, bound to the path it
+// was taken from. The binding is the point: bytes alone cannot say which file
+// they came from, and a snapshot of one config satisfying the load of another
+// would feed a load content it never preflighted.
+type configSnapshot struct {
+	path     string
+	contents []byte
+}
+
+// withSourceSnapshot returns a copy of the options that reads path from the
+// given bytes rather than from disk. The contents are cloned so a later
+// mutation of the caller's buffer cannot change what the load sees.
+func (o loadOptions) withSourceSnapshot(path string, contents []byte) loadOptions {
+	o.sourceSnapshot = &configSnapshot{path: path, contents: bytes.Clone(contents)}
+	return o
+}
+
+// snapshotFor returns the frozen bytes for path, if these options carry a
+// snapshot taken from exactly that path.
+//
+// A snapshot bound to a different path is not a snapshot of this one: honoring
+// it would load one config document's content as another's. Like the write
+// lock identity in writeLockCovers, the claim "I already have these bytes" is
+// only meaningful together with what they are bytes of.
+func (o loadOptions) snapshotFor(path string) ([]byte, bool) {
+	if o.sourceSnapshot == nil || o.sourceSnapshot.path != path {
+		return nil, false
+	}
+	return bytes.Clone(o.sourceSnapshot.contents), true
 }
 
 // forWrite projects the load's write-relevant parameters onto the options of a
-// write the load performs on the caller's behalf. It reads o.layer rather than
+// write the load performs on the caller's behalf. The source snapshot is not
+// among them: it says what a load must read, and no write consults it.
+//
+// It reads o.layer rather than
 // taking a parameter because writeConfig only consults writeOptions.layer when
 // the config being written carries no source layer of its own (cfg.sourceLayer
 // == ""), and a config produced by load always carries one: load's sole

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -18,17 +18,67 @@ import "fmt"
 
 // loadOptions carries the parameters of a single config load. The zero value
 // is the plain caller-facing load performed by the exported Load.
+//
+// The fields are flat rather than nesting writeOptions: loading and writing
+// share only the config layer, and a load-side decision (which layer's bytes
+// to read, whether that layer may read legacy keychain accounts) must not have
+// to be read out of a struct named after the write. The one write parameter a
+// load carries, writeLockHeldFor, is projected onto writeOptions by forWrite.
 type loadOptions struct {
-	// write carries the options for a write the load performs on the caller's
+	// layer names the config layer being loaded ("system", "user", "local",
+	// "explicit", or empty when the caller has not classified the target).
+	// It decides whether the file is read through the no-symlink repository
+	// reader, how the canonical source identity is derived, and whether a
+	// legacy migration may read predictable per-user keychain accounts, so it
+	// must be stated per target rather than inherited from an ancestor load.
+	layer string
+
+	// suppressMigrationPersistence makes a legacy config migrate in memory
+	// only: it takes no migration lock, writes no file, and marks the result
+	// migrationDeferred. Layered loads and pre-write reloads use it so that
+	// reading never mutates a layer the caller did not select.
+	suppressMigrationPersistence bool
+
+	// explicitLegacyMigrationConsent is the canonical identity of the config
+	// document the user selected through --config or GCX_CONFIG. Only the
+	// high-level explicit loader mints it; the generic ExplicitConfigFile
+	// Source stays a path resolver and cannot by itself authorize reads from
+	// predictable legacy keychain accounts. Empty means no consent, and the
+	// identity comparison in trustedLegacyKeychainSource rejects it.
+	explicitLegacyMigrationConsent string
+
+	// migrationWarnings collects the per-source in-memory migration
+	// diagnostics of a layered load so the caller can collapse them into one
+	// warning. Nil sends each warning straight to the warning writer or log.
+	migrationWarnings *inMemoryMigrationWarningCollector
+
+	// writeLockHeldFor names the canonical config source whose write lock the
+	// caller already holds, for a write the load performs on the caller's
 	// behalf: loading migrates plaintext credentials into the keychain and
-	// persists legacy config migrations. Nesting rather than duplicating the
-	// write options keeps a single definition of what a write needs to know.
-	write writeOptions
+	// persists legacy config migrations.
+	writeLockHeldFor string
+}
+
+// forWrite projects the load's write-relevant parameters onto the options of a
+// write the load performs on the caller's behalf. layer is passed explicitly
+// because the write targets the layer the load resolved, not whatever the
+// caller happened to name.
+func (o loadOptions) forWrite(layer string) writeOptions {
+	return writeOptions{
+		layer:            layer,
+		writeLockHeldFor: o.writeLockHeldFor,
+	}
 }
 
 // writeOptions carries the parameters of a single config write. The zero value
 // is the plain caller-facing write performed by the exported Write.
 type writeOptions struct {
+	// layer names the config layer being written. It is only consulted when
+	// the config being written carries no source layer of its own (a config
+	// built in memory rather than loaded), and then decides the same things
+	// it decides on the load side.
+	layer string
+
 	// writeLockHeldFor names the canonical config source whose write lock the
 	// caller already holds, so the write must not acquire it again. Empty
 	// means no lock is held and the write takes its own. Config write locks

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -1,0 +1,39 @@
+package config
+
+// This file holds the explicit parameter structs for the config load and write
+// paths. Historically these parameters travelled as context values, which made
+// them invisible in every signature they crossed and impossible to reason
+// about locally: a caller could not tell which decisions a nested Load or Write
+// would inherit from an ancestor. Only genuinely ambient, request-scoped CLI
+// identity (the selected context name, the --config file, and the warning
+// writer) belongs in a context.Context; a parameter that changes what a
+// function does belongs in its signature.
+//
+// The exported entry points (Load, Write, LoadLayered, LoadForWrite) keep their
+// signatures — they have hundreds of call sites across the CLI — and delegate
+// to unexported workhorses that take these structs. Intra-package callers use
+// the workhorses and state their options explicitly.
+
+// loadOptions carries the parameters of a single config load. The zero value
+// is the plain caller-facing load performed by the exported Load.
+type loadOptions struct {
+	// write carries the options for a write the load performs on the caller's
+	// behalf: loading migrates plaintext credentials into the keychain and
+	// persists legacy config migrations. Nesting rather than duplicating the
+	// write options keeps a single definition of what a write needs to know.
+	write writeOptions
+}
+
+// writeOptions carries the parameters of a single config write. The zero value
+// is the plain caller-facing write performed by the exported Write.
+type writeOptions struct {
+	// writeLockHeld records that the caller already holds the config write
+	// lock, so the write must not acquire it again.
+	writeLockHeld bool
+}
+
+// writeLockCovers reports whether a caller-held write lock already protects
+// this write, letting the write skip acquiring the flock itself.
+func (o writeOptions) writeLockCovers() bool {
+	return o.writeLockHeld
+}

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -1,5 +1,7 @@
 package config
 
+import "fmt"
+
 // This file holds the explicit parameter structs for the config load and write
 // paths. Historically these parameters travelled as context values, which made
 // them invisible in every signature they crossed and impossible to reason
@@ -27,13 +29,31 @@ type loadOptions struct {
 // writeOptions carries the parameters of a single config write. The zero value
 // is the plain caller-facing write performed by the exported Write.
 type writeOptions struct {
-	// writeLockHeld records that the caller already holds the config write
-	// lock, so the write must not acquire it again.
-	writeLockHeld bool
+	// writeLockHeldFor names the canonical config source whose write lock the
+	// caller already holds, so the write must not acquire it again. Empty
+	// means no lock is held and the write takes its own. Config write locks
+	// are per-source (configLockFile derives the lock file from the canonical
+	// source identity), so the identity is part of the claim: "a lock is
+	// held" is only meaningful together with what it is held for.
+	writeLockHeldFor string
 }
 
-// writeLockCovers reports whether a caller-held write lock already protects
-// this write, letting the write skip acquiring the flock itself.
-func (o writeOptions) writeLockCovers() bool {
-	return o.writeLockHeld
+// writeLockCovers reports whether the caller-held write lock protects a write
+// to sourceIdentity, letting the write skip acquiring the flock itself.
+//
+// A lock held for a different source protects nothing here: the two writes
+// take different lock files and can interleave freely. Treating that as
+// "locked" would write the target without mutual exclusion, so it is an
+// error rather than a silent pass.
+func (o writeOptions) writeLockCovers(sourceIdentity string) (bool, error) {
+	switch o.writeLockHeldFor {
+	case "":
+		return false, nil
+	case sourceIdentity:
+		return true, nil
+	default:
+		return false, fmt.Errorf(
+			"refusing to write config without mutual exclusion: the write lock is held for %q but this write targets %q",
+			o.writeLockHeldFor, sourceIdentity)
+	}
 }

--- a/internal/config/options.go
+++ b/internal/config/options.go
@@ -60,12 +60,15 @@ type loadOptions struct {
 }
 
 // forWrite projects the load's write-relevant parameters onto the options of a
-// write the load performs on the caller's behalf. layer is passed explicitly
-// because the write targets the layer the load resolved, not whatever the
-// caller happened to name.
-func (o loadOptions) forWrite(layer string) writeOptions {
+// write the load performs on the caller's behalf. It reads o.layer rather than
+// taking a parameter because writeConfig only consults writeOptions.layer when
+// the config being written carries no source layer of its own (cfg.sourceLayer
+// == ""), and a config produced by load always carries one: load's sole
+// caller of forWrite runs after load has set config.sourceLayer, so that
+// field wins and o.layer is never consulted for the layer decision itself.
+func (o loadOptions) forWrite() writeOptions {
 	return writeOptions{
-		layer:            layer,
+		layer:            o.layer,
 		writeLockHeldFor: o.writeLockHeldFor,
 	}
 }

--- a/internal/config/rest.go
+++ b/internal/config/rest.go
@@ -94,9 +94,6 @@ func (n *NamespacedRESTConfig) WireTokenPersistence(ctx context.Context, source 
 	// cancelled the moment the caller has what it needs. Use a context
 	// detached from that cancellation so Load/Write always complete.
 	persistCtx := context.WithoutCancel(ctx)
-	// Every load and write below runs under the flock taken by the Lock
-	// callback, so they declare the lock as already held.
-	lockHeld := loadOptions{write: writeOptions{writeLockHeld: true}}
 
 	persistLoad := func() (Config, error) {
 		path, err := persistSource()
@@ -114,7 +111,14 @@ func (n *NamespacedRESTConfig) WireTokenPersistence(ctx context.Context, source 
 				loadCtx = withMigrationPersistenceSuppressed(loadCtx)
 			}
 		}
-		fresh, err := load(loadCtx, persistSource, lockHeld)
+		// The Lock callback below holds the write lock for exactly this
+		// identity, so any write the load performs on our behalf is already
+		// protected. Naming the identity is what makes that claim checkable.
+		identity, err := tokenPersistenceIdentity(sources, path)
+		if err != nil {
+			return Config{}, err
+		}
+		fresh, err := load(loadCtx, persistSource, loadOptions{write: writeOptions{writeLockHeldFor: identity}})
 		if err != nil {
 			return fresh, err
 		}
@@ -145,15 +149,11 @@ func (n *NamespacedRESTConfig) WireTokenPersistence(ctx context.Context, source 
 		if err != nil {
 			return nil, err
 		}
-		layer := ""
-		if selected, ok := configSourceForPath(sources, path); ok {
-			layer = selected.Type
-		}
-		identity, err := canonicalConfigSourceForLayer(path, layer)
+		identity, err := tokenPersistenceIdentity(sources, path)
 		if err != nil {
 			return nil, err
 		}
-		lockPath, err := configLockFile(identity, "write")
+		lockPath, err := configLockFile(identity)
 		if err != nil {
 			return nil, err
 		}
@@ -241,8 +241,42 @@ func (n *NamespacedRESTConfig) WireTokenPersistence(ctx context.Context, source 
 		g.OAuthRefreshToken = refreshToken
 		g.OAuthTokenExpiresAt = expiresAt
 		g.OAuthRefreshExpiresAt = refreshExpiresAt
-		return write(persistCtx, persistSource, fresh, lockHeld.write)
+		// Derive the held lock's identity from tokenPersistenceIdentity, the
+		// same helper the Lock callback and persistLoad use, so the three
+		// cannot disagree. fresh.sourceIdentity agrees with it, but only by
+		// following the path and layer four hops back through the load.
+		_, identity, err := tokenPersistenceIdentityFor(persistSource, sources)
+		if err != nil {
+			return err
+		}
+		return write(persistCtx, persistSource, fresh, writeOptions{writeLockHeldFor: identity})
 	})
+}
+
+// tokenPersistenceIdentityFor resolves the persistence target path and its
+// canonical write-lock identity together, so a caller cannot name one without
+// the other.
+func tokenPersistenceIdentityFor(source Source, sources []ConfigSource) (string, string, error) {
+	path, err := source()
+	if err != nil {
+		return "", "", err
+	}
+	identity, err := tokenPersistenceIdentity(sources, path)
+	if err != nil {
+		return "", "", err
+	}
+	return path, identity, nil
+}
+
+// tokenPersistenceIdentity returns the canonical identity of the config source
+// at path. The lock callback, the reload, and the write all derive the write
+// lock's identity here so the three cannot disagree.
+func tokenPersistenceIdentity(sources []ConfigSource, path string) (string, error) {
+	layer := ""
+	if selected, ok := configSourceForPath(sources, path); ok {
+		layer = selected.Type
+	}
+	return canonicalConfigSourceForLayer(path, layer)
 }
 
 func configSourceForPath(sources []ConfigSource, path string) (ConfigSource, bool) {

--- a/internal/config/rest.go
+++ b/internal/config/rest.go
@@ -93,7 +93,10 @@ func (n *NamespacedRESTConfig) WireTokenPersistence(ctx context.Context, source 
 	// Persistence runs inside an HTTP RoundTrip whose request context may be
 	// cancelled the moment the caller has what it needs. Use a context
 	// detached from that cancellation so Load/Write always complete.
-	persistCtx := withConfigWriteLockHeld(context.WithoutCancel(ctx))
+	persistCtx := context.WithoutCancel(ctx)
+	// Every load and write below runs under the flock taken by the Lock
+	// callback, so they declare the lock as already held.
+	lockHeld := loadOptions{write: writeOptions{writeLockHeld: true}}
 
 	persistLoad := func() (Config, error) {
 		path, err := persistSource()
@@ -111,7 +114,7 @@ func (n *NamespacedRESTConfig) WireTokenPersistence(ctx context.Context, source 
 				loadCtx = withMigrationPersistenceSuppressed(loadCtx)
 			}
 		}
-		fresh, err := Load(loadCtx, persistSource)
+		fresh, err := load(loadCtx, persistSource, lockHeld)
 		if err != nil {
 			return fresh, err
 		}
@@ -238,7 +241,7 @@ func (n *NamespacedRESTConfig) WireTokenPersistence(ctx context.Context, source 
 		g.OAuthRefreshToken = refreshToken
 		g.OAuthTokenExpiresAt = expiresAt
 		g.OAuthRefreshExpiresAt = refreshExpiresAt
-		return Write(persistCtx, persistSource, fresh)
+		return write(persistCtx, persistSource, fresh, lockHeld.write)
 	})
 }
 
@@ -297,7 +300,7 @@ func pickHighestSourceForStack(ctx context.Context, sources []ConfigSource, stac
 	// DiscoverSources returns low→high precedence, so scan in reverse.
 	for _, src := range slices.Backward(sources) {
 		loadCtx := withMigrationPersistenceSuppressed(withConfigLayer(ctx, src.Type))
-		cfg, err := Load(loadCtx, ExplicitConfigFile(src.Path))
+		cfg, err := load(loadCtx, ExplicitConfigFile(src.Path), loadOptions{})
 		if err != nil {
 			return ConfigSource{}, false, fmt.Errorf("rescan OAuth persistence source %s: %w", src.Path, err)
 		}

--- a/internal/config/rest.go
+++ b/internal/config/rest.go
@@ -100,15 +100,15 @@ func (n *NamespacedRESTConfig) WireTokenPersistence(ctx context.Context, source 
 		if err != nil {
 			return Config{}, err
 		}
-		loadCtx := persistCtx
+		loadOpts := loadOptions{layer: configLayerFromCtx(persistCtx)}
 		if selected, ok := configSourceForPath(sources, path); ok {
-			loadCtx = withConfigLayer(loadCtx, selected.Type)
+			loadOpts.layer = selected.Type
 			current, readErr := readConfigSource(selected)
 			if readErr != nil {
 				return Config{}, readErr
 			}
 			if len(sources) > 1 && isLegacyConfig(current) {
-				loadCtx = withMigrationPersistenceSuppressed(loadCtx)
+				loadOpts.suppressMigrationPersistence = true
 			}
 		}
 		// The Lock callback below holds the write lock for exactly this
@@ -118,7 +118,8 @@ func (n *NamespacedRESTConfig) WireTokenPersistence(ctx context.Context, source 
 		if err != nil {
 			return Config{}, err
 		}
-		fresh, err := load(loadCtx, persistSource, loadOptions{write: writeOptions{writeLockHeldFor: identity}})
+		loadOpts.writeLockHeldFor = identity
+		fresh, err := load(persistCtx, persistSource, loadOpts)
 		if err != nil {
 			return fresh, err
 		}
@@ -145,11 +146,7 @@ func (n *NamespacedRESTConfig) WireTokenPersistence(ctx context.Context, source 
 	}
 
 	n.oauthTransport.Lock = func(reqCtx context.Context) (func(), error) {
-		path, err := persistSource()
-		if err != nil {
-			return nil, err
-		}
-		identity, err := tokenPersistenceIdentity(sources, path)
+		path, identity, err := tokenPersistenceIdentityFor(persistSource, sources)
 		if err != nil {
 			return nil, err
 		}
@@ -249,7 +246,7 @@ func (n *NamespacedRESTConfig) WireTokenPersistence(ctx context.Context, source 
 		if err != nil {
 			return err
 		}
-		return write(persistCtx, persistSource, fresh, writeOptions{writeLockHeldFor: identity})
+		return write(persistCtx, persistSource, fresh, writeOptions{layer: fresh.sourceLayer, writeLockHeldFor: identity})
 	})
 }
 
@@ -333,8 +330,10 @@ func resolveTokenPersistenceSource(ctx context.Context, fallback Source, stackNa
 func pickHighestSourceForStack(ctx context.Context, sources []ConfigSource, stackName string, match func(*StackConfig) bool) (ConfigSource, bool, error) {
 	// DiscoverSources returns low→high precedence, so scan in reverse.
 	for _, src := range slices.Backward(sources) {
-		loadCtx := withMigrationPersistenceSuppressed(withConfigLayer(ctx, src.Type))
-		cfg, err := load(loadCtx, ExplicitConfigFile(src.Path), loadOptions{})
+		cfg, err := load(ctx, ExplicitConfigFile(src.Path), loadOptions{
+			layer:                        src.Type,
+			suppressMigrationPersistence: true,
+		})
 		if err != nil {
 			return ConfigSource{}, false, fmt.Errorf("rescan OAuth persistence source %s: %w", src.Path, err)
 		}

--- a/internal/config/write_lock_internal_test.go
+++ b/internal/config/write_lock_internal_test.go
@@ -1,0 +1,119 @@
+package config
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/gofrs/flock"
+	"github.com/stretchr/testify/require"
+)
+
+const writeLockTestConfig = `
+version: 1
+contexts:
+  default: {}
+current-context: default
+`
+
+// TestWriteLockIdentityGovernsWriteLockSkip pins the rule that a caller-held
+// config write lock only authorizes writes to the source it was taken for.
+//
+// Config write locks are per-source: configLockFile derives the lock file from
+// the canonical source identity. A caller that holds the lock for source A and
+// then writes source B is writing without mutual exclusion, so the write must
+// refuse rather than skip locking.
+//
+// Each case holds a foreign flock on the *target's* write lock, which makes the
+// three outcomes observably different: covered writes proceed straight through
+// it, uncovered writes block on it, and mismatched writes are rejected before
+// reaching it.
+func TestWriteLockIdentityGovernsWriteLockSkip(t *testing.T) {
+	tests := []struct {
+		name string
+		// heldFor selects which source identity the caller claims to hold the
+		// write lock for; "" means it claims none.
+		heldFor         func(targetIdentity, otherIdentity string) string
+		lockWaitTimeout time.Duration
+		wantErrContains string
+		wantWritten     bool
+	}{
+		{
+			name:            "lock held for the target skips acquisition",
+			heldFor:         func(target, _ string) string { return target },
+			lockWaitTimeout: time.Second,
+			wantWritten:     true,
+		},
+		{
+			name:            "no lock held acquires the target lock",
+			heldFor:         func(_, _ string) string { return "" },
+			lockWaitTimeout: 200 * time.Millisecond,
+			wantErrContains: "lock config for write",
+			wantWritten:     false,
+		},
+		{
+			name:            "lock held for another source is rejected",
+			heldFor:         func(_, other string) string { return other },
+			lockWaitTimeout: time.Second,
+			wantErrContains: "the write lock is held for",
+			wantWritten:     false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			targetPath := writeTestConfig(t, writeLockTestConfig)
+			otherPath := writeTestConfig(t, writeLockTestConfig)
+
+			targetIdentity, err := canonicalConfigSourceForLayer(targetPath, "")
+			require.NoError(t, err)
+			otherIdentity, err := canonicalConfigSourceForLayer(otherPath, "")
+			require.NoError(t, err)
+			require.NotEqual(t, targetIdentity, otherIdentity)
+
+			target := ExplicitConfigFile(targetPath)
+			cfg, err := load(t.Context(), target, loadOptions{})
+			require.NoError(t, err)
+
+			// A change that must reach disk only if the write is allowed.
+			cfg.SetContext("written", true, Context{})
+			cfg.Resolve()
+
+			before, err := os.ReadFile(targetPath)
+			require.NoError(t, err)
+
+			// Stand in for another process that holds the target's write lock.
+			targetLockPath, err := configLockFile(targetIdentity)
+			require.NoError(t, err)
+			foreign := flock.New(targetLockPath)
+			locked, err := foreign.TryLock()
+			require.NoError(t, err)
+			require.True(t, locked, "another test must not hold the target write lock")
+			t.Cleanup(func() { _ = foreign.Unlock() })
+
+			ctx, cancel := context.WithTimeout(t.Context(), tc.lockWaitTimeout)
+			defer cancel()
+
+			writeErr := write(ctx, target, cfg, writeOptions{
+				writeLockHeldFor: tc.heldFor(targetIdentity, otherIdentity),
+			})
+
+			if tc.wantErrContains == "" {
+				require.NoError(t, writeErr)
+			} else {
+				require.Error(t, writeErr)
+				require.ErrorContains(t, writeErr, tc.wantErrContains)
+			}
+
+			after, err := os.ReadFile(targetPath)
+			require.NoError(t, err)
+			if tc.wantWritten {
+				require.NotEqual(t, string(before), string(after), "write should have replaced the config")
+				require.Contains(t, string(after), "written")
+			} else {
+				require.Equal(t, string(before), string(after), "config must be unchanged when the write is not allowed")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Makes the load-and-write parameters of `internal/config` explicit. The package carried nine `context.Context` keys; six were not ambient request identity but parameters of a specific load or write — which layer, whether migration may persist, whether a write lock is already held, the frozen source bytes, the legacy-migration consent identity, the warning collector. They travelled by context because context propagates for free. This adds `loadOptions` and `writeOptions`, threads them through the unexported `load`, `write`, `loadLayered`, `loadForWrite`, and `migrateLegacyConfig` chain, and deletes five key types. Four context keys remain: three ambient CLI identity values, plus `configLayerKey`.

Carries one behaviour change, in its own commit with its own changelog entry: a held config write lock was a bare `bool` in the context, so a lock taken for one config file let a write to a *different* file skip locking entirely. The decision now carries the source identity, and a mismatch is an error rather than a silent pass. Concurrent invocations could previously write the same file at once.

`configLayerKey` is retained deliberately. It is the transport for the exported `ContextWithConfigSource`, whose three production callers reach this package through entry points that have no options parameter and whose signatures are frozen. Its doc comment records that constraint and the invariant that each entry point translates the ambient value into an option exactly once.

No exported signature changes. All 134 exported declarations in the package are byte-identical to `main`, struct fields included.

## Why

Every new cross-cutting config decision was expensive under the old shape. A recent single-field feature cost roughly 1,300 production lines, most of it context plumbing: a key type, a `with*` setter, a `*FromContext` reader, and a re-derivation at each call site. Because the value was invisible in signatures, it then needed guards to prove it had not been lost. Two such guards exist only for that reason.

The arithmetic is concrete. `main` carried 23 setter call sites across the five migrated parameters, plus a `//nolint:fatcontext` waiver where the chaining got dense. Each one now costs a single struct field, set where it originates and read at the consumer.

One honest limit, stated up front to save a review round: this makes *internal* load and write parameters cheap. A new *ambient* parameter that must cross the frozen exported boundary still costs a context key plus a translation at each entry point, which is exactly why `configLayerKey` survives. The win is not universal.

The write-lock defect was found while migrating that parameter, not sought. It is separated into its own commit so the refactor can be read as mechanical parameter threading without hunting for semantic changes.

## How it was tested

- [x] `GCX_AGENT_MODE=false mise run gate` passed — lint 0 issues, install suite 16/16, linter suite 44/44, build succeeded
- [x] `GCX_AGENT_MODE=false go test ./...` passed across the whole repository, no failures
- [x] `GCX_AGENT_MODE=false mise run reference-drift` clean — all four generators produce no drift
- [x] Exported surface diffed between `main` and the branch head with `go doc -all ./internal/config` on both revisions: 134 declarations byte-identical, struct fields included
- [x] Write-lock regression test mutation-verified three ways: restoring the old `return true` semantics fails the mismatch case with "An error is expected but got nil"; making a mismatch take the lock fails it on the error message; disabling the match fast path fails the held-lock case
- [x] Snapshot path binding mutation-verified: deleting the path comparison fails `TestLoadSourceSnapshotIsBoundToItsPath`, and forcing the migration-side read to miss fails `TestMigrationRejectsSourceChangedAfterPreflight`, a reader that had no coverage before this branch
- [x] Per-layer option derivation mutation-verified: replacing the per-iteration copy with mutation of the shared value fails `TestLoadLayeredDerivesPerLayerOptionsIndependently`, and that test alone
- [x] All eight surviving layer-boundary translations poisoned individually against the full suite to establish which are pinned; two are, six are inert for reasons recorded in the branch reports
- [x] Each commit verified to build and pass `go test ./internal/config/...` in isolation, so a bisect on config behaviour lands on a working tree

## Related

- Relates to #1266
- Follow-up to #1242

---
**Generated by Claude Code**
