### PR TITLE
feat(config): require explicit context with GCX_REQUIRE_CONTEXT

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -160,6 +160,14 @@ credential-bearing stack/Cloud entries atomically, select `--context` or
 `GRAFANA_TOKEN`, `GRAFANA_PROVIDER_{NAME}_{KEY}`). Overrides take runtime
 precedence but remain ephemeral.
 
+**Strict context mode:** `GCX_REQUIRE_CONTEXT` drops the `current-context`
+fallback from that chain, so an invocation must name its target with `--context`
+or `GRAFANA_SERVER` or be refused with exit code 2. It protects workstations
+holding many contexts, where one session's `config use-context` would otherwise
+retarget commands running in another. Enforced pre-dispatch in
+`cmd/gcx/root/contextguard.go`, ahead of Cobra's hooks, so no command subtree can
+opt out of it.
+
 **Namespace resolution:** `org-id` (on-prem, maps to K8s namespace) or `stack-id` (Cloud, discovered via GCOM). Providers use `ConfigLoader` which resolves these uniformly.
 
 **Secret handling:** Config keys marked `Secret: true` in provider `ConfigKeys()`

--- a/README.md
+++ b/README.md
@@ -202,6 +202,12 @@ export GRAFANA_CLOUD_STACK="your-stack-slug"
 
 Env vars resolve at every command invocation, so you can run `gcx` commands directly without a prior `gcx login`.
 
+If you keep several contexts and run `gcx` from more than one session (or from
+a coding agent), `current-context` is shared mutable state: `gcx config
+use-context` in one shell retargets every other invocation. Set
+`GCX_REQUIRE_CONTEXT=true` so commands that reach Grafana must name
+`--context <name>` (or `GRAFANA_SERVER`) instead of inheriting the file default.
+
 For safety, an auto-discovered repository `.gcx.yaml` cannot attach runtime
 tokens, prompted login credentials, or external mTLS keypairs to destinations
 the file supplies. If you intend that file to own credentials or direct

--- a/claude-plugin/skills/gcx/SKILL.md
+++ b/claude-plugin/skills/gcx/SKILL.md
@@ -88,6 +88,11 @@ Before any operation, confirm which environment is targeted:
 - `gcx config use-context <name>` — switch contexts
 - `--context <name>` flag on any command — target a specific context without switching
 
+If a command fails with "This invocation does not name a context",
+`GCX_REQUIRE_CONTEXT` is set. Do not fall back to `current-context`. Pass
+`--context <name>` on that invocation (or ask the user which context to use).
+`gcx config list-contexts` lists the names you can choose from.
+
 ## Output Control
 
 | Intent | Flag |
@@ -117,7 +122,7 @@ asks for speed.
 | Intent | Flag |
 |--------|------|
 | Preview without changing anything | `--dry-run` |
-| Target a specific context | `--context <name>` |
+| Target a specific context | `--context <name>` (required when `GCX_REQUIRE_CONTEXT` is set) |
 | Continue on errors vs stop | `--on-error fail\|ignore\|abort` |
 | Control concurrency | `--max-concurrent <n>` (default 10) |
 

--- a/cmd/gcx/main.go
+++ b/cmd/gcx/main.go
@@ -77,6 +77,10 @@ func main() {
 		exitWith(cmd, gate, start, reportError(err, boolFlags, subCmds))
 	}
 
+	if err := root.EnforceContextSelection(formattedVersion, os.Args[1:]); err != nil {
+		exitWith(cmd, gate, start, reportError(err, boolFlags, subCmds))
+	}
+
 	err := cmd.ExecuteContext(ctx)
 
 	// An interrupted invocation reports no error: a fused error document would

