### PR TITLE
fix(output): Make --jq compatible with -o agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,6 +592,7 @@ jobs:
 - `--dry-run` on `push` and `delete` to preview changes
 - `--on-error abort|fail|ignore` to control error behavior
 - `-o json` or `-o yaml` for machine-parseable output
+- `--jq '<expr>' -o agents` for [jq with compact output and spilling](docs/design/output.md#16-jq-transformation)
 
 
 ## Documentation

--- a/cmd/gcx/agent/prune.go
+++ b/cmd/gcx/agent/prune.go
@@ -21,9 +21,13 @@ const pruneOlderThan = 30 * time.Minute
 // PruneSpillFiles deletes gcx agent spill files in dir that are older than olderThan.
 // Returns the number of files deleted.
 func PruneSpillFiles(dir string, olderThan time.Duration) (int, error) {
-	matches, err := filepath.Glob(filepath.Join(dir, cmdio.SpillFilePattern))
-	if err != nil {
-		return 0, fmt.Errorf("glob spill files: %w", err)
+	var matches []string
+	for _, pattern := range []string{cmdio.SpillFilePattern, cmdio.SpillStreamFilePattern} {
+		files, err := filepath.Glob(filepath.Join(dir, pattern))
+		if err != nil {
+			return 0, fmt.Errorf("glob spill files: %w", err)
+		}
+		matches = append(matches, files...)
 	}
 
 	cutoff := time.Now().Add(-olderThan)
@@ -93,7 +97,7 @@ func pruneCommand() *cobra.Command {
 		Annotations: map[string]string{
 			agent.AnnotationTokenCost: "small",
 		},
-		Long: `Remove gcx agent spill files (` + cmdio.SpillFilePattern + `) from the system temp directory that are older than 30 minutes.
+		Long: `Remove gcx agent spill files (` + cmdio.SpillFilePattern + ` and ` + cmdio.SpillStreamFilePattern + `) from the system temp directory that are older than 30 minutes.
 
 These files are created when a command response exceeds the spill threshold (default 100 KiB). Run prune periodically to keep the temp directory clean, or call it at the end of an agent session.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/cmd/gcx/agent/prune_test.go
+++ b/cmd/gcx/agent/prune_test.go
@@ -60,6 +60,38 @@ func TestPrune_IgnoresNonSpillFiles(t *testing.T) {
 	require.NoError(t, statErr, "non-spill file must still exist")
 }
 
+func TestPrune_JSONLSpillFiles(t *testing.T) {
+	tests := []struct {
+		name    string
+		file    string
+		age     time.Duration
+		deleted int
+	}{
+		{"old stream", "gcx-results-old.jsonl", 31 * time.Minute, 1},
+		{"recent stream", "gcx-results-recent.jsonl", time.Minute, 0},
+		{"unrelated JSONL", "other.jsonl", time.Hour, 0},
+		{"not a spill extension", "gcx-results-old.jsonl.backup", time.Hour, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, tt.file)
+			require.NoError(t, os.WriteFile(path, []byte("1\n2\n"), 0o600))
+			modified := time.Now().Add(-tt.age)
+			require.NoError(t, os.Chtimes(path, modified, modified))
+			deleted, err := agent.PruneSpillFiles(dir, 30*time.Minute)
+			require.NoError(t, err)
+			assert.Equal(t, tt.deleted, deleted)
+			_, err = os.Stat(path)
+			if tt.deleted == 1 {
+				require.ErrorIs(t, err, os.ErrNotExist)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestPrune_NoFiles_ReturnsZero(t *testing.T) {
 	dir := t.TempDir()
 	deleted, err := agent.PruneSpillFiles(dir, 30*time.Minute)

--- a/cmd/gcx/config/jq_agents_test.go
+++ b/cmd/gcx/config/jq_agents_test.go
@@ -1,0 +1,31 @@
+package config_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/grafana/gcx/internal/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListContexts_JQAgents(t *testing.T) {
+	for _, agentMode := range []bool{false, true} {
+		for _, jqFirst := range []bool{false, true} {
+			t.Run(fmt.Sprintf("agent=%t/jqFirst=%t", agentMode, jqFirst), func(t *testing.T) {
+				testutils.SetAgentMode(t, agentMode)
+				t.Setenv("GCX_AGENT_SPILL_BYTES", "2") // Full contexts spill, the transformed count fits.
+				t.Setenv("TMPDIR", t.TempDir())
+				configFile := testutils.CreateTempFile(t, "version: 1\ncurrent-context: first\ncontexts:\n  first: {}\n  second: {}\n")
+				args := []string{"list-contexts", "--config", configFile}
+				if jqFirst {
+					args = append(args, "--jq", ".contexts | length", "-o", "agents")
+				} else {
+					args = append(args, "-o", "agents", "--jq", ".contexts | length")
+				}
+				stdout, err := runConfigCommand(t, args...)
+				require.NoError(t, err)
+				require.Equal(t, "2\n", stdout)
+			})
+		}
+	}
+}

--- a/cmd/gcx/resources/get_partial_failure_test.go
+++ b/cmd/gcx/resources/get_partial_failure_test.go
@@ -124,10 +124,7 @@ func TestGetPartialFailure_AtomicStdout(t *testing.T) {
 	}
 }
 
-// TestGetPartialFailure_JQKeepsShape pins that an active --jq transformation
-// is never dropped by the agent-mode fused envelope: the jq output keeps its
-// shape (identical to a success run) and the failure travels via the typed
-// stderr diagnostic + EmittedError exit 4, like other explicit formats.
+// Partial failures preserve jq output; stderr and EmittedError carry the failure.
 func TestGetPartialFailure_JQKeepsShape(t *testing.T) {
 	agent.SetFlag(true)
 	t.Cleanup(func() { agent.SetFlag(false) })
@@ -138,39 +135,47 @@ func TestGetPartialFailure_JQKeepsShape(t *testing.T) {
 		"metadata":   map[string]any{"name": "alpha"},
 	}}
 
-	flags := pflag.NewFlagSet("get", pflag.ContinueOnError)
-	opts := resources.NewGetOptsForTest(flags)
-	if err := flags.Set("jq", ".items[].metadata.name"); err != nil {
-		t.Fatalf("set --jq: %v", err)
-	}
-	if err := opts.Validate(); err != nil {
-		t.Fatalf("Validate() = %v", err)
-	}
+	for _, outputFormat := range []string{"json", "agents"} {
+		t.Run(outputFormat, func(t *testing.T) {
+			t.Setenv("GCX_AGENT_SPILL_BYTES", "102400")
+			flags := pflag.NewFlagSet("get", pflag.ContinueOnError)
+			opts := resources.NewGetOptsForTest(flags)
+			if err := flags.Set("output", outputFormat); err != nil {
+				t.Fatalf("set -o: %v", err)
+			}
+			if err := flags.Set("jq", ".items[].metadata.name"); err != nil {
+				t.Fatalf("set --jq: %v", err)
+			}
+			if err := opts.Validate(); err != nil {
+				t.Fatalf("Validate() = %v", err)
+			}
 
-	summary := &remote.OperationSummary{}
-	summary.RecordSuccess()
-	summary.RecordFailure(nil, errors.New("boom"))
-	res := &resources.FetchResponse{PullSummary: summary}
-	output := unstructured.UnstructuredList{Items: []unstructured.Unstructured{item}}
+			summary := &remote.OperationSummary{}
+			summary.RecordSuccess()
+			summary.RecordFailure(nil, errors.New("boom"))
+			res := &resources.FetchResponse{PullSummary: summary}
+			output := unstructured.UnstructuredList{Items: []unstructured.Unstructured{item}}
 
-	var stdout, stderr bytes.Buffer
-	opts.IO.ErrWriter = &stderr
-	err := resources.WriteGetOutputForTest(&stdout, &stderr, opts, res, output)
+			var stdout, stderr bytes.Buffer
+			opts.IO.ErrWriter = &stderr
+			err := resources.WriteGetOutputForTest(&stdout, &stderr, opts, res, output)
 
-	var emitted *gcxerrors.EmittedError
-	if !errors.As(err, &emitted) {
-		t.Fatalf("writeGetOutput() error = %T (%v), want *gcxerrors.EmittedError", err, err)
-	}
-	if emitted.Code != gcxerrors.ExitPartialFailure {
-		t.Fatalf("EmittedError.Code = %d, want %d", emitted.Code, gcxerrors.ExitPartialFailure)
-	}
+			var emitted *gcxerrors.EmittedError
+			if !errors.As(err, &emitted) {
+				t.Fatalf("writeGetOutput() error = %T (%v), want *gcxerrors.EmittedError", err, err)
+			}
+			if emitted.Code != gcxerrors.ExitPartialFailure {
+				t.Fatalf("EmittedError.Code = %d, want %d", emitted.Code, gcxerrors.ExitPartialFailure)
+			}
 
-	// stdout must be the jq transformation, not a fused envelope.
-	got := strings.TrimSpace(stdout.String())
-	if got != `"alpha"` {
-		t.Fatalf("stdout = %q, want jq output %q", got, `"alpha"`)
-	}
-	if !strings.Contains(stderr.String(), "failed to get") {
-		t.Fatalf("stderr = %q, want partial-failure diagnostic", stderr.String())
+			// stdout must be the jq transformation, not a fused envelope.
+			got := strings.TrimSpace(stdout.String())
+			if got != `"alpha"` {
+				t.Fatalf("stdout = %q, want jq output %q", got, `"alpha"`)
+			}
+			if !strings.Contains(stderr.String(), "failed to get") {
+				t.Fatalf("stderr = %q, want partial-failure diagnostic", stderr.String())
+			}
+		})
 	}
 }

--- a/cmd/gcx/root/agentconformance_test.go
+++ b/cmd/gcx/root/agentconformance_test.go
@@ -196,6 +196,37 @@ func TestAgentConformance_FailuresAreOneInBandErrorDocument(t *testing.T) {
 	}
 }
 
+// Late jq errors must emit only the error document, even after spilling.
+func TestAgentConformance_JQAgentsRuntimeError(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds the gcx binary; skipped with -short")
+	}
+	configFile := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(configFile, []byte("version: 1\ncontexts: {}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, query := range []string{`1, error("boom")`, `("x" * 102400), error("boom")`} {
+		t.Run(query, func(t *testing.T) {
+			stdout, code := runGcx(t, "config", "list-contexts", "--config", configFile,
+				"--jq", query, "-o", "agents")
+			if code == 0 {
+				t.Fatalf("expected runtime failure, got success:\n%s", stdout)
+			}
+			obj, ok := assertOneJSONValue(t, stdout).(map[string]any)
+			if !ok || obj["type"] != "gcx.error" {
+				t.Fatalf("expected gcx.error, got:\n%s", stdout)
+			}
+			errField, ok := obj["error"].(map[string]any)
+			if !ok || errField["exitCode"] != float64(code) {
+				t.Fatalf("error exit code disagrees with process code %d:\n%s", code, stdout)
+			}
+			if !strings.Contains(stdout, "boom") {
+				t.Fatalf("runtime error was lost:\n%s", stdout)
+			}
+		})
+	}
+}
+
 // TestAgentConformance_InvalidStackSlugIsUsageError pins the client-side slug
 // validation added for issue #950: an invalid slug fails before the dry-run
 // preview with a single gcx.error document and a usage exit code, in both the

--- a/docs/architecture/cli-layer.md
+++ b/docs/architecture/cli-layer.md
@@ -585,7 +585,11 @@ empty), and the agents codec's spill summary previews and counts the
 envelope's items. The opt-in is deliberate: a structural multi-key heuristic
 would misclassify detail objects that happen to contain one nested array.
 
-Built-in codecs: `json` and `yaml` (always available). Commands register additional ones (e.g. `text`, `wide`, `graph`) by calling `RegisterCustomCodec` before `BindFlags`.
+Use `Options.Encode` for structured output: `Codec().Encode` bypasses jq,
+field selection, and discovery. jq runs before formatting or spilling; see
+[the output contract](../design/output.md#16-jq-transformation).
+
+Built-in codecs: `json`, `yaml`, and `agents` (always available). Commands register additional ones (e.g. `text`, `wide`, `graph`) by calling `RegisterCustomCodec` before `BindFlags`.
 
 The `graph` codec is a special-purpose output format available on per-kind `query` subcommands (`metrics query`, `logs query`, `profiles series`, etc.) and `synth checks status`. It renders Prometheus or Loki query results (or check status metrics) as a terminal line chart using `ntcharts` and `lipgloss` (via `internal/graph`). Terminal width is detected at render time via `golang.org/x/term`.
 

--- a/docs/design/agent-mode.md
+++ b/docs/design/agent-mode.md
@@ -78,7 +78,9 @@ from `| python -c "..."` aggregation pipelines toward built-in transformation.
 ### 6.3 Opt-Out
 
 Explicit flags override agent mode defaults:
-- `-o json` forces full compact JSON to stdout (no spill)
+- `-o json` forces full indented JSON to stdout (no spill)
+- Bare `--jq` disables spill; add `-o agents` for
+  [compact/spill handling](output.md#16-jq-transformation)
 - `-o text` or `-o yaml` overrides the agents default
 - `-o wide` retains human table output even in agent mode (explicit-override semantics — the
   operator has explicitly requested wide table format, so the JSON default is not applied)

--- a/docs/design/output.md
+++ b/docs/design/output.md
@@ -49,11 +49,12 @@ spill threshold (default **100 KiB**), and spills to a temp file otherwise.
 |-------|---------------|-------------|
 | `type` | yes | Fixed discriminator `gcx.spill_reference` — the receipt shape differs from the domain result, so consumers dispatch on this marker instead of heuristics |
 | `schema_version` | yes | Version of the receipt shape itself (currently `1`) |
-| `content_format` | yes | Media type of the spilled file's content (`json`) |
+| `content_format` | yes | `json` for documents; `jsonl` for jq streams (see § 1.6) |
 | `spilled_to` | yes | Absolute path to the full-payload file |
 | `bytes` | yes | Byte size of the full payload |
 | `total_items` | only for lists | Element count — named `total_items` (not `items`) to avoid collision with the k8s list `items` array shape |
-| `preview_sample` | yes | First 3 items for list shapes; sorted top-level key names for object/map shapes; `null` for other shapes. Named `preview_sample` (not `preview`) to signal it is never the complete dataset |
+| `total_values` | only for jq streams | Yielded-value count, not list elements; replaces `total_items` |
+| `preview_sample` | yes | First 3 items for list shapes; sorted top-level key names for object/map shapes; `null` for other shapes and jq streams. Named `preview_sample` (not `preview`) to signal it is never the complete dataset |
 | `message` | yes | Human-readable guidance: references `spilled_to` path and opt-outs |
 
 **Override:** `-o json` forces the full document inline to stdout regardless
@@ -170,49 +171,44 @@ resource object. `--json` is an independent mechanism (NC-002).
 
 ### 1.6 JQ Transformation
 
-The `--jq` flag applies a [jq](https://jqlang.github.io/jq/) expression to the
-command's JSON output before it reaches stdout. This eliminates the need to
-pipe gcx output into external scripts for grouping, reducing, or filtering — a
-common pain point when agents drive investigations and resort to generated
-Python.
+`--jq` transforms the full command result **before** formatting or spilling,
+never a spill receipt.
 
 ```bash
-# Count items
-gcx resources get dashboards --jq '.items | length'
+# Count contexts, with compact/spill handling
+gcx config list-contexts --jq '.contexts | length' -o agents
 
-# Extract names
+# Yield one value per dashboard
 gcx resources get dashboards --jq '.items[] | .metadata.name'
-
-# Reshape into a custom collection
-gcx resources get dashboards --jq '[.items[] | {name: .metadata.name, title: .spec.title}]'
 ```
 
-**Flag semantics:**
+| Combination | Behavior |
+|-------------|----------|
+| Bare `--jq` or `-o json --jq` | Pretty-printed JSON values, no spill, including in agent mode |
+| `-o agents --jq` | Compact JSONL, without HTML escaping, with aggregate spilling |
+| Other `-o` formats or `--json` with `--jq` | Rejected |
+| Invalid syntax | Validation error before command execution |
+| Empty/whitespace expression or unknown function | jq evaluation error |
 
-| Value | Behavior |
-|-------|----------|
-| `--jq '<expr>'` | Run the jq expression against the full JSON output |
-| `--jq` + `-o json` (or `-o` unset) | Allowed; auto-flips to JSON when `-o` is unset |
-| `--jq` + `-o <non-json>` | Usage error — jq operates on JSON input |
-| `--jq` + `--json ...` | Usage error — jq supersedes field selection |
-| Invalid jq expression | Validation error (syntax fails fast at flag parse time) |
+**Shape:** Zero values emit nothing; one or many values (including primitives)
+remain separate, never implicitly wrapped in an array. A yielded `null` emits
+`null\n`. Pretty-printed JSON can span lines; only agents output is JSONL.
 
-**Output shape:** Real-jq-compatible NDJSON. Each yielded value is
-pretty-printed JSON on its own line, so filters like `.items[]` stream one
-object per line — matching what users intuit from real `jq`. Empty result sets
-emit nothing.
+**Spilling with explicit `-o agents`:**
+- `GCX_AGENT_SPILL_BYTES` (default 100 KiB) limits the **entire transformed
+  stream**, including newlines—not each value or the original payload.
+- At or below the threshold, stdout gets the complete stream. Above it, the
+  same bytes go to one `$TMPDIR/gcx-results-<random>.jsonl` file; stdout gets
+  only a spill receipt, and stderr gets a hint.
+- The receipt uses `content_format: "jsonl"`, `total_values`, no `total_items`,
+  and `preview_sample: null` to avoid unbounded previews. Its fixed metadata
+  may exceed a very small threshold. `gcx agent prune` includes JSONL spills.
+- Evaluation/encoding errors discard buffered output and partial spill files;
+  I/O errors propagate without an inline fallback. Bare jq and `-o json`
+  retain already-emitted values on a later error.
 
-**Relationship to `--json`:** `--jq` strictly subsumes `--json` field
-selection. Combining the two is rejected to keep the model simple — anything
-`--json field1,field2` does, `{field1: .field1, field2: .field2}` does in jq.
-
-**Agents codec:** `--jq` bypasses the agents codec's spill-to-tempfile
-behavior. A caller using `--jq` wants the transformed results in-stream, not a
-"spilled to /tmp" summary.
-
-**Implementation:** `internal/output/jq.go` (`JQCodec`). Flag parsing and
-mutual-exclusion enforcement in `internal/output/format.go` (`applyJQFlag`).
-Library: [`github.com/itchyny/gojq`](https://github.com/itchyny/gojq).
+**Implementation:** `internal/output/{format,jq,agents}.go`, using
+[gojq](https://github.com/itchyny/gojq).
 
 ---
 

--- a/docs/reference/cli/gcx_agent_prune.md
+++ b/docs/reference/cli/gcx_agent_prune.md
@@ -4,7 +4,7 @@ Remove gcx agent spill files older than 30 minutes
 
 ### Synopsis
 
-Remove gcx agent spill files (gcx-results-*.json) from the system temp directory that are older than 30 minutes.
+Remove gcx agent spill files (gcx-results-*.json and gcx-results-*.jsonl) from the system temp directory that are older than 30 minutes.
 
 These files are created when a command response exceeds the spill threshold (default 100 KiB). Run prune periodically to keep the temp directory clean, or call it at the end of an agent session.
 

--- a/internal/output/agents.go
+++ b/internal/output/agents.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"iter"
 	"os"
 	"reflect"
 	"sort"
@@ -21,21 +22,17 @@ const (
 	defaultSpillBytes               = 100 * 1024 // 100 KiB
 	spillPreviewItems               = 3
 
-	// SpillFilePattern is the glob pattern for agent spill files. Exported so
-	// companion commands (e.g. gcx agent prune) can locate them.
+	// SpillFilePattern matches document spills for gcx agent prune.
 	SpillFilePattern = "gcx-results-*.json"
+	// SpillStreamFilePattern is the equivalent pattern for jq JSONL streams.
+	SpillStreamFilePattern = "gcx-results-*.jsonl"
 )
 
 type agentsCodec struct {
 	errWriter io.Writer
 }
 
-// spillSummary is the receipt written to stdout instead of an oversized
-// payload. Because the codec's output SHAPE changes at the spill threshold,
-// the receipt carries collision-resistant discriminators so a consumer can
-// tell it apart from domain results without heuristics: Type is the fixed
-// marker, SchemaVersion versions this receipt shape, and ContentFormat names
-// the media type of the spilled file's content.
+// spillSummary replaces oversized output with a typed, versioned file reference.
 type spillSummary struct {
 	Type          string `json:"type"`
 	SchemaVersion string `json:"schema_version"`
@@ -45,6 +42,7 @@ type spillSummary struct {
 	PreviewSample any    `json:"preview_sample"`
 	Message       string `json:"message"`
 	TotalItems    *int   `json:"total_items,omitempty"`
+	TotalValues   *int   `json:"total_values,omitempty"` // jq stream values, not array elements
 }
 
 const (
@@ -83,6 +81,65 @@ func (c *agentsCodec) Encode(dst io.Writer, value any) error {
 	return c.spill(dst, value, buf.Bytes())
 }
 
+// encodeJQ budgets the whole JSONL stream and delays stdout until evaluation
+// succeeds, so late errors leave neither partial output nor a success receipt.
+func (c *agentsCodec) encodeJQ(dst io.Writer, results iter.Seq2[any, error]) error {
+	var buf bytes.Buffer
+	enc := json.NewEncoder(&buf)
+	enc.SetEscapeHTML(false)
+	threshold := spillThreshold()
+	var f *os.File
+	success := false
+	defer func() {
+		if f != nil {
+			f.Close()
+			if !success {
+				os.Remove(f.Name())
+			}
+		}
+	}()
+
+	count, size := 0, 0
+	for value, err := range results {
+		if err != nil {
+			return err
+		}
+		if err := enc.Encode(value); err != nil {
+			return err
+		}
+		count++
+		if f == nil && buf.Len() > threshold {
+			f, err = os.CreateTemp("", SpillStreamFilePattern)
+			if err != nil {
+				return fmt.Errorf("create spill file: %w", err)
+			}
+		}
+		if f != nil {
+			size += buf.Len()
+			if _, err := io.Copy(f, &buf); err != nil {
+				return fmt.Errorf("write spill file: %w", err)
+			}
+		}
+	}
+
+	if f == nil {
+		_, err := io.Copy(dst, &buf)
+		return err
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("close spill file: %w", err)
+	}
+	// Omit previews: a single yielded value could make the receipt unbounded.
+	err := c.writeSpillSummary(dst, spillSummary{
+		SpilledTo:     f.Name(),
+		Bytes:         size,
+		ContentFormat: "jsonl",
+		TotalValues:   &count,
+	})
+	success = err == nil
+	return err
+}
+
 func (c *agentsCodec) spill(dst io.Writer, value any, payload []byte) error {
 	f, err := os.CreateTemp("", SpillFilePattern)
 	if err != nil {
@@ -97,37 +154,38 @@ func (c *agentsCodec) spill(dst io.Writer, value any, payload []byte) error {
 		return fmt.Errorf("close spill file: %w", err)
 	}
 
-	msg := fmt.Sprintf(
-		"Response too large for stdout (%d bytes). Full data written to %s. Read that file for complete results, or rerun with -o json to force inline output.",
-		len(payload), f.Name(),
-	)
-
 	s := spillSummary{
-		Type:          SpillReferenceType,
-		SchemaVersion: spillSchemaVersion,
 		SpilledTo:     f.Name(),
 		Bytes:         len(payload),
 		ContentFormat: "json",
 		PreviewSample: previewOf(value),
-		Message:       msg,
 	}
 	if n, ok := itemCount(value); ok {
 		s.TotalItems = &n
 	}
+	return c.writeSpillSummary(dst, s)
+}
 
-	// Typed hint diagnostic: on a TTY this renders the familiar
-	// "hint: ..." line; in agent mode it must be a JSONL
-	// {"class":"hint",...} record so the stderr stream stays
-	// machine-parseable (FR-104). The command argument is empty because the
-	// summary already embeds the spill file path.
-	emitHint(c.errWriter,
-		fmt.Sprintf("response too large for stdout (%d bytes) — read %s for full data, or use -o json to force inline",
-			len(payload), f.Name()),
-		"")
+func (c *agentsCodec) writeSpillSummary(dst io.Writer, s spillSummary) error {
+	s.Type = SpillReferenceType
+	s.SchemaVersion = spillSchemaVersion
+	s.Message = fmt.Sprintf(
+		"Response too large for stdout (%d bytes). Full data written to %s. Read that file for complete results, or rerun with -o json to force inline output.",
+		s.Bytes, s.SpilledTo,
+	)
 
 	out := json.NewEncoder(dst)
 	out.SetEscapeHTML(false)
-	return out.Encode(s)
+	if err := out.Encode(s); err != nil {
+		return err
+	}
+
+	emitHint(c.errWriter,
+		fmt.Sprintf("response too large for stdout (%d bytes) — read %s for full data, or use -o json to force inline",
+			s.Bytes, s.SpilledTo),
+		"")
+
+	return nil
 }
 
 func spillThreshold() int {

--- a/internal/output/format.go
+++ b/internal/output/format.go
@@ -192,17 +192,8 @@ func (opts *Options) applyJSONFlag() error {
 	return nil
 }
 
-// applyJQFlag processes the --jq flag. The flag is mutually exclusive with
-// --json (both field selection and discovery): jq strictly supersedes those
-// mechanisms, so combining them adds confusion without value. Also, the two
-// resources/* commands that bypass Options.Encode() and construct
-// FieldSelectCodec directly (get.go, schemas.go) only fire when JSONFields or
-// JSONDiscovery is set — mutual exclusion preserves correctness there.
-//
-// When -o is unset, --jq auto-flips OutputFormat to "json" (mirrors --json).
-// An explicit non-JSON -o is rejected because jq operates on JSON input.
-// The expression is parsed eagerly so syntax errors surface during validation,
-// not encoding.
+// applyJQFlag validates --jq and its output format, rejecting --json.
+// Bare --jq selects JSON even in agent mode; explicit -o agents keeps spilling.
 func (opts *Options) applyJQFlag() error {
 	if opts.flags == nil {
 		return nil
@@ -219,8 +210,12 @@ func (opts *Options) applyJQFlag() error {
 	}
 
 	outputFlag := opts.flags.Lookup("output")
-	if outputFlag != nil && outputFlag.Changed && outputFlag.Value.String() != "json" {
-		return fmt.Errorf("--jq requires JSON output, but -o %s was specified", outputFlag.Value.String())
+	if outputFlag != nil && outputFlag.Changed {
+		switch outputFlag.Value.String() {
+		case "json", "agents":
+		default:
+			return fmt.Errorf("--jq requires JSON output (json or agents), but -o %s was specified", outputFlag.Value.String())
+		}
 	}
 
 	query, err := gojq.Parse(jqFlag.Value.String())
@@ -229,13 +224,14 @@ func (opts *Options) applyJQFlag() error {
 	}
 
 	opts.jqQuery = query
-	opts.OutputFormat = "json"
+	if outputFlag == nil || !outputFlag.Changed {
+		opts.OutputFormat = "json"
+	}
 	return nil
 }
 
-// JQActive reports whether a --jq transformation is in effect. Commands that
-// build fused envelopes (bypassing Options.Encode) must not do so when jq is
-// active — the envelope would silently drop the user's transformation.
+// JQActive reports whether jq is active. Callers must not bypass Options.Encode
+// with a fused envelope that would drop the transformation.
 func (opts *Options) JQActive() bool {
 	return opts.jqQuery != nil
 }
@@ -259,19 +255,8 @@ func (opts *Options) Encode(dst io.Writer, value any) error {
 		return err
 	}
 
-	// In agent mode, nudge toward --json field selection / --jq transformation
-	// whenever the resolved codec is JSON-like (json or agents format). The
-	// hint still fires when --json field1,field2 is in use — the caller may
-	// not realize --jq exists for transformation (group_by, filter, count).
-	// Suppressed when --jq is already in use (caller already has the more
-	// powerful tool) or when --json list is requested (discovery output is
-	// not a transformation target). Also suppressed for pinned-default
-	// (file-writing) commands: their encode fills a file or editor buffer,
-	// not stdout, and they reject --json/--jq — recommending those flags
-	// would contradict the command's own validation. Emitted once per
-	// invocation to stderr (never pollutes stdout) as JSONL
-	// {"class":"hint",...} via emitHint (FR-104). Suppressed outside agent
-	// mode to avoid noise on TTYs.
+	// Nudge agents toward jq once, even with field selection. Pinned file-output
+	// commands reject --json/--jq, so recommending those flags would be wrong.
 	isJSONLike := codec.Format() == format.JSON || codec.Format() == agentsFormat
 	if !opts.jsonFieldsHintShown && agent.IsAgentMode() && isJSONLike && !opts.JSONDiscovery && opts.jqQuery == nil && !opts.defaultFormatPinned {
 		opts.jsonFieldsHintShown = true
@@ -285,22 +270,22 @@ func (opts *Options) Encode(dst io.Writer, value any) error {
 		)
 	}
 
-	// Intercept JSON field discovery, field selection, and jq transformation
-	// when the resolved codec is JSON-like. Commands that already check
-	// JSONFields/JSONDiscovery before calling Encode() will never reach here
-	// (they return early), so there is no double-application risk. --jq is
-	// mutually exclusive with --json (enforced in applyJQFlag), so the order
-	// of the branches below does not matter for correctness.
-	if isJSONLike {
-		if opts.jqQuery != nil {
-			return NewJQCodec(opts.jqQuery).Encode(dst, value)
+	// Apply JSON transformations before encoding or spilling.
+	if !isJSONLike {
+		return codec.Encode(dst, value)
+	}
+	if opts.jqQuery != nil {
+		jq := NewJQCodec(opts.jqQuery)
+		if agents, ok := codec.(*agentsCodec); ok {
+			return agents.encodeJQ(dst, jq.results(value))
 		}
-		if opts.JSONDiscovery {
-			return opts.encodeDiscovery(dst, value)
-		}
-		if len(opts.JSONFields) > 0 {
-			return NewFieldSelectCodecWithValidator(opts.JSONFields, opts.jsonFieldValidator).Encode(dst, value)
-		}
+		return jq.Encode(dst, value)
+	}
+	if opts.JSONDiscovery {
+		return opts.encodeDiscovery(dst, value)
+	}
+	if len(opts.JSONFields) > 0 {
+		return NewFieldSelectCodecWithValidator(opts.JSONFields, opts.jsonFieldValidator).Encode(dst, value)
 	}
 
 	return codec.Encode(dst, value)

--- a/internal/output/jq.go
+++ b/internal/output/jq.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"iter"
 	"strings"
 
 	"github.com/grafana/gcx/internal/format"
@@ -107,22 +108,14 @@ func shallowFieldPaths(sample map[string]any) ([]string, int) {
 	return shallow, 0
 }
 
-// JQCodec applies a jq expression to a value and writes each yielded result
-// as pretty-printed JSON, one result per encoder call (matching real jq's
-// default output: sequential values, each pretty-printed — nested results
-// span multiple physical lines, so the stream is NOT line-delimited NDJSON).
-//
-// JQCodec intentionally bypasses the agents codec's spill-to-tempfile behavior:
-// a caller using --jq wants the transformed results in-stream, not a "spilled
-// to /tmp" summary.
+// JQCodec emits sequential pretty-printed JSON values for bare --jq and -o json.
+// Options.Encode routes the same results through agents when explicitly selected.
 type JQCodec struct {
 	query   *gojq.Query
 	decoder *format.JSONCodec
 }
 
-// NewJQCodec returns a JQCodec that runs the given compiled query.
-// Callers should obtain the query via gojq.Parse so syntax errors surface
-// during flag validation, not encoding.
+// NewJQCodec accepts a query parsed with gojq.Parse during flag validation.
 func NewJQCodec(query *gojq.Query) *JQCodec {
 	return &JQCodec{query: query, decoder: format.NewJSONCodec()}
 }
@@ -132,25 +125,41 @@ func (c *JQCodec) Format() format.Format {
 }
 
 func (c *JQCodec) Encode(dst io.Writer, value any) error {
-	input, err := toJQInput(value)
-	if err != nil {
-		return err
-	}
-
 	encoder := json.NewEncoder(dst)
 	encoder.SetIndent("", "  ")
 
-	iter := c.query.Run(input)
-	for {
-		v, ok := iter.Next()
-		if !ok {
-			return nil
-		}
-		if e, ok := v.(error); ok {
-			return newJQRuntimeError(e, input)
+	for v, err := range c.results(value) {
+		if err != nil {
+			return err
 		}
 		if err := encoder.Encode(v); err != nil {
 			return err
+		}
+	}
+	return nil
+}
+
+// results shares input normalization and runtime errors between JSON and agents.
+func (c *JQCodec) results(value any) iter.Seq2[any, error] {
+	return func(yield func(any, error) bool) {
+		input, err := toJQInput(value)
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+		results := c.query.Run(input)
+		for {
+			v, ok := results.Next()
+			if !ok {
+				return
+			}
+			if err, ok := v.(error); ok {
+				yield(nil, newJQRuntimeError(err, input))
+				return
+			}
+			if !yield(v, nil) {
+				return
+			}
 		}
 	}
 }
@@ -159,13 +168,8 @@ func (c *JQCodec) Decode(src io.Reader, value any) error {
 	return c.decoder.Decode(src, value)
 }
 
-// toJQInput converts an arbitrary Go value into the generic JSON primitives
-// gojq expects (maps, slices, strings, booleans, nil, and supported numbers).
-//
-// Unstructured types are reduced to their underlying map/list shape to avoid
-// pointer-receiver MarshalJSON quirks (mirrors marshalToSampleMap in
-// format.go). All values then round-trip through encoding/json with UseNumber
-// so gojq receives supported numeric types without losing integer precision.
+// toJQInput normalizes Go values for gojq without losing integer precision.
+// Unwrapping unstructured types avoids pointer-receiver MarshalJSON quirks.
 func toJQInput(value any) (any, error) {
 	switch v := value.(type) {
 	case unstructured.Unstructured:

--- a/internal/output/jq_agents_test.go
+++ b/internal/output/jq_agents_test.go
@@ -1,0 +1,324 @@
+package output_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/testutils"
+	"github.com/spf13/pflag"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+func TestOptions_JQ_FormatAndFlagOrder(t *testing.T) {
+	for _, agentMode := range []bool{false, true} {
+		for _, defaultFormat := range []string{"json", "text", "yaml", "agents"} {
+			t.Run(fmt.Sprintf("agent=%t/default=%s", agentMode, defaultFormat), func(t *testing.T) {
+				testutils.SetAgentMode(t, agentMode)
+				t.Setenv("GCX_AGENT_SPILL_BYTES", "1") // JSON jq must still stay inline.
+				t.Setenv("TMPDIR", t.TempDir())
+				for _, output := range []string{"", "json", "agents", "text", "table", "yaml", "bogus"} {
+					for _, jqFirst := range []bool{false, true} {
+						t.Run(fmt.Sprintf("output=%s/jqFirst=%t", output, jqFirst), func(t *testing.T) {
+							opts := &cmdio.Options{ErrWriter: io.Discard}
+							opts.DefaultFormat(defaultFormat)
+							opts.RegisterCustomCodec("text", &dummyCodec{})
+							opts.RegisterCustomCodec("table", &dummyCodec{})
+							flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+							opts.BindFlags(flags)
+							args := []string{"--jq", "."}
+							if output != "" {
+								if jqFirst {
+									args = append(args, "-o", output)
+								} else {
+									args = append([]string{"-o", output}, args...)
+								}
+							}
+							require.NoError(t, flags.Parse(args))
+							for range 2 { // Validation must be idempotent, too.
+								err := opts.Validate()
+								switch output {
+								case "text", "table", "yaml":
+									require.ErrorContains(t, err, "--jq requires JSON output (json or agents)")
+								case "bogus":
+									require.ErrorContains(t, err, "unknown output format")
+								default:
+									require.NoError(t, err)
+									wantFormat := output
+									if wantFormat == "" {
+										wantFormat = "json"
+									}
+									require.Equal(t, wantFormat, opts.OutputFormat)
+									require.True(t, opts.JQActive())
+								}
+							}
+							if output == "" || output == "json" {
+								var out bytes.Buffer
+								require.NoError(t, opts.Encode(&out, map[string]string{"name": "<a>&"}))
+								//nolint:testifylint // JSONEq would hide changes to indentation and HTML escaping.
+								assert.Equal(t, "{\n  \"name\": \"\\u003ca\\u003e\\u0026\"\n}\n", out.String())
+							}
+						})
+					}
+				}
+			})
+		}
+	}
+}
+
+func TestOptions_JQ_JSONStreamCompatibility(t *testing.T) {
+	t.Setenv("GCX_AGENT_SPILL_BYTES", "1")
+	t.Setenv("TMPDIR", t.TempDir())
+	tests := []struct {
+		query   string
+		want    string
+		wantErr string
+	}{
+		{"empty", "", ""},
+		{"1, {name: \"<a>\"}, []", "1\n{\n  \"name\": \"\\u003ca\\u003e\"\n}\n[]\n", ""},
+		{"1, error(\"boom\")", "1\n", "jq runtime: error: boom"},
+		{"", "", "jq runtime: missing query"},
+		{"  ", "", "jq runtime: missing query"},
+	}
+	for _, tt := range tests {
+		for _, output := range []string{"", "json"} {
+			t.Run(tt.query+"/output="+output, func(t *testing.T) {
+				opts := &cmdio.Options{ErrWriter: io.Discard}
+				flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+				opts.BindFlags(flags)
+				args := []string{"--jq", tt.query}
+				if output != "" {
+					args = append(args, "-o", output)
+				}
+				require.NoError(t, flags.Parse(args))
+				require.NoError(t, opts.Validate())
+				var stdout bytes.Buffer
+				err := opts.Encode(&stdout, nil)
+				if tt.wantErr != "" {
+					require.ErrorContains(t, err, tt.wantErr)
+				} else {
+					require.NoError(t, err)
+				}
+				assert.Equal(t, tt.want, stdout.String())
+			})
+		}
+	}
+}
+
+func TestOptions_JQ_ConflictingAndRepeatedFlags(t *testing.T) {
+	testutils.SetAgentMode(t, false)
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"agents then json", []string{"-o", "agents", "--jq", ".", "-o", "json"}, ""},
+		{"json then agents", []string{"-o", "json", "--jq", ".", "-o", "agents"}, ""},
+		{"last format is invalid", []string{"-o", "agents", "--jq", ".", "-o", "yaml"}, "--jq requires JSON output"},
+		{"selection", []string{"--json", "name", "--jq", "."}, "--jq and --json cannot be used together"},
+		{"discovery", []string{"--json", "?", "--jq", "."}, "--jq and --json cannot be used together"},
+		{"list discovery", []string{"--json", "list", "--jq", "."}, "--jq and --json cannot be used together"},
+		{"empty selection", []string{"--json", "", "--jq", "."}, "--jq and --json cannot be used together"},
+		{"agents and selection", []string{"-o", "agents", "--json", "name", "--jq", "."}, "--json requires JSON output"},
+		{"agents and invalid jq", []string{"-o", "agents", "--jq", "broken["}, "invalid --jq expression"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orders := [][]string{tt.args}
+			if tt.want != "" { // Reverse flag/value pairs, not repeated-output precedence.
+				var reversed []string
+				for i := len(tt.args) - 2; i >= 0; i -= 2 {
+					reversed = append(reversed, tt.args[i:i+2]...)
+				}
+				if tt.name != "last format is invalid" {
+					orders = append(orders, reversed)
+				}
+			}
+			for _, args := range orders {
+				opts := &cmdio.Options{}
+				flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+				opts.BindFlags(flags)
+				require.NoError(t, flags.Parse(args))
+				for range 2 {
+					err := opts.Validate()
+					if tt.want != "" {
+						require.ErrorContains(t, err, tt.want)
+					} else {
+						require.NoError(t, err)
+						assert.Equal(t, args[len(args)-1], opts.OutputFormat)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestOptions_JQ_AgentsStream(t *testing.T) {
+	tests := []struct {
+		name      string
+		query     string
+		value     any
+		threshold string
+		want      string
+		values    int
+		spill     bool
+	}{
+		{name: "compact object without HTML escaping", query: ".", value: map[string]string{"name": "<a>&"}, threshold: "100", want: "{\"name\":\"<a>&\"}\n", values: 1},
+		{name: "at aggregate threshold", query: ".[]", value: []string{"a", "b"}, threshold: "8", want: "\"a\"\n\"b\"\n", values: 2},
+		{name: "over aggregate threshold", query: ".[]", value: []string{"a", "b"}, threshold: "7", want: "\"a\"\n\"b\"\n", values: 2, spill: true},
+		{name: "empty stream", query: "empty", threshold: "1", want: ""},
+		{name: "empty input array", query: ".[]", value: []any{}, threshold: "1", want: ""},
+		{name: "null is a value", query: "null", threshold: "5", want: "null\n", values: 1},
+		{name: "spilled null", query: "null", threshold: "4", want: "null\n", values: 1, spill: true},
+		{name: "mixed values", query: "null, true, 1.5, \"a\\nb\", {a: 1}, []", threshold: "100", want: "null\ntrue\n1.5\n\"a\\nb\"\n{\"a\":1}\n[]\n", values: 6},
+		{name: "large to small", query: ".payload | length", value: map[string]string{"payload": strings.Repeat("x", 102400)}, threshold: "8", want: "102400\n", values: 1},
+		{name: "small to large primitive", query: "\"x\" * 2048", threshold: "1024", want: "\"" + strings.Repeat("x", 2048) + "\"\n", values: 1, spill: true},
+		{name: "large array is still one value", query: "[\"x\" * 2048]", threshold: "1024", want: "[\"" + strings.Repeat("x", 2048) + "\"]\n", values: 1, spill: true},
+		{name: "many small values share one budget", query: "range(0; 10000) | 0", threshold: "1024", want: strings.Repeat("0\n", 10000), values: 10000, spill: true},
+		{name: "continue after spilling", query: "(\"x\" * 2048), 1, 2", threshold: "1024", want: "\"" + strings.Repeat("x", 2048) + "\"\n1\n2\n", values: 3, spill: true},
+		{name: "large integer inline", query: ".spec.id + 1", value: unstructured.Unstructured{Object: map[string]any{"spec": map[string]any{"id": int64(9007199254740993)}}}, threshold: "100", want: "9007199254740994\n", values: 1},
+		{name: "big integer spilled", query: "18446744073709551616 + 1", threshold: "1", want: "18446744073709551617\n", values: 1, spill: true},
+		{name: "default threshold", query: ".", value: strings.Repeat("x", 102397), threshold: "", want: "\"" + strings.Repeat("x", 102397) + "\"\n", values: 1},
+		{name: "default threshold exceeded", query: ".", value: strings.Repeat("x", 102398), threshold: "", want: "\"" + strings.Repeat("x", 102398) + "\"\n", values: 1, spill: true},
+		{name: "invalid threshold falls back", query: "1", threshold: "invalid", want: "1\n", values: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testutils.SetAgentMode(t, true)
+			t.Setenv("GCX_AGENT_SPILL_BYTES", tt.threshold)
+			dir := t.TempDir()
+			t.Setenv("TMPDIR", dir)
+			var stdout, stderr bytes.Buffer
+			opts := jqAgentsOptions(t, tt.query, &stderr)
+			require.NoError(t, opts.Encode(&stdout, tt.value))
+
+			files, err := os.ReadDir(dir)
+			require.NoError(t, err)
+			if !tt.spill {
+				assert.Equal(t, tt.want, stdout.String())
+				assert.Empty(t, files)
+				assert.Empty(t, stderr.String(), "jq suppresses the parsing hint")
+				return
+			}
+
+			require.Len(t, files, 1, "one file for the whole stream")
+			var receipt map[string]any
+			require.NoError(t, json.Unmarshal(stdout.Bytes(), &receipt), "stdout is only one receipt")
+			assert.Equal(t, cmdio.SpillReferenceType, receipt["type"])
+			assert.Equal(t, "1", receipt["schema_version"])
+			assert.Equal(t, "jsonl", receipt["content_format"])
+			assert.EqualValues(t, len(tt.want), receipt["bytes"])
+			assert.EqualValues(t, tt.values, receipt["total_values"])
+			assert.NotContains(t, receipt, "total_items", "array elements are not stream values")
+			require.Contains(t, receipt, "preview_sample")
+			assert.Nil(t, receipt["preview_sample"], "receipt must not embed unbounded values")
+			assert.Less(t, stdout.Len(), 2048, "receipt size must not grow with the stream")
+			path, ok := receipt["spilled_to"].(string)
+			require.True(t, ok)
+			assert.Equal(t, filepath.Join(dir, files[0].Name()), path)
+			assert.Equal(t, ".jsonl", filepath.Ext(path))
+			payload, err := os.ReadFile(path)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, string(payload), "no array wrapping, number rounding, or receipt in the file")
+			info, err := os.Stat(path)
+			require.NoError(t, err)
+			assert.Equal(t, os.FileMode(0600), info.Mode().Perm())
+			var hint map[string]any
+			require.NoError(t, json.Unmarshal(stderr.Bytes(), &hint), "one typed spill hint")
+			assert.Equal(t, "hint", hint["class"])
+			assert.Contains(t, hint["summary"], path)
+		})
+	}
+}
+
+func jqAgentsOptions(t *testing.T, query string, stderr io.Writer) *cmdio.Options {
+	t.Helper()
+	opts := &cmdio.Options{ErrWriter: stderr}
+	flags := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	opts.BindFlags(flags)
+	require.NoError(t, flags.Parse([]string{"--jq", query, "-o", "agents"}))
+	require.NoError(t, opts.Validate())
+	return opts
+}
+
+func TestOptions_JQ_AgentsErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		query   string
+		value   any
+		wantErr string
+	}{
+		{"marshal input", ".", make(chan int), "jq: marshal input"},
+		{"runtime before output", ".items.name", map[string]any{"items": []any{map[string]any{"name": "a"}}}, "jq runtime"},
+		{"runtime after output", "1, error(\"boom\")", map[string]int{"original": 42}, "jq runtime: error: boom"},
+		{"compile failure", "no_such_function", nil, "jq runtime"},
+		{"empty expression", "", nil, "jq runtime: missing query"},
+		{"whitespace expression", "  ", nil, "jq runtime: missing query"},
+		{"encoding failure", "1, nan", nil, "json: unsupported value: NaN"},
+	}
+	for _, tt := range tests {
+		for _, threshold := range []string{"1", "102400"} {
+			t.Run(tt.name+"/threshold="+threshold, func(t *testing.T) {
+				t.Setenv("GCX_AGENT_SPILL_BYTES", threshold)
+				dir := t.TempDir()
+				t.Setenv("TMPDIR", dir)
+				var stdout, stderr bytes.Buffer
+				err := jqAgentsOptions(t, tt.query, &stderr).Encode(&stdout, tt.value)
+				require.ErrorContains(t, err, tt.wantErr)
+				if strings.HasPrefix(tt.wantErr, "jq runtime") {
+					var jqErr cmdio.JQRuntimeError
+					require.ErrorAs(t, err, &jqErr)
+					assert.NotEmpty(t, jqErr.Shape)
+					require.Error(t, jqErr.Unwrap())
+					if tt.name == "runtime after output" {
+						assert.Equal(t, []string{"original"}, jqErr.Fields, "error describes the original input")
+					}
+				}
+				assert.Empty(t, stdout.String(), "no partial output or success receipt on failure")
+				assert.Empty(t, stderr.String(), "no spill hint for a failed stream")
+				files, err := os.ReadDir(dir)
+				require.NoError(t, err)
+				assert.Empty(t, files, "failed evaluation removes any partial spill file")
+			})
+		}
+	}
+}
+
+func TestOptions_JQ_AgentsIOErrors(t *testing.T) {
+	t.Run("create spill file", func(t *testing.T) {
+		t.Setenv("TMPDIR", filepath.Join(t.TempDir(), "missing"))
+		t.Setenv("GCX_AGENT_SPILL_BYTES", "1")
+		var stdout bytes.Buffer
+		err := jqAgentsOptions(t, "1", io.Discard).Encode(&stdout, nil)
+		require.ErrorContains(t, err, "create spill file")
+		assert.Empty(t, stdout.String())
+	})
+	for _, threshold := range []string{"1", "102400"} {
+		t.Run("stdout/threshold="+threshold, func(t *testing.T) {
+			dir := t.TempDir()
+			t.Setenv("TMPDIR", dir)
+			t.Setenv("GCX_AGENT_SPILL_BYTES", threshold)
+			wantErr := errors.New("stdout failed")
+			var stderr bytes.Buffer
+			err := jqAgentsOptions(t, "1", &stderr).Encode(jqErrorWriter{err: wantErr}, nil)
+			require.ErrorIs(t, err, wantErr)
+			assert.Empty(t, stderr.String(), "no success hint if stdout failed")
+			files, err := os.ReadDir(dir)
+			require.NoError(t, err)
+			assert.Empty(t, files, "no orphaned spill file if receipt cannot be written")
+		})
+	}
+}
+
+type jqErrorWriter struct{ err error }
+
+func (w jqErrorWriter) Write([]byte) (int, error) { return 0, w.err }


### PR DESCRIPTION
Previously, gcx rejected this combination even though agents output is JSON. This change lets jq transform the full result before agents applies compact formatting and automatic spilling.

```bash
   gcx config list-contexts -o agents --jq '.contexts[0].name'
```

This now returns the first context’s name as compact JSON instead of an incompatible-output error.

Bare --jq and explicit -o json behavior remain unchanged. 