### PR TITLE
docs: add guidelines for engineering teams in grafana

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,21 @@ designs the command's agent-facing contract before any code gets written. It
 hands implementation off to `add-provider` or `add-datasource` where those
 apply, and runs a pre-review self-check over the finished diff.
 
+## Code ownership
+
+The code in this repository is owned by multiple teams. The ownership is codified in the [CODEOWNERS](./.github/CODEOWNERS) file. The @grafana/grafana-gcx team is responsible for the overall architecture of the repository, along with any features or functionality that are not specific to any particular provider.
+
+### Product teams
+
+Grafana engineering teams are welcome to contribute to and maintain their areas of the codebase without any interaction from the @grafana/grafana-gcx team. The [CODEOWNERS](./.github/CODEOWNERS) file should be such that these teams only need approvals from their own team to merge pull requests in their product area. If you find this is not the case, please do reach out to the @grafana/grafana-gcx team, or raise a pull request with a [CODEOWNERS](./.github/CODEOWNERS) change. If you are unsure, please reach out in the #gcx channel and we'd be happy to discuss.
+
+We have tools in place to help maintain a consistent command surface and output conventions across the codebase, as well as LLM-assisted code review to try and ensure that the architecture and design conventions are followed. For more details on these tools, see:
+
+- [The claude code review GH action, with prompt & references](.github/workflows/claude-code-review.yml). This should encourage authors to adhere to the guidelines linked above.
+- [Prefer existing command operations over creating new ones](docs/design/command-naming.md)  (test files are [here](cmd/gcx/root/commandoperations_test.go))
+- [Syntax for experimental commands](docs/design/experimental-commands.md) (test files are referenced from the docs)
+
+
 ## Issue Tracking
 
 Issues are tracked in [GitHub Issues](https://github.com/grafana/gcx/issues).


### PR DESCRIPTION
Closes https://github.com/grafana/gcx-internal/issues/29

We want to encourage product engineering teams in grafana to take ownership of their command areas in gcx, and to do that they need to be able to contribute independently. To compliment the existing .github/CODEOWNERS file, this addition to CONTRIBUTING.md exists to encode that practice somewhere we can reference to. We might need to iterate on the CODEOWNERS content, but this section should make it clear to those other engineering teams that they are enouraged to contribute independently, and without our explicit approval.

This follows similar patterns we see in e.g. grafana/grafana, grafana/terraform-provider-grafana, and so on.