--- a/cmd/gcx/root/contextguard.go
+++ b/cmd/gcx/root/contextguard.go
@@ -1,0 +1,208 @@
+package root
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	internalconfig "github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/gcxerrors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// contextExemptRoutes are the command routes that may run without naming a
+// context under strict context mode, expressed relative to the root command. A
+// route covers its whole subtree.
+//
+// Two kinds of command belong here: those that never reach a Grafana or Cloud
+// environment (local metadata, local file operations, shell plumbing), and
+// bootstrapping commands that carry their own destination — `login` takes the
+// context name as its argument, so it cannot inherit the wrong one.
+//
+//nolint:gochecknoglobals // Static policy table, read through requiresExplicitContext.
+var contextExemptRoutes = []string{
+	"agent",       // Local: skills installer, invocation-log pruning.
+	"cloud login", // Bootstrapping: names its own destination.
+	"commands",    // Local: command catalog for agents.
+	"completion",  // Shell plumbing.
+	"config",      // Operates on the config file itself (see contextRequiredRoutes).
+	"dev generate",
+	"dev lint",
+	"dev scaffold",
+	"help",      // Cobra's help command.
+	"help-tree", // Local: command tree for agent context.
+	"instrumentation check",
+	"instrumentation explain",
+	"instrumentation list-explanations",
+	"login",     // Bootstrapping: names its own destination.
+	"providers", // Local: registered provider list.
+	"resources list-examples",
+	"version",
+}
+
+// contextRequiredRoutes are enforced even though an ancestor route is exempt.
+//
+//nolint:gochecknoglobals // Static policy table, read through requiresExplicitContext.
+var contextRequiredRoutes = []string{
+	"config check", // Connects to the environment to verify it.
+}
+
+// EnforceContextSelection refuses an invocation that would silently fall back
+// to current-context while strict context mode (GCX_REQUIRE_CONTEXT) is on.
+//
+// The check runs before Cobra dispatch rather than in the root command's
+// PersistentPreRun because Cobra runs only the closest PersistentPreRun in the
+// chain, and many provider groups define their own and chain back to root's by
+// hand. A guard in that hook would be skipped by any subtree that forgot to
+// chain — an omission that fails open, which is the one outcome a safety guard
+// cannot have. Running pre-dispatch also routes the error through the same
+// reporting path as ValidateArgs, so agent mode still gets a single JSON error
+// whose exit code agrees with it.
+//
+// It builds its own command tree because resolving the invocation parses flags,
+// which mutates flag state on the tree it walks.
+func EnforceContextSelection(version string, args []string) error {
+	if !strictContextEnabled() {
+		return nil
+	}
+
+	return enforceContextSelection(Command(version), args)
+}
+
+// strictContextEnabled reads the switch straight from the environment rather
+// than through LoadCLIOptions, so that a parse failure on an unrelated CLI
+// option cannot lift the requirement. How the value is interpreted still lives
+// with the option itself.
+func strictContextEnabled() bool {
+	opts := internalconfig.CLIOptions{RequireContext: os.Getenv("GCX_REQUIRE_CONTEXT")}
+	return opts.RequireContextEnabled()
+}
+
+func enforceContextSelection(rootCmd *cobra.Command, args []string) error {
+	if rootCmd == nil {
+		return nil
+	}
+
+	trimmed, ok := trimLeadingRootFlags(rootCmd, args)
+	if !ok {
+		return nil // Cobra reports the flag error itself.
+	}
+	if len(trimmed) == 0 {
+		return nil // Bare `gcx` prints help.
+	}
+	switch trimmed[0] {
+	case cobra.ShellCompRequestCmd, cobra.ShellCompNoDescRequestCmd:
+		return nil
+	}
+
+	cmd, remaining, ok := traverseArgs(rootCmd, trimmed)
+	if !ok || cmd == nil {
+		return nil
+	}
+
+	// Cobra installs --help during execution, so it has to be registered here
+	// for the parse below to recognize it rather than fail on an unknown flag.
+	cmd.InitDefaultHelpFlag()
+	if !parseGroupFlags(cmd, remaining) {
+		return nil // Cobra reports the flag error itself.
+	}
+
+	// A group node or a help/version request only prints text.
+	if !cmd.Runnable() || boolFlagSet(cmd, "help") || boolFlagSet(cmd, "version") {
+		return nil
+	}
+
+	if !requiresExplicitContext(cmd) || contextIsExplicit(rootCmd, cmd) {
+		return nil
+	}
+
+	return missingContextError(cmd)
+}
+
+// requiresExplicitContext reports whether cmd may reach a Grafana or Cloud
+// environment, and so must name the one it means. Commands are enforced unless
+// listed as exempt, so a newly added command is covered by default.
+func requiresExplicitContext(cmd *cobra.Command) bool {
+	route := commandRoute(cmd)
+
+	// `instrumentation check` validates the local workstation and reaches a
+	// stack only to have Grafana Assistant write the fix plan.
+	if route == "instrumentation check" {
+		return flagValue(cmd, "fix-plan") == "assistant"
+	}
+
+	for _, required := range contextRequiredRoutes {
+		if routeCovers(required, route) {
+			return true
+		}
+	}
+	for _, exempt := range contextExemptRoutes {
+		if routeCovers(exempt, route) {
+			return false
+		}
+	}
+	return true
+}
+
+// contextIsExplicit reports whether the invocation names its target itself,
+// rather than inheriting whichever context the config file currently selects.
+//
+// GRAFANA_SERVER counts: it overrides the destination for the invocation, so
+// the command cannot be redirected by another session's `config use-context`.
+func contextIsExplicit(rootCmd, cmd *cobra.Command) bool {
+	// Both flag sets are consulted because subtrees such as `config` bind their
+	// own --context, which shadows root's in the resolved command's flag set.
+	// `gcx --context x config view` sets root's; `gcx config --context x view`
+	// sets the subtree's.
+	for _, flags := range []*pflag.FlagSet{cmd.Flags(), rootCmd.PersistentFlags()} {
+		f := flags.Lookup("context")
+		if f != nil && f.Changed && strings.TrimSpace(f.Value.String()) != "" {
+			return true
+		}
+	}
+
+	return strings.TrimSpace(os.Getenv("GRAFANA_SERVER")) != ""
+}
+
+func missingContextError(cmd *cobra.Command) error {
+	exitCode := gcxerrors.ExitUsageError
+
+	return &gcxerrors.DetailedError{
+		Summary: "This invocation does not name a context",
+		Details: "GCX_REQUIRE_CONTEXT is set, so gcx will not fall back to current-context from the config " +
+			"file. current-context is shared between sessions: another shell or agent can change it at any " +
+			"time, which would send this command to a different environment than intended.",
+		Suggestions: []string{
+			fmt.Sprintf("Name the target explicitly: %s --context <name>", cmd.CommandPath()),
+			"See the contexts you can choose from: gcx config list-contexts",
+			"Drop the requirement for this shell: unset GCX_REQUIRE_CONTEXT",
+		},
+		ExitCode: &exitCode,
+	}
+}
+
+// commandRoute returns cmd's path relative to the root command, e.g.
+// "config check". The root's own name is dropped because it comes from
+// path.Base(os.Args[0]) and therefore changes when the binary is renamed.
+func commandRoute(cmd *cobra.Command) string {
+	names := []string{}
+	for c := cmd; c.HasParent(); c = c.Parent() {
+		names = append([]string{c.Name()}, names...)
+	}
+	return strings.Join(names, " ")
+}
+
+// routeCovers reports whether route is prefix, or a command below it. Matching
+// is per path component, so "dev lint" does not cover "dev lint-preview".
+func routeCovers(prefix, route string) bool {
+	return route == prefix || strings.HasPrefix(route, prefix+" ")
+}
+
+func flagValue(cmd *cobra.Command, name string) string {
+	f := cmd.Flags().Lookup(name)
+	if f == nil {
+		return ""
+	}
+	return f.Value.String()
+}

