### PR TITLE
refactor(irm): render discovery tables from column lists

### DIFF
--- a/internal/providers/irm/discovery_codec_golden_internal_test.go
+++ b/internal/providers/irm/discovery_codec_golden_internal_test.go
@@ -1,0 +1,71 @@
+package irm
+
+import (
+	"bytes"
+	"testing"
+
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+// Each fixture pairs a fully populated row with one leaving the optional
+// fields empty, so the goldens pin the blank renderings too.
+
+func goldenEscalationStepOptions() []EscalationStepOption {
+	return []EscalationStepOption{
+		{Value: 19, CreateDisplayName: "Declare Incident", DisplayName: "declare incident", SlackIntegrationRequired: true},
+		{Value: 0},
+	}
+}
+
+func goldenWebhookTriggerOptions() []WebhookTriggerOption {
+	return []WebhookTriggerOption{
+		{Value: 12, DisplayName: "Incident Changed"},
+		{Value: 0},
+	}
+}
+
+func goldenWebhookPresets() []WebhookPreset {
+	return []WebhookPreset{
+		{
+			ID:          "preset-1",
+			Name:        "ServiceNow",
+			Description: "Create a ServiceNow ticket",
+			TriggerTypes: []WebhookPresetTriggerType{
+				{Value: "alert group created"},
+				{Value: "resolved"},
+			},
+		},
+		{ID: "preset-2", Name: "bare"},
+	}
+}
+
+func goldenRouteFilterTypes() []RouteFilterType {
+	return []RouteFilterType{
+		{Value: 0, DisplayName: "Regex"},
+		{Value: 1},
+	}
+}
+
+func TestDiscoveryTableGolden(t *testing.T) {
+	var esc bytes.Buffer
+	require.NoError(t, escalationStepOptionTable().Codec(cmdio.FormatTable).Encode(&esc, goldenEscalationStepOptions()))
+	testutils.Golden(t, "discovery_escalation_steps", esc.String())
+
+	var trig bytes.Buffer
+	require.NoError(t, webhookTriggerOptionTable().Codec(cmdio.FormatTable).Encode(&trig, goldenWebhookTriggerOptions()))
+	testutils.Golden(t, "discovery_webhook_triggers", trig.String())
+
+	var preset bytes.Buffer
+	require.NoError(t, webhookPresetTable().Codec(cmdio.FormatTable).Encode(&preset, goldenWebhookPresets()))
+	testutils.Golden(t, "discovery_webhook_presets", preset.String())
+
+	var filter bytes.Buffer
+	require.NoError(t, routeFilterTypeTable().Codec(cmdio.FormatTable).Encode(&filter, goldenRouteFilterTypes()))
+	testutils.Golden(t, "discovery_route_filter_types", filter.String())
+
+	var empty bytes.Buffer
+	require.NoError(t, routeFilterTypeTable().Codec(cmdio.FormatTable).Encode(&empty, []RouteFilterType{}))
+	testutils.Golden(t, "discovery_route_filter_types_empty", empty.String())
+}

--- a/internal/providers/irm/oncall_discovery_commands.go
+++ b/internal/providers/irm/oncall_discovery_commands.go
@@ -2,21 +2,14 @@ package irm
 
 import (
 	"context"
-	"errors"
-	"io"
 	"strconv"
 	"strings"
 
 	"github.com/grafana/gcx/internal/format"
 	cmdio "github.com/grafana/gcx/internal/output"
-	"github.com/grafana/gcx/internal/style"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
-
-// errInvalidTableInput is returned by discovery table codecs when Encode
-// receives a value of an unexpected type.
-var errInvalidTableInput = errors.New("invalid data type for table codec")
 
 // Discovery commands surface the enum catalogs behind OnCall resource fields
 // that previously required raw `gcx api` calls or hard-coded numeric "magic
@@ -142,7 +135,7 @@ func newEscalationStepCmds(loader OnCallConfigLoader) []*cobra.Command {
 
   # Put that value in the step field of policy.yaml, then create the policy
   gcx irm oncall escalation-policies create -f policy.yaml`,
-		codec: &escalationStepOptionTableCodec{},
+		codec: escalationStepOptionTable().Codec(cmdio.FormatTable),
 		fetch: func(ctx context.Context, client OnCallAPI) ([]EscalationStepOption, error) {
 			return client.ListEscalationStepOptions(ctx)
 		},
@@ -170,7 +163,7 @@ func newWebhookTriggerCmds(loader OnCallConfigLoader) []*cobra.Command {
 
   # Put that value in the trigger_type field of webhook.yaml, then create the webhook
   gcx irm oncall webhooks create -f webhook.yaml`,
-		codec: &webhookTriggerOptionTableCodec{},
+		codec: webhookTriggerOptionTable().Codec(cmdio.FormatTable),
 		fetch: func(ctx context.Context, client OnCallAPI) ([]WebhookTriggerOption, error) {
 			return client.ListWebhookTriggerOptions(ctx)
 		},
@@ -197,7 +190,7 @@ func newWebhookPresetCmds(loader OnCallConfigLoader) []*cobra.Command {
 
   # Put the preset ID in the preset field of webhook.yaml, then create the webhook
   gcx irm oncall webhooks create -f webhook.yaml`,
-		codec: &webhookPresetTableCodec{},
+		codec: webhookPresetTable().Codec(cmdio.FormatTable),
 		fetch: func(ctx context.Context, client OnCallAPI) ([]WebhookPreset, error) {
 			return client.ListWebhookPresets(ctx)
 		},
@@ -225,79 +218,56 @@ func newRouteFilterTypeCmds(loader OnCallConfigLoader) []*cobra.Command {
 
   # Put that value in the filtering_term_type field of route.yaml, then create the route
   gcx irm oncall routes create -f route.yaml`,
-		codec: &routeFilterTypeTableCodec{},
+		codec: routeFilterTypeTable().Codec(cmdio.FormatTable),
 		fetch: func(ctx context.Context, client OnCallAPI) ([]RouteFilterType, error) {
 			return client.ListRouteFilterTypes(ctx)
 		},
 	})
 }
 
-// --- Table codecs ---
+// --- Tables ---
 
-type escalationStepOptionTableCodec struct{ noDecodeCodec }
-
-func (c *escalationStepOptionTableCodec) Format() format.Format { return "table" }
-
-func (c *escalationStepOptionTableCodec) Encode(w io.Writer, v any) error {
-	items, ok := v.([]EscalationStepOption)
-	if !ok {
-		return errInvalidTableInput
+func escalationStepOptionTable() cmdio.Table[EscalationStepOption] {
+	return cmdio.Table[EscalationStepOption]{
+		Columns: []cmdio.Column[EscalationStepOption]{
+			{Header: "VALUE", Content: func(o EscalationStepOption) string { return strconv.Itoa(o.Value) }},
+			{Header: "NAME", Content: func(o EscalationStepOption) string { return o.CreateDisplayName }},
+			{Header: "DISPLAY NAME", Content: func(o EscalationStepOption) string { return o.DisplayName }},
+		},
 	}
-	t := style.NewTable("VALUE", "NAME", "DISPLAY NAME")
-	for _, it := range items {
-		t.Row(strconv.Itoa(it.Value), it.CreateDisplayName, it.DisplayName)
-	}
-	return t.Render(w)
 }
 
-type webhookTriggerOptionTableCodec struct{ noDecodeCodec }
-
-func (c *webhookTriggerOptionTableCodec) Format() format.Format { return "table" }
-
-func (c *webhookTriggerOptionTableCodec) Encode(w io.Writer, v any) error {
-	items, ok := v.([]WebhookTriggerOption)
-	if !ok {
-		return errInvalidTableInput
+func webhookTriggerOptionTable() cmdio.Table[WebhookTriggerOption] {
+	return cmdio.Table[WebhookTriggerOption]{
+		Columns: []cmdio.Column[WebhookTriggerOption]{
+			{Header: "VALUE", Content: func(o WebhookTriggerOption) string { return strconv.Itoa(o.Value) }},
+			{Header: "NAME", Content: func(o WebhookTriggerOption) string { return o.DisplayName }},
+		},
 	}
-	t := style.NewTable("VALUE", "NAME")
-	for _, it := range items {
-		t.Row(strconv.Itoa(it.Value), it.DisplayName)
-	}
-	return t.Render(w)
 }
 
-type webhookPresetTableCodec struct{ noDecodeCodec }
-
-func (c *webhookPresetTableCodec) Format() format.Format { return "table" }
-
-func (c *webhookPresetTableCodec) Encode(w io.Writer, v any) error {
-	items, ok := v.([]WebhookPreset)
-	if !ok {
-		return errInvalidTableInput
+func webhookPresetTable() cmdio.Table[WebhookPreset] {
+	return cmdio.Table[WebhookPreset]{
+		Columns: []cmdio.Column[WebhookPreset]{
+			{Header: "ID", Content: func(p WebhookPreset) string { return p.ID }},
+			{Header: "NAME", Content: func(p WebhookPreset) string { return p.Name }},
+			{Header: "TRIGGERS", Content: func(p WebhookPreset) string {
+				triggers := make([]string, 0, len(p.TriggerTypes))
+				for _, tt := range p.TriggerTypes {
+					triggers = append(triggers, tt.Value)
+				}
+				return strings.Join(triggers, ", ")
+			}},
+			{Header: "DESCRIPTION", Content: func(p WebhookPreset) string { return p.Description }},
+		},
 	}
-	t := style.NewTable("ID", "NAME", "TRIGGERS", "DESCRIPTION")
-	for _, it := range items {
-		triggers := make([]string, 0, len(it.TriggerTypes))
-		for _, tt := range it.TriggerTypes {
-			triggers = append(triggers, tt.Value)
-		}
-		t.Row(it.ID, it.Name, strings.Join(triggers, ", "), it.Description)
-	}
-	return t.Render(w)
 }
 
-type routeFilterTypeTableCodec struct{ noDecodeCodec }
-
-func (c *routeFilterTypeTableCodec) Format() format.Format { return "table" }
-
-func (c *routeFilterTypeTableCodec) Encode(w io.Writer, v any) error {
-	items, ok := v.([]RouteFilterType)
-	if !ok {
-		return errInvalidTableInput
+func routeFilterTypeTable() cmdio.Table[RouteFilterType] {
+	return cmdio.Table[RouteFilterType]{
+		Columns: []cmdio.Column[RouteFilterType]{
+			{Header: "VALUE", Content: func(f RouteFilterType) string { return strconv.Itoa(f.Value) }},
+			{Header: "NAME", Content: func(f RouteFilterType) string { return f.DisplayName }},
+		},
 	}
-	t := style.NewTable("VALUE", "NAME")
-	for _, it := range items {
-		t.Row(strconv.Itoa(it.Value), it.DisplayName)
-	}
-	return t.Render(w)
 }

--- a/internal/providers/irm/testdata/discovery_escalation_steps.golden
+++ b/internal/providers/irm/testdata/discovery_escalation_steps.golden
@@ -1,0 +1,3 @@
+VALUE  NAME              DISPLAY NAME
+19     Declare Incident  declare incident
+0                        

--- a/internal/providers/irm/testdata/discovery_route_filter_types.golden
+++ b/internal/providers/irm/testdata/discovery_route_filter_types.golden
@@ -1,0 +1,3 @@
+VALUE  NAME
+0      Regex
+1      

--- a/internal/providers/irm/testdata/discovery_route_filter_types_empty.golden
+++ b/internal/providers/irm/testdata/discovery_route_filter_types_empty.golden
@@ -1,0 +1,1 @@
+VALUE  NAME

--- a/internal/providers/irm/testdata/discovery_webhook_presets.golden
+++ b/internal/providers/irm/testdata/discovery_webhook_presets.golden
@@ -1,0 +1,3 @@
+ID        NAME        TRIGGERS                       DESCRIPTION
+preset-1  ServiceNow  alert group created, resolved  Create a ServiceNow ticket
+preset-2  bare                                       

--- a/internal/providers/irm/testdata/discovery_webhook_triggers.golden
+++ b/internal/providers/irm/testdata/discovery_webhook_triggers.golden
@@ -1,0 +1,3 @@
+VALUE  NAME
+12     Incident Changed
+0      


### PR DESCRIPTION
Part of #1275.

First of three PRs migrating irm table codecs onto `output.Table[T]` 


- replace four codec implementations with column lists, using the common table codec interface.
- Add golden files for all four codecs, to ensure the output remains unchanged.