--- a/cmd/gcx/root/contextguard_test.go
+++ b/cmd/gcx/root/contextguard_test.go
@@ -1,0 +1,248 @@
+package root_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/grafana/gcx/cmd/gcx/fail"
+	"github.com/grafana/gcx/cmd/gcx/root"
+	"github.com/grafana/gcx/internal/agent"
+	"github.com/grafana/gcx/internal/gcxerrors"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const guardTestVersion = "v0.0.0-test"
+
+// enableStrictContext turns on strict context mode and clears the environment
+// overrides that would otherwise satisfy the guard on a developer machine.
+func enableStrictContext(t *testing.T) {
+	t.Helper()
+	t.Setenv("GCX_REQUIRE_CONTEXT", "true")
+	t.Setenv("GRAFANA_SERVER", "")
+}
+
+func TestEnforceContextSelection_Disabled(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "unset", value: ""},
+		{name: "false", value: "false"},
+		{name: "zero", value: "0"},
+		{name: "off", value: "off"},
+		{name: "no", value: "no"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("GCX_REQUIRE_CONTEXT", tc.value)
+			t.Setenv("GRAFANA_SERVER", "")
+
+			assert.NoError(t, root.EnforceContextSelection(guardTestVersion,
+				[]string{"slo", "definitions", "list"}))
+		})
+	}
+}
+
+// A value that is neither recognized nor an off switch keeps the requirement
+// in place: a typo must not silently disable the guard.
+func TestEnforceContextSelection_UnrecognizedValueStaysOn(t *testing.T) {
+	t.Setenv("GCX_REQUIRE_CONTEXT", "ture")
+	t.Setenv("GRAFANA_SERVER", "")
+
+	assert.Error(t, root.EnforceContextSelection(guardTestVersion,
+		[]string{"slo", "definitions", "list"}))
+}
+
+func TestEnforceContextSelection_RequiresContext(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "provider command", args: []string{"slo", "definitions", "list"}},
+		{name: "signal query", args: []string{"metrics", "query", "up"}},
+		{name: "resources get", args: []string{"resources", "get", "dashboards"}},
+		{name: "resources list-types", args: []string{"resources", "list-types"}},
+		{name: "raw api passthrough", args: []string{"api", "/api/health"}},
+		{name: "setup status", args: []string{"setup", "status"}},
+		{name: "config check reaches the environment", args: []string{"config", "check"}},
+		{name: "instrumentation status", args: []string{"instrumentation", "status"}},
+		{name: "cloud stacks list", args: []string{"cloud", "stacks", "list"}},
+		{name: "dev import", args: []string{"dev", "import", "dashboards"}},
+		{name: "empty context value", args: []string{"--context=", "slo", "definitions", "list"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			enableStrictContext(t)
+
+			err := root.EnforceContextSelection(guardTestVersion, tc.args)
+			require.Error(t, err)
+
+			detailed := fail.ErrorToDetailedError(err)
+			require.NotNil(t, detailed)
+			require.NotNil(t, detailed.ExitCode)
+			assert.Equal(t, gcxerrors.ExitUsageError, *detailed.ExitCode)
+			assert.Contains(t, strings.Join(detailed.Suggestions, "\n"), "--context <name>")
+		})
+	}
+}
+
+func TestEnforceContextSelection_SatisfiedByExplicitTarget(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          []string
+		grafanaServer string
+	}{
+		{
+			name: "context before the command",
+			args: []string{"--context", "prospect-a", "slo", "definitions", "list"},
+		},
+		{
+			name: "context after the command",
+			args: []string{"slo", "definitions", "list", "--context", "prospect-a"},
+		},
+		{
+			name: "context in equals form",
+			args: []string{"--context=prospect-a", "slo", "definitions", "list"},
+		},
+		{
+			// `config` binds its own --context, which shadows root's in the
+			// resolved command's flag set.
+			name: "subtree-bound context flag",
+			args: []string{"config", "check", "--context", "prospect-a"},
+		},
+		{
+			name: "root context flag ahead of a shadowing subtree",
+			args: []string{"--context", "prospect-a", "config", "check"},
+		},
+		{
+			name:          "server override names the destination",
+			args:          []string{"slo", "definitions", "list"},
+			grafanaServer: "https://prospect-a.grafana.net",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			enableStrictContext(t)
+			if tc.grafanaServer != "" {
+				t.Setenv("GRAFANA_SERVER", tc.grafanaServer)
+			}
+
+			assert.NoError(t, root.EnforceContextSelection(guardTestVersion, tc.args))
+		})
+	}
+}
+
+func TestEnforceContextSelection_ExemptCommands(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "no arguments prints help", args: []string{}},
+		{name: "version", args: []string{"version"}},
+		{name: "help command", args: []string{"help"}},
+		{name: "help flag on an enforced command", args: []string{"slo", "definitions", "list", "--help"}},
+		{name: "group node prints help", args: []string{"slo"}},
+		{name: "completion", args: []string{"completion", "bash"}},
+		{name: "shell completion helper", args: []string{cobra.ShellCompRequestCmd, "slo"}},
+		{name: "commands catalog", args: []string{"commands"}},
+		{name: "help tree", args: []string{"help-tree"}},
+		{name: "providers list", args: []string{"providers", "list"}},
+		{name: "skills installer", args: []string{"agent", "skills", "list"}},
+		{name: "config view", args: []string{"config", "view"}},
+		{name: "config use-context", args: []string{"config", "use-context", "prospect-a"}},
+		{name: "login names its own destination", args: []string{"login", "prospect-a"}},
+		{name: "cloud login", args: []string{"cloud", "login"}},
+		{name: "local lint", args: []string{"dev", "lint", "run", "./dashboards"}},
+		{name: "scaffold", args: []string{"dev", "scaffold", "myproject"}},
+		{name: "resources list-examples", args: []string{"resources", "list-examples"}},
+		{name: "local instrumentation check", args: []string{"instrumentation", "check"}},
+		{name: "instrumentation explain", args: []string{"instrumentation", "explain", "some-id"}},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			enableStrictContext(t)
+
+			assert.NoError(t, root.EnforceContextSelection(guardTestVersion, tc.args))
+		})
+	}
+}
+
+// `instrumentation check` is local until --fix-plan=assistant sends the
+// findings to a stack, which is the point at which it needs a named context.
+func TestEnforceContextSelection_InstrumentationCheckFixPlan(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		wantError bool
+	}{
+		{name: "default is local", args: []string{"instrumentation", "check"}},
+		{name: "local fix plan", args: []string{"instrumentation", "check", "--fix-plan", "local"}},
+		{
+			name:      "assistant fix plan reaches a stack",
+			args:      []string{"instrumentation", "check", "--fix-plan", "assistant"},
+			wantError: true,
+		},
+		{
+			name: "assistant fix plan with a context",
+			args: []string{"instrumentation", "check", "--fix-plan", "assistant", "--context", "prospect-a"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			enableStrictContext(t)
+
+			err := root.EnforceContextSelection(guardTestVersion, tc.args)
+			if tc.wantError {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+		})
+	}
+}
+
+// A provider group that defines its own PersistentPreRun would shadow root's
+// hook, so enforcement must not depend on that hook running.
+func TestEnforceContextSelection_CoversSubtreesWithOwnPreRun(t *testing.T) {
+	enableStrictContext(t)
+
+	for _, args := range [][]string{
+		{"slo", "definitions", "list"},
+		{"synthetic-monitoring", "checks", "list"},
+		{"dashboards", "list"},
+		{"datasources", "list"},
+		{"alert", "rules", "list"},
+	} {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			assert.Error(t, root.EnforceContextSelection(guardTestVersion, args))
+		})
+	}
+}
+
+// The exempt list must keep naming real commands, so a rename or removal shows
+// up here rather than silently widening or narrowing what the guard covers.
+func TestContextExemptRoutesExist(t *testing.T) {
+	rootCmd := root.Command(guardTestVersion)
+
+	routes := map[string]bool{}
+	agent.WalkCommands(rootCmd, func(cmd *cobra.Command) {
+		names := []string{}
+		for c := cmd; c.HasParent(); c = c.Parent() {
+			names = append([]string{c.Name()}, names...)
+		}
+		if len(names) > 0 {
+			routes[strings.Join(names, " ")] = true
+		}
+	})
+
+	for _, route := range root.ContextPolicyRoutesForTest() {
+		assert.True(t, routes[route], "route %q is in the context policy but not in the command tree", route)
+	}
+}

--- a/cmd/gcx/root/export_test.go
+++ b/cmd/gcx/root/export_test.go
@@ -10,3 +10,9 @@ import (
 func NewCommandForTest(version string, pp []providers.Provider) *cobra.Command {
 	return newCommand(version, pp)
 }
+
+// ContextPolicyRoutesForTest exposes the command routes named by the strict
+// context policy so a test can check them against the real command tree.
+func ContextPolicyRoutesForTest() []string {
+	return append(append([]string{}, contextExemptRoutes...), contextRequiredRoutes...)
+}

--- a/docs/architecture/config-system.md
+++ b/docs/architecture/config-system.md
@@ -914,24 +914,23 @@ affect command behavior but are not tied to any specific Grafana context.
 ```go
 // internal/config/cli_options.go
 type CLIOptions struct {
-    AutoApprove bool `env:"GCX_AUTO_APPROVE"`
+    AutoApprove      bool   `env:"GCX_AUTO_APPROVE"`
+    DisableUpdateNotifier string `env:"GCX_NO_UPDATE_NOTIFIER"`
+    Keychain         string `env:"GCX_KEYCHAIN"`
+    RequireContext   string `env:"GCX_REQUIRE_CONTEXT"`
 }
 
 func LoadCLIOptions() (CLIOptions, error)
 ```
 
-`LoadCLIOptions()` uses `caarlos0/env/v11` (the same library used for
-context-scoped env vars) to parse global environment variables into a
-`CLIOptions` struct. Unlike context overrides, these options are loaded
-independently — they do not read from the config file or affect any context.
-
-**Current usage:** The `delete` command calls `LoadCLIOptions()` in its `RunE`
-and, when `AutoApprove` is true (or `--yes`/`-y` is passed), automatically
-enables the `--force` flag for non-interactive operation in CI/CD pipelines.
+`LoadCLIOptions()` parses these tags into a `CLIOptions` struct. Unlike context
+overrides, they are loaded independently — they do not read from the config file
+or change any context.
 
 | Env Var | CLI Flag | Effect |
 |---------|----------|--------|
 | `GCX_AUTO_APPROVE` | `--yes` / `-y` | Auto-enables `--force` on delete |
+| `GCX_REQUIRE_CONTEXT` | (none) | Require `--context` or `GRAFANA_SERVER` on commands that reach Grafana; see [Strict Context Mode](#strict-context-mode) |
 
 See [environment-variables.md](../design/environment-variables.md) for the full environment
 variable reference.

--- a/docs/architecture/config-system.md
+++ b/docs/architecture/config-system.md
@@ -489,6 +489,28 @@ func (config *Config) GetCurrentContext() *Context {
 
 Returns `nil` if `CurrentContext` is empty or not found — callers must check.
 
+### Strict Context Mode
+
+`GCX_REQUIRE_CONTEXT` removes step 2 from the selection order above: an
+invocation must name its own target, or it is refused before it runs. It exists
+because `current-context` is shared mutable state — on a workstation holding
+many contexts, one session's `gcx config use-context` silently retargets every
+later command in every other session, including commands run by coding agents.
+
+An invocation satisfies the requirement with `--context <name>` (root's
+persistent flag or a subtree-bound one) or a `GRAFANA_SERVER` override, both of
+which name the destination for that invocation alone. Anything else fails with
+exit code 2.
+
+The check lives in `EnforceContextSelection` (`cmd/gcx/root/contextguard.go`) and
+runs pre-dispatch from `main()`, not in root's `PersistentPreRun`. Cobra runs
+only the closest `PersistentPreRun` in the chain, and several provider groups
+define their own and chain back to root's by hand, so a guard in that hook would
+be skipped by any subtree that forgot to chain — a fail-open outcome. Commands
+are enforced by default; `contextExemptRoutes` lists the routes that are not
+(local metadata, shell plumbing, config-file editing, and the bootstrapping
+`login` commands, which name their own destination).
+
 ---
 
 ## From Config to REST Client

--- a/docs/design/environment-variables.md
+++ b/docs/design/environment-variables.md
@@ -46,6 +46,7 @@ stack because its TLS and proxy settings affect the transport.
 | `GCX_TELEMETRY` | global | `enabled`, `disabled`, or `log`; takes precedence over `DO_NOT_TRACK` and config |
 | `DO_NOT_TRACK` | global | Disable anonymous telemetry when `1` or `true` unless `GCX_TELEMETRY` overrides it |
 | `GCX_NO_UPDATE_NOTIFIER` | global | Disable the periodic gcx/skill update notifier when non-empty |
+| `GCX_REQUIRE_CONTEXT` | global | Refuse commands that would fall back to `current-context`; the invocation must name `--context` or set `GRAFANA_SERVER`. Any non-empty value except `false`/`0`/`off`/`no` enables it. See [config-system.md § Strict Context Mode](../architecture/config-system.md#strict-context-mode) |
 | `NO_COLOR` | global | Disable color output ([no-color.org](https://no-color.org/)) |
 
 ### Provider Variables

--- a/docs/reference/environment-variables/index.md
+++ b/docs/reference/environment-variables/index.md
@@ -25,6 +25,18 @@ DisableUpdateNotifier disables the periodic notifier that reminds users
 when their installed gcx skills can be updated. Any non-empty value
 disables the notifier (NO_COLOR convention).
 
+## `GCX_REQUIRE_CONTEXT`
+
+RequireContext makes gcx refuse any invocation that would fall back to
+current-context from the config file, so a command can only reach the
+environment its own invocation names. Intended for workstations that
+hold many contexts and run gcx from several sessions or coding agents at
+once, where current-context is shared mutable state: another session's
+`config use-context` silently retargets every later command.
+
+Any non-empty value except an explicit off switch enables it, so a typo
+leaves the requirement in place rather than silently lifting it.
+
 ## `GCX_TELEMETRY`
 
 Telemetry controls anonymous usage telemetry for this invocation:

--- a/docs/sources/configuration.md
+++ b/docs/sources/configuration.md
@@ -167,6 +167,17 @@ Switch to a different context:
 gcx config use-context staging
 ```
 
+`current-context` is shared across every process that reads the same config
+file. If you keep many contexts on one machine, or run `gcx` from coding
+agents, set `GCX_REQUIRE_CONTEXT` so a command cannot inherit whichever
+context another session last selected. With it set, commands that reach Grafana
+must pass `--context <name>` (or `GRAFANA_SERVER`) or they exit 2.
+
+```shell
+export GCX_REQUIRE_CONTEXT=true
+gcx --context staging resources get dashboards
+```
+
 See the entire configuration:
 
 ```shell

--- a/internal/config/cli_options.go
+++ b/internal/config/cli_options.go
@@ -1,6 +1,9 @@
 package config
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // CLIOptions holds CLI-level configuration options that affect command behavior
 // but are not specific to any Grafana context.
@@ -20,6 +23,27 @@ type CLIOptions struct {
 	// disables it; every other value, recognised or not, leaves the keychain in
 	// use, so a typo cannot silently write credentials in plaintext.
 	Keychain string `env:"GCX_KEYCHAIN"`
+
+	// RequireContext makes gcx refuse any invocation that would fall back to
+	// current-context from the config file, so a command can only reach the
+	// environment its own invocation names. Intended for workstations that
+	// hold many contexts and run gcx from several sessions or coding agents at
+	// once, where current-context is shared mutable state: another session's
+	// `config use-context` silently retargets every later command.
+	//
+	// Any non-empty value except an explicit off switch enables it, so a typo
+	// leaves the requirement in place rather than silently lifting it.
+	RequireContext string `env:"GCX_REQUIRE_CONTEXT"`
+}
+
+// RequireContextEnabled reports whether strict context mode is on.
+func (opts CLIOptions) RequireContextEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(opts.RequireContext)) {
+	case "", "false", "0", "off", "no":
+		return false
+	default:
+		return true
+	}
 }
 
 // LoadCLIOptions loads CLI options from environment variables.


### PR DESCRIPTION
## Summary
- Adds opt-in `GCX_REQUIRE_CONTEXT` so gcx refuses commands that would silently inherit `current-context` from the config file. That field is shared across shells and coding agents; another session's `gcx config use-context` can otherwise retarget later invocations.
- An invocation satisfies the requirement with `--context <name>` (root or subtree-bound) or `GRAFANA_SERVER`. Local/meta commands stay exempt; `config check` and `instrumentation check --fix-plan=assistant` still require an explicit target.
- The guard runs pre-dispatch in `main()` rather than root `PersistentPreRun`, because Cobra only runs the closest hook and provider groups that define their own would otherwise skip it.

## Test plan
- [ ] `export GCX_REQUIRE_CONTEXT=true` then run `gcx slo definitions list` without `--context` — expect exit 2 and a message to pass `--context`
- [ ] Same with `gcx --context <name> slo definitions list` — command proceeds
- [ ] `GRAFANA_SERVER=https://example.grafana.net gcx resources list-types` satisfies the guard without `--context`
- [ ] `gcx version`, `gcx config view`, `gcx login`, `gcx agent skills list` still work without `--context`
- [ ] `gcx config check` without `--context` is refused; with `--context` it runs
- [ ] Unset `GCX_REQUIRE_CONTEXT` — existing `current-context` fallback is unchanged
