### PR TITLE
refactor(providers): migrate SLO and OnCall registration

### DIFF
--- a/.claude/skills/add-provider/SKILL.md
+++ b/.claude/skills/add-provider/SKILL.md
@@ -287,8 +287,8 @@ Summary of the key steps:
 1. Provider interface + `init()` with a single `providers.Register()` call + `providers.ConfigLoader` (mirror the SLO reference)
 2. Config keys + validation
 3. Commands with UX compliance
-4. Types + client; adapter only for resources placed in the `resources` pipeline (returned from `TypedRegistrations()`, non-nil `Schema`)
-5. Register (blank import in `cmd/gcx/root/command.go`; adapter registration flows through `TypedRegistrations()` — never call `adapter.Register()` directly)
+4. Types + capability-satisfying client; declare `adapter.Resource[T]` only for resources placed in the `resources` pipeline (returned from `TypedRegistrations()`, non-nil `Schema`)
+5. Register via `adapter.NewProvider(...).WithCommands(...)` for adapter-backed resources (blank import in `cmd/gcx/root/command.go`; adapter registration flows through `TypedRegistrations()` — never call `adapter.Register()` directly)
 6. Tests (interface compliance, client httptest request mapping; adapter round-trip only when an adapter exists)
 
 **Key patterns** (see provider-guide.md for details):
@@ -296,6 +296,7 @@ Summary of the key steps:
 - Use `providers.ConfigLoader` (instantiate once in `Commands()`, `BindFlags` on the parent) — don't hand-roll config loading or import `cmd/gcx/config`
 - Config key names use hyphen-case
 - Adapter-backed resources must strip server-generated fields on Create/Update
+- Declare adapter-backed resource types with `adapter.Resource[T]`; see the SLO reference in `internal/providers/slo/definitions/resource_adapter.go`.
 
 ### Gate: Stage Complete
 
@@ -369,7 +370,7 @@ what a reviewer must run before merge. Wiring checks pass; docs updated.
 
 | Provider | Auth Model | API Type | Key Entry Point |
 |----------|-----------|----------|-----------------|
-| SLO | Same Grafana token | Plugin API | `internal/providers/slo/provider.go` |
+| SLO | Same Grafana token | Plugin API | `internal/providers/slo/provider.go` — declarative `adapter.Resource[T]` reference |
 | Synth | Separate URL + token | External service | `internal/providers/synth/provider.go` |
 
 ## Common Pitfalls

--- a/docs/adrs/declarative-provider-registration/001-declarative-resource-front-door.md
+++ b/docs/adrs/declarative-provider-registration/001-declarative-resource-front-door.md
@@ -20,8 +20,8 @@ information to derive one.
 ## Decision
 
 Keep `TypedCRUD[T]`, `ResourceIdentity`, and `Provider.TypedRegistrations()`.
-Add `adapter.Resource[T]` as a declarative registration entry point. Expose
-OnCall's existing builder pattern as
+Add `adapter.Resource[T]` as a declarative registration entry point and migrate
+SLO definitions as its first consumer. Lift OnCall's existing builder into
 `adapter.BuildRegistration[T, C]` for clients whose methods do not match the
 capability interfaces. Remove the unused `TypedRegistration[T]`.
 
@@ -57,26 +57,26 @@ Unsupported operations return `errors.ErrUnsupported`. Dry-run create/update
 uses `Validator` when available; otherwise it skips the mutation and returns
 `ErrDryRunUnverified`. It must not report an unvalidated mutation as successful.
 
-### Metadata and migration plan
+### Metadata and SLO migration
 
 `AsAdapter()` derives its schema from the resource type and descriptor.
 Both builders carry examples through registration and adapter construction.
 Natural-key and deep-link metadata remain available to the generic resource
 pipeline.
 
-The dependent migration will move SLO's create/update-and-refetch behavior
-into its client methods.
+SLO's create/update-and-refetch behavior moves into its client methods.
 Provider commands and generic resource operations call those same methods.
 The existing command tree retains its `NewTypedCRUD` entry point; it and the
-declarative registration construct separate adapters. The migration will compare their resource output in tests. This preserves the CLI while removing duplicated mutation
+declarative registration construct separate adapters. Tests compare their
+resource output. This preserves the CLI while removing duplicated mutation
 logic, without adding command generation to this PR.
 
 ## Consequences and alternatives
 
 - New resource declarations derive common metadata and infer supported verbs.
   Existing providers can migrate independently.
-- Existing providers remain unchanged in the machinery PR. A dependent PR
-  migrates SLO to declarations and OnCall to the shared explicit builder.
+- OnCall retains explicit operation wiring through the shared builder; it is
+  not migrated to capability interfaces in this change.
 - A single interface requiring every CRUD verb would force read-only clients
   to implement unsupported methods, so separate capability interfaces are used.
 - Reflection-based resource tags would spread runtime dispatch beyond the

--- a/docs/architecture/patterns.md
+++ b/docs/architecture/patterns.md
@@ -519,7 +519,7 @@ rule above, narrowly scoped:
 
 This qualifies Pattern 18's "No `any` type erasure — all 16 types use
 concrete generics" claim below: that claim describes the **hand-written,
-per-provider registration path** (OnCall's existing private builder). The
+per-provider registration path** (OnCall's `adapter.BuildRegistration`). The
 separate declarative `Resource[T]` path uses exactly one sanctioned
 `any`-assertion seam, documented here.
 
@@ -634,39 +634,47 @@ return opts.IO.Encode(cmd.OutOrStdout(), objs)
 
 ### 18. Table-Driven TypedCRUD Registration for Providers
 
-Providers with many resource types (e.g., OnCall with 17 types) use a generic
-`registerXResource[T]` function with functional options to register each type
-in a single, self-contained call. This replaces the earlier switch-dispatch
-pattern where a single adapter struct dispatched all types through runtime
-kind-string matching.
+Providers with many resource types (e.g., OnCall with 16 types) use the
+`adapter` package's generic `BuildRegistration[T, C]` builder with functional
+options to register each type in a single, self-contained call. This lives in
+`internal/resources/adapter` (not per-provider) and replaces the earlier
+switch-dispatch pattern where a single adapter struct dispatched all types
+through runtime kind-string matching.
 
 **Pattern structure:**
 
 ```go
-// 1. resourceMeta holds static registration metadata.
-type resourceMeta struct {
-    Descriptor resources.Descriptor
-    Aliases    []string
-    Schema, Example json.RawMessage
+// 1. RegistrationMeta holds static registration metadata. Schema and GVK are
+// NOT carried here — BuildRegistration derives them from the type parameter
+// and Descriptor, so callers must not hand-thread them.
+type RegistrationMeta struct {
+    Descriptor  resources.Descriptor
+    StripFields []string
+    Example     json.RawMessage
+    URLTemplate string
 }
 
-// 2. crudOption[T] configures optional CRUD operations.
-type crudOption[T any] func(client *Client, crud *adapter.TypedCRUD[T])
+// NewRegistrationMeta builds a RegistrationMeta from a GroupVersion + kind/
+// singular/plural. Providers with their own GroupVersion constants typically
+// wrap this in a package-local helper (see irm.oncallMeta).
+func NewRegistrationMeta(gv schema.GroupVersion, kind, singular, plural string) RegistrationMeta
 
-// 3. withCreate/withUpdate/withDelete set the corresponding Fn fields.
-func withCreate[T any](fn func(ctx context.Context, c *Client, item *T) (*T, error)) crudOption[T]
+// 2. CRUDOption[T, C] configures optional CRUD operations, generic over both
+// the resource type T and the resolved client type C.
+type CRUDOption[T ResourceNamer, C any] func(client C, crud *TypedCRUD[T])
 
-// 4. buildRegistration[T] wires everything and returns an adapter.Registration.
-//    The per-type registrations are collected by buildOnCallRegistrations and
-//    returned from the provider's TypedRegistrations() — providers.Register()
-//    in init() performs the actual registration.
-func buildRegistration[T adapter.ResourceNamer](
-    loader OnCallConfigLoader,
-    meta   resourceMeta,
-    listFn func(ctx context.Context, client OnCallAPI) ([]T, error),
-    getFn  func(ctx context.Context, client OnCallAPI, name string) (*T, error), // nil for list-only
-    opts   ...crudOption[T],
-) adapter.Registration
+// 3. WithCreate/WithUpdate/WithDelete set the corresponding Fn fields.
+func WithCreate[T ResourceNamer, C any](fn func(ctx context.Context, client C, item *T) (*T, error)) CRUDOption[T, C]
+
+// 4. BuildRegistration[T, C] wires everything and returns a Registration
+// (Schema/GVK auto-derived from T and meta.Descriptor).
+func BuildRegistration[T ResourceNamer, C any](
+    loadClient func(ctx context.Context) (C, string, error),
+    meta       RegistrationMeta,
+    listFn     func(ctx context.Context, client C) ([]T, error),
+    getFn      func(ctx context.Context, client C, name string) (*T, error), // nil for list-only
+    opts       ...CRUDOption[T, C],
+) Registration
 ```
 
 **When to use:** When a provider has 4+ resource types sharing the same
@@ -674,13 +682,18 @@ API group/version and client initialization pattern. The generic helper
 eliminates per-type boilerplate while keeping each registration self-documenting.
 
 **Key properties:**
-- No `any` type erasure — all 17 types use concrete generics
+- No `any` type erasure in this hand-written registration pattern — all 16
+  types use concrete generics over both the resource type T and the client
+  type C. (The separate declarative `adapter.Resource[T]` registration path
+  uses exactly one sanctioned `any`-assertion seam; see "Sanctioned Exception
+  — Single-Seam Capability Assertion" above.)
 - No switch/case dispatch — CRUD behavior determined at registration time
-- Functional options express the CRUD matrix declaratively (only 10/17 types support create, etc.)
+- Functional options express the CRUD matrix declaratively (only 9/16 types support create, etc.)
 - Special-case type conversions (e.g., Shift→ShiftRequest) are closures in the option, not if/else branches
 
 **Evidence:**
-- `internal/providers/irm/oncall_adapter.go`: `registerOnCallResource[T]`, 17 registrations
+- `internal/resources/adapter/builder.go`: `RegistrationMeta`, `NewRegistrationMeta`, `CRUDOption[T, C]`, `WithCreate`/`WithUpdate`/`WithDelete`, `BuildRegistration[T, C]`
+- `internal/providers/irm/oncall_adapter.go`: `oncallMeta` helper + 16 `adapter.BuildRegistration` calls
 - ADR: `docs/adrs/oncall-typed-crud/001-table-driven-typedcrud.md`
 
 ### 19. Singleton Adapter Pattern (Adopt)

--- a/docs/design/provider-checklist.md
+++ b/docs/design/provider-checklist.md
@@ -11,11 +11,20 @@ UX requirements. All items are unless marked otherwise.
 
 ### Interface Compliance
 
-- [ ] Struct implements all six `Provider` interface methods (including `TypedRegistrations()`; `nil` is valid for commands-only providers)
+- [ ] Provider satisfies all six `Provider` interface methods — build it
+  declaratively with `adapter.NewProvider` (recommended for resource-backed
+  providers; see the SLO reference, `internal/providers/slo/provider.go`) or
+  hand-write the struct (command-only providers, or ones needing real
+  `ConfigKeys()`/`Validate()`)
 - [ ] `Name()` is lowercase, unique, and stable (it's the config map key)
 - [ ] All config keys are declared in `ConfigKeys()`
 - [ ] Secret keys (passwords, tokens, API keys) have `Secret: true`
 - [ ] `Validate()` returns error pointing to `gcx config set ...`
+- [ ] Each adapter-backed resource type is declared as an `adapter.Resource[T]` value
+  (Group/Version/Kind, `NaturalKey`, `URLTemplate`, typed `Example`,
+  `NewClient`), with a client implementing only the capability interfaces
+  (`Lister`/`Getter`/`Creator`/`Updater`/`Deleter`/`Validator`) its client
+  actually supports — not a hand-built `adapter.Registration{}` literal
 - [ ] Provider self-registers via a single `providers.Register()` in `init()` + blank import in `cmd/gcx/root/command.go` (no separate `adapter.Register()` calls)
 
 ### UX Compliance
@@ -83,4 +92,8 @@ Commands that are **exempt** from K8s wrapping:
 
 ## Architecture Patterns
 
-Provider architecture patterns (TypedCRUD, ConfigLoader, output consistency) are documented in [patterns.md § Provider Plugin System](../architecture/patterns.md). Those are structural requirements; this file covers UX requirements.
+Provider architecture patterns (TypedCRUD, ConfigLoader, output consistency,
+and the declarative `adapter.Resource[T]` registration model with its single
+sanctioned capability-assertion seam) are documented in
+[patterns.md § Provider Plugin System](../architecture/patterns.md). Those
+are structural requirements; this file covers UX requirements.

--- a/docs/designs/provider-registration-simplification.md
+++ b/docs/designs/provider-registration-simplification.md
@@ -2,7 +2,7 @@
 
 Provider resources are declared through `adapter.Resource[T]`, with supported
 operations inferred from client capability interfaces and common metadata derived
-from the resource type. Provider migrations follow in a separate change.
+from the resource type. OnCall retains explicit wiring through the shared builder.
 
 The design decision, constraints, alternatives, and migration scope are recorded
 in [ADR-025](../adrs/declarative-provider-registration/001-declarative-resource-front-door.md).

--- a/docs/reference/provider-guide.md
+++ b/docs/reference/provider-guide.md
@@ -43,7 +43,17 @@ adapter-backed resources return `nil` — that is a valid, first-class shape
 (plain provider commands do not require an adapter, and an adapter must never be
 created merely to unlock a CRUD verb; see CONSTITUTION § Provider Architecture).
 
-A minimal skeleton:
+**If your provider exposes adapter-backed resource types**, skip
+hand-writing this struct: build it declaratively with `adapter.NewProvider`
+instead, which implements all six methods for you — `TypedRegistrations()`
+from the `adapter.Resource[T]` values you declare (Step 4c), `Commands()`
+from your existing hand-written command tree (`WithCommands`, Step 5),
+`ConfigKeys()`/`Validate()` as no-ops unless you need real config keys. See
+Step 5 and the SLO reference (`internal/providers/slo/provider.go`).
+
+A minimal hand-written skeleton — still the right shape for command-only
+providers with no resource types (`TypedRegistrations` returns `nil`), or
+providers that need real `ConfigKeys()`/`Validate()`:
 
 ```go
 package slo
@@ -51,6 +61,7 @@ package slo
 import (
     "github.com/spf13/cobra"
     "github.com/grafana/gcx/internal/providers"
+    "github.com/grafana/gcx/internal/resources/adapter"
 )
 
 // SLOProvider manages Grafana SLO resources.
@@ -60,6 +71,7 @@ var _ providers.Provider = &SLOProvider{}
 
 func (p *SLOProvider) Name() string      { return "slo" }
 func (p *SLOProvider) ShortDesc() string { return "Manage Grafana SLO resources." }
+func (p *SLOProvider) TypedRegistrations() []adapter.Registration { return nil }
 ```
 
 **Naming rules:**
@@ -410,10 +422,106 @@ Always include `httputils.LoggingMiddleware` in custom middleware stacks.
 
 ---
 
+## Step 4c: Declare Resource Types (`adapter.Resource[T]`)
+
+If your provider exposes resource types through `gcx resources` (list/get/
+push/pull/delete), declare each type as one `adapter.Resource[T]` value
+instead of hand-building an `adapter.Registration{}` literal. This is the
+single value a provider author writes per type — `adapter.NewProvider`
+derives `Schema`, `GVK`, `Singular`/`Plural`, and `Namespace` from it, folds
+in natural-key and deep-link registration, and wires CRUD by checking which
+capability interfaces your client implements.
+
+```go
+func SloResource() adapter.Resource[Slo] {
+    return adapter.Resource[Slo]{
+        Group:   "slo.ext.grafana.app",
+        Version: "v1alpha1",
+        Kind:    "SLO",
+
+        NaturalKey:  "name",                          // folds in RegisterNaturalKey — no init() needed
+        URLTemplate: "/a/grafana-slo-app/slo/{name}", // folds in deeplink registration — no init() needed
+        StripFields: []string{"uuid", "readOnly"},
+
+        Example: &Slo{ /* one representative, typed value — no hand-written JSON manifest */ },
+
+        NewClient: newAdapterClient, // func(ctx, adapter.ClientDeps) (any, error)
+    }
+}
+```
+
+Implement only the capability interfaces your client's API actually
+supports — an unimplemented interface resolves to `errors.ErrUnsupported`
+with no nil-`Fn` plumbing and no provider-side flags:
+
+| Interface | Method | Verb |
+|-----------|--------|------|
+| `Lister[T]` | `List(ctx, adapter.ListOptions) ([]T, error)` | list |
+| `Getter[T]` | `Get(ctx, name string) (*T, error)` | get |
+| `Creator[T]` | `Create(ctx, item *T) (*T, error)` | create |
+| `Updater[T]` | `Update(ctx, name string, item *T) (*T, error)` | update |
+| `Deleter[T]` | `Delete(ctx, name string) error` | delete |
+| `Validator[T]` | `Validate(ctx, items []*T) error` | `--dry-run` / `resources validate` (if unimplemented, dry-run returns `ErrDryRunUnverified` and the resource is reported as skipped) |
+
+`NewClient` receives `adapter.ClientDeps{HTTP, BaseURL, Namespace}` — a
+pre-built, fully-configured `*http.Client` (logging, retry,
+`--insecure-log-http-payload`, timeouts, auth mode already wired). Reuse
+`deps.HTTP` directly; never construct competing transport (see Step 4b).
+
+Optional fields: `Singular`/`Plural` (override the derived names — set
+`Plural` explicitly for irregulars the naive pluralizer gets wrong) and
+`Namespace` (override `ClientDeps.Namespace`). The domain type implements
+`GetResourceName`/`SetResourceName` itself (see `adapter.ResourceIdentity`).
+
+Reference: `internal/providers/slo/definitions/resource_adapter.go`
+(`SloResource()`, the declaration) and `client.go` (the capability-interface
+implementation, including the create-then-refetch `Creator`/`Updater`
+behavior that used to live in the registration closure).
+
+**Providers with several heterogeneous types sharing one client** (e.g.
+OnCall's 16 types) can instead use the lower-level
+`adapter.BuildRegistration[T, C]` + `CRUDOption[T, C]` builder — see Pattern
+18 in `patterns.md`. Either way, never hand-build an `adapter.Registration{}`
+literal or thread `Schema`/`GVK`/`Example` by hand.
+
+---
+
 ## Step 5: Register the Provider
 
-Providers self-register using the `Register()` function in your provider's `init()` function.
-Add this to your provider package (typically in `internal/providers/{provider}/provider.go`):
+**Recommended: build the provider declaratively.** Once your resource types
+are declared (Step 4c), pass them to `adapter.NewProvider` and attach your
+existing hand-written command tree with `WithCommands` — no separate
+`Provider` struct required:
+
+```go
+func NewSLOProvider() *adapter.Provider {
+    return adapter.NewProvider("slo", shortDesc, loadSLODeps, definitions.SloResource()).
+        WithCommands(func() []*cobra.Command {
+            loader := &providers.ConfigLoader{}
+            sloCmd := &cobra.Command{Use: "slo", Short: shortDesc}
+            loader.BindFlags(sloCmd.PersistentFlags())
+            sloCmd.AddCommand(definitions.Commands(loader))
+            return []*cobra.Command{sloCmd}
+        })
+}
+
+func init() { //nolint:gochecknoinits // Self-registration pattern (like database/sql drivers).
+    providers.Register(NewSLOProvider())
+}
+```
+
+`loadSLODeps` is a `func(ctx context.Context) (adapter.ClientDeps, error)`
+closure — `adapter` cannot import `internal/providers` (the reverse import
+already exists), so every provider supplies its own loader, typically
+`providers.ConfigLoader.LoadGrafanaConfig` + `rest.HTTPClientFor`. Reference:
+`internal/providers/slo/provider.go` for the full implementation.
+`adapter.NewProvider` does **not** auto-generate CRUD command verbs — it
+calls the factory passed to `WithCommands` each time it mounts commands.
+The factory must create fresh commands and flag state for each root.
+
+**Manual alternative:** command-only providers with no resource types, or
+providers that need real `ConfigKeys()`/`Validate()` behavior, hand-write
+the `Provider` struct from Step 1 and self-register the same way:
 
 ```go
 func init() {
@@ -431,6 +539,7 @@ Once registered via `init()`:
 - Its name and description appear in `gcx providers list`
 - Its secrets are correctly redacted by `gcx config view`
 - Its config is loaded from YAML and env vars automatically
+- Its resource types (if any) appear in `gcx resources list-types`, `gcx resources list-examples`, and `gcx resources get`
 
 Self-registration only fires if the package is linked into the binary, so add a
 blank import for it in `cmd/gcx/root/command.go`:
@@ -542,11 +651,12 @@ when writing tests that need a fake provider:
 
 ```go
 type mockProvider struct {
-    name       string
-    shortDesc  string
-    commands   []*cobra.Command
-    validateFn func(cfg map[string]string) error
-    configKeys []providers.ConfigKey
+    name          string
+    shortDesc     string
+    commands      []*cobra.Command
+    validateFn    func(cfg map[string]string) error
+    configKeys    []providers.ConfigKey
+    registrations []adapter.Registration
 }
 
 var _ providers.Provider = &mockProvider{}
@@ -603,11 +713,16 @@ see `internal/providers/redact_test.go` for table-driven examples.
 
 When implementing a new provider (see also [provider-checklist.md](../design/provider-checklist.md) for UX compliance requirements):
 
-- [ ] Struct implements all six `Provider` interface methods (including `TypedRegistrations()`, which may return `nil` for commands-only providers)
+- [ ] Provider satisfies all six `Provider` interface methods — either built
+  declaratively via `adapter.NewProvider` (Step 5, recommended for
+  resource-backed providers) or hand-written (Step 1, for command-only
+  providers or ones needing real `ConfigKeys()`/`Validate()`)
 - [ ] `Name()` is lowercase, unique, and stable (it is the map key in config files)
 - [ ] All config keys read by commands are declared in `ConfigKeys()`
 - [ ] Secret keys (`passwords`, `tokens`, `api_keys`) have `Secret: true`
 - [ ] `Validate` returns a helpful error message pointing to the `config set` command
+- [ ] Resource types are declared via `adapter.Resource[T]` (Step 4c), not a
+  hand-built `adapter.Registration{}` literal
 - [ ] Provider self-registers via a single `providers.Register()` call in `init()`, and the package is blank-imported in `cmd/gcx/root/command.go`
 - [ ] `mise run build` succeeds
 - [ ] `mise run tests` passes

--- a/internal/providers/irm/oncall_adapter.go
+++ b/internal/providers/irm/oncall_adapter.go
@@ -3,10 +3,8 @@ package irm
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 
-	"github.com/grafana/gcx/internal/resources"
 	"github.com/grafana/gcx/internal/resources/adapter"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -26,37 +24,6 @@ func init() { //nolint:gochecknoinits // Natural key registration for cross-stac
 	)
 }
 
-type resourceMeta struct {
-	Descriptor  resources.Descriptor
-	Schema      json.RawMessage
-	Example     json.RawMessage
-	URLTemplate string
-}
-
-func withCreate[T adapter.ResourceNamer](fn func(ctx context.Context, c OnCallAPI, item *T) (*T, error)) crudOption[T] {
-	return func(client OnCallAPI, crud *adapter.TypedCRUD[T]) {
-		crud.CreateFn = func(ctx context.Context, item *T) (*T, error) {
-			return fn(ctx, client, item)
-		}
-	}
-}
-
-func withUpdate[T adapter.ResourceNamer](fn func(ctx context.Context, c OnCallAPI, name string, item *T) (*T, error)) crudOption[T] {
-	return func(client OnCallAPI, crud *adapter.TypedCRUD[T]) {
-		crud.UpdateFn = func(ctx context.Context, name string, item *T) (*T, error) {
-			return fn(ctx, client, name, item)
-		}
-	}
-}
-
-func withDelete[T adapter.ResourceNamer](fn func(ctx context.Context, c OnCallAPI, name string) error) crudOption[T] {
-	return func(client OnCallAPI, crud *adapter.TypedCRUD[T]) {
-		crud.DeleteFn = func(ctx context.Context, name string) error {
-			return fn(ctx, client, name)
-		}
-	}
-}
-
 // ---------------------------------------------------------------------------
 // Per-resource CRUD wiring, shared between the resource adapters (push/pull)
 // and the noun-command verbs (create/update/delete). A single source of truth
@@ -65,13 +32,13 @@ func withDelete[T adapter.ResourceNamer](fn func(ctx context.Context, c OnCallAP
 
 func integrationCRUDOpts() []crudOption[Integration] {
 	return []crudOption[Integration]{
-		withCreate(func(ctx context.Context, c OnCallAPI, item *Integration) (*Integration, error) {
+		adapter.WithCreate(func(ctx context.Context, c OnCallAPI, item *Integration) (*Integration, error) {
 			return c.CreateIntegration(ctx, *item)
 		}),
-		withUpdate(func(ctx context.Context, c OnCallAPI, name string, item *Integration) (*Integration, error) {
+		adapter.WithUpdate(func(ctx context.Context, c OnCallAPI, name string, item *Integration) (*Integration, error) {
 			return c.UpdateIntegration(ctx, name, *item)
 		}),
-		withDelete[Integration](func(ctx context.Context, c OnCallAPI, name string) error {
+		adapter.WithDelete[Integration](func(ctx context.Context, c OnCallAPI, name string) error {
 			return c.DeleteIntegration(ctx, name)
 		}),
 	}
@@ -79,13 +46,13 @@ func integrationCRUDOpts() []crudOption[Integration] {
 
 func escalationChainCRUDOpts() []crudOption[EscalationChain] {
 	return []crudOption[EscalationChain]{
-		withCreate(func(ctx context.Context, c OnCallAPI, item *EscalationChain) (*EscalationChain, error) {
+		adapter.WithCreate(func(ctx context.Context, c OnCallAPI, item *EscalationChain) (*EscalationChain, error) {
 			return c.CreateEscalationChain(ctx, *item)
 		}),
-		withUpdate(func(ctx context.Context, c OnCallAPI, name string, item *EscalationChain) (*EscalationChain, error) {
+		adapter.WithUpdate(func(ctx context.Context, c OnCallAPI, name string, item *EscalationChain) (*EscalationChain, error) {
 			return c.UpdateEscalationChain(ctx, name, *item)
 		}),
-		withDelete[EscalationChain](func(ctx context.Context, c OnCallAPI, name string) error {
+		adapter.WithDelete[EscalationChain](func(ctx context.Context, c OnCallAPI, name string) error {
 			return c.DeleteEscalationChain(ctx, name)
 		}),
 	}
@@ -93,13 +60,13 @@ func escalationChainCRUDOpts() []crudOption[EscalationChain] {
 
 func escalationPolicyCRUDOpts() []crudOption[EscalationPolicy] {
 	return []crudOption[EscalationPolicy]{
-		withCreate(func(ctx context.Context, c OnCallAPI, item *EscalationPolicy) (*EscalationPolicy, error) {
+		adapter.WithCreate(func(ctx context.Context, c OnCallAPI, item *EscalationPolicy) (*EscalationPolicy, error) {
 			return c.CreateEscalationPolicy(ctx, *item)
 		}),
-		withUpdate(func(ctx context.Context, c OnCallAPI, name string, item *EscalationPolicy) (*EscalationPolicy, error) {
+		adapter.WithUpdate(func(ctx context.Context, c OnCallAPI, name string, item *EscalationPolicy) (*EscalationPolicy, error) {
 			return c.UpdateEscalationPolicy(ctx, name, *item)
 		}),
-		withDelete[EscalationPolicy](func(ctx context.Context, c OnCallAPI, name string) error {
+		adapter.WithDelete[EscalationPolicy](func(ctx context.Context, c OnCallAPI, name string) error {
 			return c.DeleteEscalationPolicy(ctx, name)
 		}),
 	}
@@ -107,13 +74,13 @@ func escalationPolicyCRUDOpts() []crudOption[EscalationPolicy] {
 
 func scheduleCRUDOpts() []crudOption[Schedule] {
 	return []crudOption[Schedule]{
-		withCreate(func(ctx context.Context, c OnCallAPI, item *Schedule) (*Schedule, error) {
+		adapter.WithCreate(func(ctx context.Context, c OnCallAPI, item *Schedule) (*Schedule, error) {
 			return c.CreateSchedule(ctx, *item)
 		}),
-		withUpdate(func(ctx context.Context, c OnCallAPI, name string, item *Schedule) (*Schedule, error) {
+		adapter.WithUpdate(func(ctx context.Context, c OnCallAPI, name string, item *Schedule) (*Schedule, error) {
 			return c.UpdateSchedule(ctx, name, *item)
 		}),
-		withDelete[Schedule](func(ctx context.Context, c OnCallAPI, name string) error {
+		adapter.WithDelete[Schedule](func(ctx context.Context, c OnCallAPI, name string) error {
 			return c.DeleteSchedule(ctx, name)
 		}),
 	}
@@ -121,13 +88,13 @@ func scheduleCRUDOpts() []crudOption[Schedule] {
 
 func shiftCRUDOpts() []crudOption[Shift] {
 	return []crudOption[Shift]{
-		withCreate(func(ctx context.Context, c OnCallAPI, item *Shift) (*Shift, error) {
+		adapter.WithCreate(func(ctx context.Context, c OnCallAPI, item *Shift) (*Shift, error) {
 			return c.CreateShift(ctx, shiftToRequest(item))
 		}),
-		withUpdate(func(ctx context.Context, c OnCallAPI, name string, item *Shift) (*Shift, error) {
+		adapter.WithUpdate(func(ctx context.Context, c OnCallAPI, name string, item *Shift) (*Shift, error) {
 			return c.UpdateShift(ctx, name, shiftToRequest(item))
 		}),
-		withDelete[Shift](func(ctx context.Context, c OnCallAPI, name string) error {
+		adapter.WithDelete[Shift](func(ctx context.Context, c OnCallAPI, name string) error {
 			return c.DeleteShift(ctx, name)
 		}),
 	}
@@ -135,13 +102,13 @@ func shiftCRUDOpts() []crudOption[Shift] {
 
 func routeCRUDOpts() []crudOption[Route] {
 	return []crudOption[Route]{
-		withCreate(func(ctx context.Context, c OnCallAPI, item *Route) (*Route, error) {
+		adapter.WithCreate(func(ctx context.Context, c OnCallAPI, item *Route) (*Route, error) {
 			return c.CreateRoute(ctx, *item)
 		}),
-		withUpdate(func(ctx context.Context, c OnCallAPI, name string, item *Route) (*Route, error) {
+		adapter.WithUpdate(func(ctx context.Context, c OnCallAPI, name string, item *Route) (*Route, error) {
 			return c.UpdateRoute(ctx, name, *item)
 		}),
-		withDelete[Route](func(ctx context.Context, c OnCallAPI, name string) error {
+		adapter.WithDelete[Route](func(ctx context.Context, c OnCallAPI, name string) error {
 			return c.DeleteRoute(ctx, name)
 		}),
 	}
@@ -149,13 +116,13 @@ func routeCRUDOpts() []crudOption[Route] {
 
 func webhookCRUDOpts() []crudOption[Webhook] {
 	return []crudOption[Webhook]{
-		withCreate(func(ctx context.Context, c OnCallAPI, item *Webhook) (*Webhook, error) {
+		adapter.WithCreate(func(ctx context.Context, c OnCallAPI, item *Webhook) (*Webhook, error) {
 			return c.CreateWebhook(ctx, *item)
 		}),
-		withUpdate(func(ctx context.Context, c OnCallAPI, name string, item *Webhook) (*Webhook, error) {
+		adapter.WithUpdate(func(ctx context.Context, c OnCallAPI, name string, item *Webhook) (*Webhook, error) {
 			return c.UpdateWebhook(ctx, name, *item)
 		}),
-		withDelete[Webhook](func(ctx context.Context, c OnCallAPI, name string) error {
+		adapter.WithDelete[Webhook](func(ctx context.Context, c OnCallAPI, name string) error {
 			return c.DeleteWebhook(ctx, name)
 		}),
 	}
@@ -163,18 +130,18 @@ func webhookCRUDOpts() []crudOption[Webhook] {
 
 func resolutionNoteCRUDOpts() []crudOption[ResolutionNote] {
 	return []crudOption[ResolutionNote]{
-		withCreate(func(ctx context.Context, c OnCallAPI, item *ResolutionNote) (*ResolutionNote, error) {
+		adapter.WithCreate(func(ctx context.Context, c OnCallAPI, item *ResolutionNote) (*ResolutionNote, error) {
 			return c.CreateResolutionNote(ctx, CreateResolutionNoteInput{
 				AlertGroup: item.AlertGroup,
 				Text:       item.Text,
 			})
 		}),
-		withUpdate(func(ctx context.Context, c OnCallAPI, name string, item *ResolutionNote) (*ResolutionNote, error) {
+		adapter.WithUpdate(func(ctx context.Context, c OnCallAPI, name string, item *ResolutionNote) (*ResolutionNote, error) {
 			return c.UpdateResolutionNote(ctx, name, UpdateResolutionNoteInput{
 				Text: item.Text,
 			})
 		}),
-		withDelete[ResolutionNote](func(ctx context.Context, c OnCallAPI, name string) error {
+		adapter.WithDelete[ResolutionNote](func(ctx context.Context, c OnCallAPI, name string) error {
 			return c.DeleteResolutionNote(ctx, name)
 		}),
 	}
@@ -182,7 +149,7 @@ func resolutionNoteCRUDOpts() []crudOption[ResolutionNote] {
 
 func shiftSwapCRUDOpts() []crudOption[ShiftSwap] {
 	return []crudOption[ShiftSwap]{
-		withCreate(func(ctx context.Context, c OnCallAPI, item *ShiftSwap) (*ShiftSwap, error) {
+		adapter.WithCreate(func(ctx context.Context, c OnCallAPI, item *ShiftSwap) (*ShiftSwap, error) {
 			return c.CreateShiftSwap(ctx, CreateShiftSwapInput{
 				Schedule:    item.Schedule,
 				SwapStart:   item.SwapStart,
@@ -190,76 +157,27 @@ func shiftSwapCRUDOpts() []crudOption[ShiftSwap] {
 				Beneficiary: item.Beneficiary,
 			})
 		}),
-		withUpdate(func(ctx context.Context, c OnCallAPI, name string, item *ShiftSwap) (*ShiftSwap, error) {
+		adapter.WithUpdate(func(ctx context.Context, c OnCallAPI, name string, item *ShiftSwap) (*ShiftSwap, error) {
 			return c.UpdateShiftSwap(ctx, name, UpdateShiftSwapInput{
 				Schedule:  item.Schedule,
 				SwapStart: item.SwapStart,
 				SwapEnd:   item.SwapEnd,
 			})
 		}),
-		withDelete[ShiftSwap](func(ctx context.Context, c OnCallAPI, name string) error {
+		adapter.WithDelete[ShiftSwap](func(ctx context.Context, c OnCallAPI, name string) error {
 			return c.DeleteShiftSwap(ctx, name)
 		}),
 	}
 }
 
-func buildRegistration[T adapter.ResourceNamer](
-	loader OnCallConfigLoader,
-	meta resourceMeta,
-	listFn func(ctx context.Context, client OnCallAPI) ([]T, error),
-	getFn func(ctx context.Context, client OnCallAPI, name string) (*T, error),
-	opts ...crudOption[T],
-) adapter.Registration {
-	desc := meta.Descriptor
-	return adapter.Registration{
-		Factory: func(ctx context.Context) (adapter.ResourceAdapter, error) {
-			client, namespace, err := loader.LoadOnCallClient(ctx)
-			if err != nil {
-				return nil, fmt.Errorf("failed to load IRM OnCall config for %s adapter: %w", desc.Kind, err)
-			}
-
-			crud := &adapter.TypedCRUD[T]{
-				StripFields: DefaultStripFields,
-				Namespace:   namespace,
-				Descriptor:  desc,
-			}
-
-			if listFn != nil {
-				crud.ListFn = adapter.LimitedListFn(func(ctx context.Context) ([]T, error) { return listFn(ctx, client) })
-			}
-
-			if getFn != nil {
-				crud.GetFn = func(ctx context.Context, name string) (*T, error) { return getFn(ctx, client, name) }
-			} else {
-				crud.GetFn = func(_ context.Context, _ string) (*T, error) { return nil, errors.ErrUnsupported }
-			}
-
-			for _, opt := range opts {
-				opt(client, crud)
-			}
-
-			return crud.AsAdapter(), nil
-		},
-		Descriptor:  desc,
-		GVK:         desc.GroupVersionKind(),
-		Schema:      meta.Schema,
-		Example:     meta.Example,
-		URLTemplate: meta.URLTemplate,
-	}
-}
-
-func oncallMeta(kind, singular, plural string) resourceMeta {
-	return resourceMeta{
-		Descriptor: resources.Descriptor{
-			GroupVersion: schema.GroupVersion{
-				Group:   APIGroup,
-				Version: Version,
-			},
-			Kind:     kind,
-			Singular: singular,
-			Plural:   plural,
-		},
-	}
+// oncallMeta builds an adapter.RegistrationMeta for an OnCall resource type,
+// wiring OnCall's GroupVersion and default strip fields. Schema and GVK are
+// auto-derived by adapter.BuildRegistration — callers only set Example and
+// URLTemplate on the returned value.
+func oncallMeta(kind, singular, plural string) adapter.RegistrationMeta {
+	meta := adapter.NewRegistrationMeta(schema.GroupVersion{Group: APIGroup, Version: Version}, kind, singular, plural)
+	meta.StripFields = DefaultStripFields
+	return meta
 }
 
 func buildOnCallRegistrations(loader OnCallConfigLoader) []adapter.Registration {
@@ -267,10 +185,9 @@ func buildOnCallRegistrations(loader OnCallConfigLoader) []adapter.Registration 
 
 	// 1. Integration — full CRUD
 	meta := oncallMeta("Integration", "integration", "integrations")
-	meta.Schema = adapter.SchemaFromType[Integration](meta.Descriptor)
 	meta.Example = integrationExample()
 	meta.URLTemplate = "/a/grafana-oncall-app/integrations/{name}"
-	regs = append(regs, buildRegistration(loader, meta,
+	regs = append(regs, adapter.BuildRegistration(loader.LoadOnCallClient, meta,
 		func(ctx context.Context, c OnCallAPI) ([]Integration, error) { return c.ListIntegrations(ctx) },
 		func(ctx context.Context, c OnCallAPI, name string) (*Integration, error) {
 			return c.GetIntegration(ctx, name)
@@ -280,10 +197,9 @@ func buildOnCallRegistrations(loader OnCallConfigLoader) []adapter.Registration 
 
 	// 2. EscalationChain — full CRUD
 	meta = oncallMeta("EscalationChain", "escalationchain", "escalationchains")
-	meta.Schema = adapter.SchemaFromType[EscalationChain](meta.Descriptor)
 	meta.Example = escalationChainExample()
 	meta.URLTemplate = "/a/grafana-oncall-app/escalation-chains/{name}"
-	regs = append(regs, buildRegistration(loader, meta,
+	regs = append(regs, adapter.BuildRegistration(loader.LoadOnCallClient, meta,
 		func(ctx context.Context, c OnCallAPI) ([]EscalationChain, error) {
 			return c.ListEscalationChains(ctx)
 		},
@@ -295,9 +211,8 @@ func buildOnCallRegistrations(loader OnCallConfigLoader) []adapter.Registration 
 
 	// 3. EscalationPolicy — full CRUD
 	meta = oncallMeta("EscalationPolicy", "escalationpolicy", "escalationpolicies")
-	meta.Schema = adapter.SchemaFromType[EscalationPolicy](meta.Descriptor)
 	meta.Example = escalationPolicyExample()
-	regs = append(regs, buildRegistration(loader, meta,
+	regs = append(regs, adapter.BuildRegistration(loader.LoadOnCallClient, meta,
 		func(ctx context.Context, c OnCallAPI) ([]EscalationPolicy, error) {
 			return c.ListEscalationPolicies(ctx, "")
 		},
@@ -309,10 +224,9 @@ func buildOnCallRegistrations(loader OnCallConfigLoader) []adapter.Registration 
 
 	// 4. Schedule — full CRUD
 	meta = oncallMeta("Schedule", "schedule", "schedules")
-	meta.Schema = adapter.SchemaFromType[Schedule](meta.Descriptor)
 	meta.Example = scheduleExample()
 	meta.URLTemplate = "/a/grafana-oncall-app/schedules/{name}"
-	regs = append(regs, buildRegistration(loader, meta,
+	regs = append(regs, adapter.BuildRegistration(loader.LoadOnCallClient, meta,
 		func(ctx context.Context, c OnCallAPI) ([]Schedule, error) { return c.ListSchedules(ctx) },
 		func(ctx context.Context, c OnCallAPI, name string) (*Schedule, error) {
 			return c.GetSchedule(ctx, name)
@@ -322,9 +236,8 @@ func buildOnCallRegistrations(loader OnCallConfigLoader) []adapter.Registration 
 
 	// 5. Shift — CRUD with ShiftRequest conversion
 	meta = oncallMeta("Shift", "shift", "shifts")
-	meta.Schema = adapter.SchemaFromType[Shift](meta.Descriptor)
 	meta.Example = shiftExample()
-	regs = append(regs, buildRegistration(loader, meta,
+	regs = append(regs, adapter.BuildRegistration(loader.LoadOnCallClient, meta,
 		func(ctx context.Context, c OnCallAPI) ([]Shift, error) { return c.ListShifts(ctx) },
 		func(ctx context.Context, c OnCallAPI, name string) (*Shift, error) { return c.GetShift(ctx, name) },
 		shiftCRUDOpts()...,
@@ -332,9 +245,8 @@ func buildOnCallRegistrations(loader OnCallConfigLoader) []adapter.Registration 
 
 	// 6. Route — full CRUD
 	meta = oncallMeta("Route", "route", "routes")
-	meta.Schema = adapter.SchemaFromType[Route](meta.Descriptor)
 	meta.Example = routeExample()
-	regs = append(regs, buildRegistration(loader, meta,
+	regs = append(regs, adapter.BuildRegistration(loader.LoadOnCallClient, meta,
 		func(ctx context.Context, c OnCallAPI) ([]Route, error) { return c.ListRoutes(ctx, "") },
 		func(ctx context.Context, c OnCallAPI, name string) (*Route, error) { return c.GetRoute(ctx, name) },
 		routeCRUDOpts()...,
@@ -342,10 +254,9 @@ func buildOnCallRegistrations(loader OnCallConfigLoader) []adapter.Registration 
 
 	// 7. Webhook — full CRUD
 	meta = oncallMeta("Webhook", "webhook", "webhooks")
-	meta.Schema = adapter.SchemaFromType[Webhook](meta.Descriptor)
 	meta.Example = webhookExample()
 	meta.URLTemplate = "/a/grafana-oncall-app/outgoing-webhooks/{name}"
-	regs = append(regs, buildRegistration(loader, meta,
+	regs = append(regs, adapter.BuildRegistration(loader.LoadOnCallClient, meta,
 		func(ctx context.Context, c OnCallAPI) ([]Webhook, error) { return c.ListWebhooks(ctx) },
 		func(ctx context.Context, c OnCallAPI, name string) (*Webhook, error) {
 			return c.GetWebhook(ctx, name)
@@ -355,62 +266,55 @@ func buildOnCallRegistrations(loader OnCallConfigLoader) []adapter.Registration 
 
 	// 8. AlertGroup — read-only + delete
 	meta = oncallMeta("AlertGroup", "alertgroup", "alertgroups")
-	meta.Schema = adapter.SchemaFromType[AlertGroup](meta.Descriptor)
 	meta.URLTemplate = "/a/grafana-oncall-app/alert-groups/{name}"
-	regs = append(regs, buildRegistration(loader, meta,
+	regs = append(regs, adapter.BuildRegistration(loader.LoadOnCallClient, meta,
 		func(ctx context.Context, c OnCallAPI) ([]AlertGroup, error) { return c.ListAlertGroups(ctx) },
 		func(ctx context.Context, c OnCallAPI, name string) (*AlertGroup, error) {
 			return c.GetAlertGroup(ctx, name)
 		},
-		withDelete[AlertGroup](func(ctx context.Context, c OnCallAPI, name string) error {
+		adapter.WithDelete[AlertGroup](func(ctx context.Context, c OnCallAPI, name string) error {
 			return c.DeleteAlertGroup(ctx, name)
 		}),
 	))
 
 	// 9. User — read-only
 	meta = oncallMeta("User", "oncalluser", "oncallusers")
-	meta.Schema = adapter.SchemaFromType[User](meta.Descriptor)
-	regs = append(regs, buildRegistration(loader, meta,
+	regs = append(regs, adapter.BuildRegistration(loader.LoadOnCallClient, meta,
 		func(ctx context.Context, c OnCallAPI) ([]User, error) { return c.ListUsers(ctx) },
 		func(ctx context.Context, c OnCallAPI, name string) (*User, error) { return c.GetUser(ctx, name) },
 	))
 
 	// 10. Team — read-only
 	meta = oncallMeta("Team", "oncallteam", "oncallteams")
-	meta.Schema = adapter.SchemaFromType[Team](meta.Descriptor)
-	regs = append(regs, buildRegistration(loader, meta,
+	regs = append(regs, adapter.BuildRegistration(loader.LoadOnCallClient, meta,
 		func(ctx context.Context, c OnCallAPI) ([]Team, error) { return c.ListTeams(ctx) },
 		func(ctx context.Context, c OnCallAPI, name string) (*Team, error) { return c.GetTeam(ctx, name) },
 	))
 
 	// 11. UserGroup — list-only
 	meta = oncallMeta("UserGroup", "usergroup", "usergroups")
-	meta.Schema = adapter.SchemaFromType[UserGroup](meta.Descriptor)
-	regs = append(regs, buildRegistration(loader, meta,
+	regs = append(regs, adapter.BuildRegistration(loader.LoadOnCallClient, meta,
 		func(ctx context.Context, c OnCallAPI) ([]UserGroup, error) { return c.ListUserGroups(ctx) },
 		nil,
 	))
 
 	// 12. SlackChannel — list-only
 	meta = oncallMeta("SlackChannel", "slackchannel", "slackchannels")
-	meta.Schema = adapter.SchemaFromType[SlackChannel](meta.Descriptor)
-	regs = append(regs, buildRegistration(loader, meta,
+	regs = append(regs, adapter.BuildRegistration(loader.LoadOnCallClient, meta,
 		func(ctx context.Context, c OnCallAPI) ([]SlackChannel, error) { return c.ListSlackChannels(ctx) },
 		nil,
 	))
 
 	// 13. Alert — get-only
 	meta = oncallMeta("Alert", "alert", "alerts")
-	meta.Schema = adapter.SchemaFromType[Alert](meta.Descriptor)
-	regs = append(regs, buildRegistration(loader, meta,
+	regs = append(regs, adapter.BuildRegistration(loader.LoadOnCallClient, meta,
 		nil,
 		func(ctx context.Context, c OnCallAPI, name string) (*Alert, error) { return c.GetAlert(ctx, name) },
 	))
 
 	// 14. Organization — read-only (singular endpoint, no list)
 	meta = oncallMeta("Organization", "organization", "organizations")
-	meta.Schema = adapter.SchemaFromType[Organization](meta.Descriptor)
-	regs = append(regs, buildRegistration[Organization](loader, meta,
+	regs = append(regs, adapter.BuildRegistration[Organization](loader.LoadOnCallClient, meta,
 		nil,
 		func(ctx context.Context, c OnCallAPI, _ string) (*Organization, error) {
 			return c.GetOrganization(ctx)
@@ -419,9 +323,8 @@ func buildOnCallRegistrations(loader OnCallConfigLoader) []adapter.Registration 
 
 	// 15. ResolutionNote — CRUD with input conversion
 	meta = oncallMeta("ResolutionNote", "resolutionnote", "resolutionnotes")
-	meta.Schema = adapter.SchemaFromType[ResolutionNote](meta.Descriptor)
 	meta.Example = resolutionNoteExample()
-	regs = append(regs, buildRegistration(loader, meta,
+	regs = append(regs, adapter.BuildRegistration(loader.LoadOnCallClient, meta,
 		func(ctx context.Context, c OnCallAPI) ([]ResolutionNote, error) {
 			return c.ListResolutionNotes(ctx, "")
 		},
@@ -433,9 +336,8 @@ func buildOnCallRegistrations(loader OnCallConfigLoader) []adapter.Registration 
 
 	// 16. ShiftSwap — CRUD with input conversion
 	meta = oncallMeta("ShiftSwap", "shiftswap", "shiftswaps")
-	meta.Schema = adapter.SchemaFromType[ShiftSwap](meta.Descriptor)
 	meta.Example = shiftSwapExample()
-	regs = append(regs, buildRegistration(loader, meta,
+	regs = append(regs, adapter.BuildRegistration(loader.LoadOnCallClient, meta,
 		func(ctx context.Context, c OnCallAPI) ([]ShiftSwap, error) { return c.ListShiftSwaps(ctx) },
 		func(ctx context.Context, c OnCallAPI, name string) (*ShiftSwap, error) {
 			return c.GetShiftSwap(ctx, name)

--- a/internal/providers/irm/oncall_commands.go
+++ b/internal/providers/irm/oncall_commands.go
@@ -328,7 +328,9 @@ func newDeleteSubcommand[T adapter.ResourceNamer](
 }
 
 // crudOption configures optional CRUD operations on a TypedCRUD instance.
-type crudOption[T adapter.ResourceNamer] func(client OnCallAPI, crud *adapter.TypedCRUD[T])
+// Alias of the shared adapter option type so the per-resource *CRUDOpts()
+// helpers feed both the noun-command verbs and adapter.BuildRegistration.
+type crudOption[T adapter.ResourceNamer] = adapter.CRUDOption[T, OnCallAPI]
 
 func newTypedCRUD[T adapter.ResourceNamer](
 	ctx context.Context,

--- a/internal/providers/slo/definitions/client.go
+++ b/internal/providers/slo/definitions/client.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/resources/adapter"
 	"k8s.io/client-go/rest"
 )
 
@@ -28,6 +29,17 @@ type Client struct {
 	httpClient *http.Client
 }
 
+// Compile-time guards: the capability seam discovers these interfaces via
+// runtime type assertion, so a signature drift would otherwise silently
+// demote the verb to errors.ErrUnsupported.
+var (
+	_ adapter.Lister[Slo]  = (*Client)(nil)
+	_ adapter.Getter[Slo]  = (*Client)(nil)
+	_ adapter.Creator[Slo] = (*Client)(nil)
+	_ adapter.Updater[Slo] = (*Client)(nil)
+	_ adapter.Deleter[Slo] = (*Client)(nil)
+)
+
 // NewClient creates a new SLO definitions client.
 func NewClient(cfg config.NamespacedRESTConfig) (*Client, error) {
 	httpClient, err := rest.HTTPClientFor(&cfg.Config)
@@ -41,8 +53,23 @@ func NewClient(cfg config.NamespacedRESTConfig) (*Client, error) {
 	}, nil
 }
 
-// List returns all SLO definitions.
-func (c *Client) List(ctx context.Context) ([]Slo, error) {
+// newClientFromDeps builds the SLO definitions client used by the
+// declarative adapter.Resource[Slo] registration (see resource_adapter.go).
+// Unlike NewClient, it reuses the pre-built ClientDeps.HTTP directly and
+// constructs no transport of its own (see docs/architecture/patterns.md §
+// Provider ConfigLoader).
+func newClientFromDeps(deps adapter.ClientDeps) *Client {
+	return &Client{
+		restConfig: config.NamespacedRESTConfig{
+			Config: rest.Config{Host: deps.BaseURL},
+		},
+		httpClient: deps.HTTP,
+	}
+}
+
+// List returns all SLO definitions, truncated to opts.Limit when positive
+// (implements adapter.Lister[Slo]).
+func (c *Client) List(ctx context.Context, opts adapter.ListOptions) ([]Slo, error) {
 	resp, err := c.doRequest(ctx, http.MethodGet, basePath, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list SLOs: %w", err)
@@ -58,11 +85,12 @@ func (c *Client) List(ctx context.Context) ([]Slo, error) {
 		return nil, fmt.Errorf("failed to decode SLO list response: %w", err)
 	}
 
-	if listResp.SLOs == nil {
-		return []Slo{}, nil
+	slos := listResp.SLOs
+	if slos == nil {
+		slos = []Slo{}
 	}
 
-	return listResp.SLOs, nil
+	return adapter.TruncateSlice(slos, opts.Limit), nil
 }
 
 // Get returns a single SLO definition by UUID.
@@ -89,8 +117,24 @@ func (c *Client) Get(ctx context.Context, uuid string) (*Slo, error) {
 	return &slo, nil
 }
 
-// Create creates a new SLO definition.
-func (c *Client) Create(ctx context.Context, slo *Slo) (*SLOCreateResponse, error) {
+// Create creates a new SLO definition and returns the fully populated
+// resource (implements adapter.Creator[Slo]). The create endpoint responds
+// with only a UUID, so Create re-fetches the created SLO before returning.
+func (c *Client) Create(ctx context.Context, slo *Slo) (*Slo, error) {
+	resp, err := c.createRequest(ctx, slo)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create SLO: %w", err)
+	}
+	created, err := c.Get(ctx, resp.UUID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch created SLO %q: %w", resp.UUID, err)
+	}
+	return created, nil
+}
+
+// createRequest issues the raw create HTTP request, returning the server's
+// create response (UUID + message only, not the full SLO).
+func (c *Client) createRequest(ctx context.Context, slo *Slo) (*SLOCreateResponse, error) {
 	body, err := json.Marshal(slo)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal SLO: %w", err)
@@ -114,8 +158,21 @@ func (c *Client) Create(ctx context.Context, slo *Slo) (*SLOCreateResponse, erro
 	return &createResp, nil
 }
 
-// Update updates an existing SLO definition.
-func (c *Client) Update(ctx context.Context, uuid string, slo *Slo) error {
+// Update updates an existing SLO definition and returns the fully populated
+// resource, re-fetching it after the update (implements adapter.Updater[Slo]).
+func (c *Client) Update(ctx context.Context, name string, slo *Slo) (*Slo, error) {
+	if err := c.updateRequest(ctx, name, slo); err != nil {
+		return nil, fmt.Errorf("failed to update SLO %q: %w", name, err)
+	}
+	updated, err := c.Get(ctx, name)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch updated SLO %q: %w", name, err)
+	}
+	return updated, nil
+}
+
+// updateRequest issues the raw update HTTP request.
+func (c *Client) updateRequest(ctx context.Context, uuid string, slo *Slo) error {
 	body, err := json.Marshal(slo)
 	if err != nil {
 		return fmt.Errorf("failed to marshal SLO: %w", err)

--- a/internal/providers/slo/definitions/client_test.go
+++ b/internal/providers/slo/definitions/client_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/gcx/internal/config"
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/providers/slo/definitions"
+	"github.com/grafana/gcx/internal/resources/adapter"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/client-go/rest"
@@ -89,7 +90,7 @@ func TestClient_List(t *testing.T) {
 			defer server.Close()
 
 			client := newTestClient(t, server)
-			slos, err := client.List(t.Context())
+			slos, err := client.List(t.Context(), adapter.ListOptions{})
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -100,6 +101,24 @@ func TestClient_List(t *testing.T) {
 			assert.Len(t, slos, tt.wantSLOs)
 		})
 	}
+}
+
+func TestClient_List_Limit(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		writeJSON(w, definitions.SLOListResponse{
+			SLOs: []definitions.Slo{
+				{UUID: "uuid-1", Name: "SLO 1"},
+				{UUID: "uuid-2", Name: "SLO 2"},
+				{UUID: "uuid-3", Name: "SLO 3"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	client := newTestClient(t, server)
+	slos, err := client.List(t.Context(), adapter.ListOptions{Limit: 2})
+	require.NoError(t, err)
+	assert.Len(t, slos, 2, "List must truncate client-side to opts.Limit")
 }
 
 func TestClient_Get(t *testing.T) {
@@ -154,6 +173,9 @@ func TestClient_Get(t *testing.T) {
 	}
 }
 
+// TestClient_Create exercises Create's create-then-refetch behavior: the
+// create endpoint only returns a UUID, so Create must re-fetch the full SLO
+// before returning it (FR-020).
 func TestClient_Create(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -163,30 +185,44 @@ func TestClient_Create(t *testing.T) {
 		wantUID string
 	}{
 		{
-			name: "success 202",
+			name: "success 202 then refetch",
 			slo:  &definitions.Slo{Name: "New SLO", Description: "A new SLO"},
 			handler: func(w http.ResponseWriter, r *http.Request) {
-				assert.Equal(t, http.MethodPost, r.Method)
-				assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+				switch r.Method {
+				case http.MethodPost:
+					assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
 
-				var received definitions.Slo
-				if err := json.NewDecoder(r.Body).Decode(&received); err != nil {
-					http.Error(w, err.Error(), http.StatusBadRequest)
-					return
+					var received definitions.Slo
+					if err := json.NewDecoder(r.Body).Decode(&received); err != nil {
+						http.Error(w, err.Error(), http.StatusBadRequest)
+						return
+					}
+					assert.Equal(t, "New SLO", received.Name)
+
+					w.WriteHeader(http.StatusAccepted)
+					writeJSON(w, definitions.SLOCreateResponse{UUID: "new-uuid", Message: "SLO created"})
+				case http.MethodGet:
+					assert.Equal(t, "/api/plugins/grafana-slo-app/resources/v1/slo/new-uuid", r.URL.Path)
+					writeJSON(w, definitions.Slo{UUID: "new-uuid", Name: "New SLO"})
+				default:
+					w.WriteHeader(http.StatusMethodNotAllowed)
 				}
-				assert.Equal(t, "New SLO", received.Name)
-
-				w.WriteHeader(http.StatusAccepted)
-				writeJSON(w, definitions.SLOCreateResponse{UUID: "new-uuid", Message: "SLO created"})
 			},
 			wantErr: false,
 			wantUID: "new-uuid",
 		},
 		{
-			name: "success 200",
+			name: "success 200 then refetch",
 			slo:  &definitions.Slo{Name: "New SLO", Description: "A new SLO"},
 			handler: func(w http.ResponseWriter, r *http.Request) {
-				writeJSON(w, definitions.SLOCreateResponse{UUID: "new-uuid-200", Message: "SLO created"})
+				switch r.Method {
+				case http.MethodPost:
+					writeJSON(w, definitions.SLOCreateResponse{UUID: "new-uuid-200", Message: "SLO created"})
+				case http.MethodGet:
+					writeJSON(w, definitions.Slo{UUID: "new-uuid-200", Name: "New SLO"})
+				default:
+					w.WriteHeader(http.StatusMethodNotAllowed)
+				}
 			},
 			wantErr: false,
 			wantUID: "new-uuid-200",
@@ -208,7 +244,7 @@ func TestClient_Create(t *testing.T) {
 			defer server.Close()
 
 			client := newTestClient(t, server)
-			resp, err := client.Create(t.Context(), tt.slo)
+			created, err := client.Create(t.Context(), tt.slo)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -216,11 +252,14 @@ func TestClient_Create(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-			assert.Equal(t, tt.wantUID, resp.UUID)
+			require.NotNil(t, created)
+			assert.Equal(t, tt.wantUID, created.UUID)
 		})
 	}
 }
 
+// TestClient_Update exercises Update's update-then-refetch behavior: Update
+// re-fetches the full SLO after the update request succeeds (FR-020).
 func TestClient_Update(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -230,23 +269,36 @@ func TestClient_Update(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "success 202",
+			name: "success 202 then refetch",
 			uuid: "uuid-1",
 			slo:  &definitions.Slo{Name: "Updated SLO"},
 			handler: func(w http.ResponseWriter, r *http.Request) {
-				assert.Equal(t, http.MethodPut, r.Method)
-				assert.Equal(t, "/api/plugins/grafana-slo-app/resources/v1/slo/uuid-1", r.URL.Path)
-				assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
-				w.WriteHeader(http.StatusAccepted)
+				switch r.Method {
+				case http.MethodPut:
+					assert.Equal(t, "/api/plugins/grafana-slo-app/resources/v1/slo/uuid-1", r.URL.Path)
+					assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+					w.WriteHeader(http.StatusAccepted)
+				case http.MethodGet:
+					writeJSON(w, definitions.Slo{UUID: "uuid-1", Name: "Updated SLO"})
+				default:
+					w.WriteHeader(http.StatusMethodNotAllowed)
+				}
 			},
 			wantErr: false,
 		},
 		{
-			name: "success 200",
+			name: "success 200 then refetch",
 			uuid: "uuid-1",
 			slo:  &definitions.Slo{Name: "Updated SLO"},
 			handler: func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusOK)
+				switch r.Method {
+				case http.MethodPut:
+					w.WriteHeader(http.StatusOK)
+				case http.MethodGet:
+					writeJSON(w, definitions.Slo{UUID: "uuid-1", Name: "Updated SLO"})
+				default:
+					w.WriteHeader(http.StatusMethodNotAllowed)
+				}
 			},
 			wantErr: false,
 		},
@@ -268,7 +320,7 @@ func TestClient_Update(t *testing.T) {
 			defer server.Close()
 
 			client := newTestClient(t, server)
-			err := client.Update(t.Context(), tt.uuid, tt.slo)
+			updated, err := client.Update(t.Context(), tt.uuid, tt.slo)
 
 			if tt.wantErr {
 				require.Error(t, err)
@@ -276,6 +328,8 @@ func TestClient_Update(t *testing.T) {
 			}
 
 			require.NoError(t, err)
+			require.NotNil(t, updated)
+			assert.Equal(t, tt.uuid, updated.UUID)
 		})
 	}
 }
@@ -370,7 +424,7 @@ func TestClient_ErrorResponses(t *testing.T) {
 			defer server.Close()
 
 			client := newTestClient(t, server)
-			_, err := client.List(t.Context())
+			_, err := client.List(t.Context(), adapter.ListOptions{})
 
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), tt.wantErrMsg)

--- a/internal/providers/slo/definitions/resource_adapter.go
+++ b/internal/providers/slo/definitions/resource_adapter.go
@@ -2,24 +2,19 @@ package definitions
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	internalconfig "github.com/grafana/gcx/internal/config"
-	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/resources"
 	"github.com/grafana/gcx/internal/resources/adapter"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-func init() { //nolint:gochecknoinits // Natural key registration for cross-stack push identity matching.
-	adapter.RegisterNaturalKey(
-		StaticDescriptor().GroupVersionKind(),
-		adapter.SpecFieldKey("name"),
-	)
-}
-
-// StaticDescriptor returns the resource descriptor for SLO definitions.
+// StaticDescriptor returns the resource descriptor for SLO definitions. Its
+// Group/Version/Kind mirror SloResource()'s declaration below — kept as a
+// small standalone helper because NewTypedCRUD (used by the hand-written
+// commands.go) needs a *adapter.TypedCRUD[Slo] rather than the
+// ResourceAdapter that SloResource()'s registration path builds.
 func StaticDescriptor() resources.Descriptor {
 	return resources.Descriptor{
 		GroupVersion: schema.GroupVersion{
@@ -32,45 +27,78 @@ func StaticDescriptor() resources.Descriptor {
 	}
 }
 
-// SloSchema returns a JSON Schema for the SLO resource type.
-func SloSchema() json.RawMessage {
-	return adapter.SchemaFromType[Slo](StaticDescriptor())
-}
+// SloResource declares the SLO definitions resource type end-to-end for
+// adapter.NewProvider: identity (GVK), registration metadata, and client
+// constructor. Declaring NaturalKey folds in
+// RegisterNaturalKey(gvk, SpecFieldKey("name")) and declaring URLTemplate
+// folds in the deeplink registration — neither needs a separate init().
+// Schema and Example are derived from Slo/the value below rather than
+// hand-written. A function (not a package-level var) to avoid a mutable
+// shared global.
+func SloResource() adapter.Resource[Slo] {
+	return adapter.Resource[Slo]{
+		Group:   "slo.ext.grafana.app",
+		Version: "v1alpha1",
+		Kind:    "SLO",
 
-// SloExample returns an example SLO manifest as JSON.
-func SloExample() json.RawMessage {
-	example := map[string]any{
-		"apiVersion": "slo.ext.grafana.app/v1alpha1",
-		"kind":       "SLO",
-		"metadata": map[string]any{
-			"name": "my-slo",
-		},
-		"spec": map[string]any{
-			"name":        "HTTP Availability",
-			"description": "Tracks HTTP request success rate",
-			"query": map[string]any{
-				"type": "freeform",
-				"freeform": map[string]any{
-					"query": `sum(rate(http_requests_total{status!~"5.."}[5m])) / sum(rate(http_requests_total[5m]))`,
+		NaturalKey:  "name",
+		URLTemplate: "/a/grafana-slo-app/slo/{name}",
+		StripFields: []string{"uuid", "readOnly"},
+
+		Example: &Slo{
+			UUID:        "my-slo",
+			Name:        "HTTP Availability",
+			Description: "Tracks HTTP request success rate",
+			Query: Query{
+				Type: "freeform",
+				Freeform: &FreeformQuery{
+					Query: `sum(rate(http_requests_total{status!~"5.."}[5m])) / sum(rate(http_requests_total[5m]))`,
 				},
 			},
-			"objectives": []map[string]any{
-				{"value": 0.995, "window": "28d"},
-			},
-			"labels": []map[string]any{
-				{"key": "team", "value": "platform"},
-			},
+			Objectives: []Objective{{Value: 0.995, Window: "28d"}},
+			Labels:     []Label{{Key: "team", Value: "platform"}},
 		},
+
+		NewClient: newAdapterClient,
 	}
-	b, err := json.Marshal(example)
-	if err != nil {
-		panic(fmt.Sprintf("slo/definitions: failed to marshal example: %v", err))
-	}
-	return b
 }
 
-// NewTypedCRUD creates a TypedCRUD for SLO definitions using the provided loader.
-// Returns both the CRUD instance and the config for additional operations like Prometheus queries.
+// newAdapterClient is SloResource's NewClient implementation. It builds the
+// SLO client directly from ClientDeps.HTTP, constructing no transport of its
+// own. The returned *Client implements the five capability interfaces (see
+// the compile-time guards in client.go), so the capability seam wires all
+// five verbs.
+func newAdapterClient(_ context.Context, deps adapter.ClientDeps) (any, error) {
+	return newClientFromDeps(deps), nil
+}
+
+// newTypedCRUD builds the TypedCRUD used by NewTypedCRUD below. Client's
+// Get/Create/Update/Delete methods are wired directly (they already match
+// the TypedCRUD Fn signatures); List is adapted from ListOptions to the
+// limit parameter TypedCRUD expects.
+func newTypedCRUD(client *Client, cfg internalconfig.NamespacedRESTConfig) *adapter.TypedCRUD[Slo] {
+	return &adapter.TypedCRUD[Slo]{
+		ListFn: func(ctx context.Context, limit int64) ([]Slo, error) {
+			return client.List(ctx, adapter.ListOptions{Limit: limit})
+		},
+		GetFn:       client.Get,
+		CreateFn:    client.Create,
+		UpdateFn:    client.Update,
+		DeleteFn:    client.Delete,
+		Namespace:   cfg.Namespace,
+		StripFields: []string{"uuid", "readOnly"},
+		Descriptor:  StaticDescriptor(),
+	}
+}
+
+// NewTypedCRUD creates a TypedCRUD for SLO definitions using the provided
+// loader. This is the hand-written commands.go's entry point for the
+// `gcx slo definitions` command tree — a separate call site from the
+// `gcx resources` pipeline built via SloResource()/adapter.NewProvider in
+// provider.go, but both are backed by the same Client capability methods,
+// so they return equivalent data.
+// Returns both the CRUD instance and the config for additional operations
+// like Prometheus queries.
 func NewTypedCRUD(ctx context.Context, loader GrafanaConfigLoader) (*adapter.TypedCRUD[Slo], internalconfig.NamespacedRESTConfig, error) {
 	cfg, err := loader.LoadGrafanaConfig(ctx)
 	if err != nil {
@@ -82,101 +110,5 @@ func NewTypedCRUD(ctx context.Context, loader GrafanaConfigLoader) (*adapter.Typ
 		return nil, internalconfig.NamespacedRESTConfig{}, fmt.Errorf("failed to create SLO definitions client: %w", err)
 	}
 
-	//nolint:dupl // Duplicate TypedCRUD initialization intentional between factory functions.
-	crud := &adapter.TypedCRUD[Slo]{
-		ListFn: adapter.LimitedListFn(client.List),
-		GetFn: func(ctx context.Context, name string) (*Slo, error) {
-			return client.Get(ctx, name)
-		},
-		CreateFn: func(ctx context.Context, slo *Slo) (*Slo, error) {
-			resp, err := client.Create(ctx, slo)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create SLO: %w", err)
-			}
-			created, err := client.Get(ctx, resp.UUID)
-			if err != nil {
-				return nil, fmt.Errorf("failed to fetch created SLO %q: %w", resp.UUID, err)
-			}
-			return created, nil
-		},
-		UpdateFn: func(ctx context.Context, name string, slo *Slo) (*Slo, error) {
-			if err := client.Update(ctx, name, slo); err != nil {
-				return nil, fmt.Errorf("failed to update SLO %q: %w", name, err)
-			}
-			updated, err := client.Get(ctx, name)
-			if err != nil {
-				return nil, fmt.Errorf("failed to fetch updated SLO %q: %w", name, err)
-			}
-			return updated, nil
-		},
-		DeleteFn: func(ctx context.Context, name string) error {
-			return client.Delete(ctx, name)
-		},
-		Namespace:   cfg.Namespace,
-		StripFields: []string{"uuid", "readOnly"},
-		Descriptor:  StaticDescriptor(),
-	}
-	return crud, cfg, nil
-}
-
-// NewLazyFactory returns an adapter.Factory that loads its config lazily from the
-// default config file when invoked. This is used for global adapter registration in init()
-// and by SLOProvider.ResourceAdapters().
-func NewLazyFactory() adapter.Factory {
-	return func(ctx context.Context) (adapter.ResourceAdapter, error) {
-		var loader providers.ConfigLoader
-		crud, _, err := NewTypedCRUD(ctx, &loader)
-		if err != nil {
-			return nil, err
-		}
-		return crud.AsAdapter(), nil
-	}
-}
-
-// NewFactoryFromConfig returns an adapter.Factory for SLO definitions that
-// creates a definitions.Client using the provided NamespacedRESTConfig.
-// The factory is lazy — the client is only created when the factory is invoked.
-func NewFactoryFromConfig(cfg internalconfig.NamespacedRESTConfig) adapter.Factory {
-	return func(_ context.Context) (adapter.ResourceAdapter, error) {
-		client, err := NewClient(cfg)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create SLO definitions client: %w", err)
-		}
-
-		//nolint:dupl // Duplicate TypedCRUD initialization intentional between factory functions.
-		crud := &adapter.TypedCRUD[Slo]{
-			ListFn: adapter.LimitedListFn(client.List),
-			GetFn: func(ctx context.Context, name string) (*Slo, error) {
-				return client.Get(ctx, name)
-			},
-			CreateFn: func(ctx context.Context, slo *Slo) (*Slo, error) {
-				resp, err := client.Create(ctx, slo)
-				if err != nil {
-					return nil, fmt.Errorf("failed to create SLO: %w", err)
-				}
-				created, err := client.Get(ctx, resp.UUID)
-				if err != nil {
-					return nil, fmt.Errorf("failed to fetch created SLO %q: %w", resp.UUID, err)
-				}
-				return created, nil
-			},
-			UpdateFn: func(ctx context.Context, name string, slo *Slo) (*Slo, error) {
-				if err := client.Update(ctx, name, slo); err != nil {
-					return nil, fmt.Errorf("failed to update SLO %q: %w", name, err)
-				}
-				updated, err := client.Get(ctx, name)
-				if err != nil {
-					return nil, fmt.Errorf("failed to fetch updated SLO %q: %w", name, err)
-				}
-				return updated, nil
-			},
-			DeleteFn: func(ctx context.Context, name string) error {
-				return client.Delete(ctx, name)
-			},
-			Namespace:   cfg.Namespace,
-			StripFields: []string{"uuid", "readOnly"},
-			Descriptor:  StaticDescriptor(),
-		}
-		return crud.AsAdapter(), nil
-	}
+	return newTypedCRUD(client, cfg), cfg, nil
 }

--- a/internal/providers/slo/definitions/resource_adapter_test.go
+++ b/internal/providers/slo/definitions/resource_adapter_test.go
@@ -1,6 +1,7 @@
 package definitions_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -18,16 +19,26 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-// newTestAdapter creates a ResourceAdapter backed by a test HTTP server.
+// newTestAdapter creates a ResourceAdapter backed by a test HTTP server, via
+// the same declarative definitions.SloResource + adapter.NewProvider path
+// used by provider.go — the pipeline the `gcx resources` command surface
+// resolves through (AC-001, AC-019).
 func newTestAdapter(t *testing.T, server *httptest.Server, namespace string) adapter.ResourceAdapter {
 	t.Helper()
-	cfg := config.NamespacedRESTConfig{
-		Config:    rest.Config{Host: server.URL},
-		Namespace: namespace,
+
+	loadDeps := func(context.Context) (adapter.ClientDeps, error) {
+		return adapter.ClientDeps{
+			HTTP:      server.Client(),
+			BaseURL:   server.URL,
+			Namespace: namespace,
+		}, nil
 	}
 
-	factory := definitions.NewFactoryFromConfig(cfg)
-	a, err := factory(t.Context())
+	p := adapter.NewProvider("slo", "test", loadDeps, definitions.SloResource())
+	regs := p.TypedRegistrations()
+	require.Len(t, regs, 1)
+
+	a, err := regs[0].Factory(t.Context())
 	require.NoError(t, err)
 	return a
 }
@@ -386,4 +397,91 @@ func TestResourceAdapter_ListPopulatesMetadata(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, found, "spec field should be present")
 	assert.Equal(t, "Metadata SLO", spec["name"])
+}
+
+// TestSloResource_RegistrationDerivesSchemaAndExample covers AC-002: the SLO
+// definition type's registration carries a non-nil derived schema and a
+// derived example, without SloExample()/SloSchema() hand-written manifests.
+func TestSloResource_RegistrationDerivesSchemaAndExample(t *testing.T) {
+	loadDeps := func(context.Context) (adapter.ClientDeps, error) { return adapter.ClientDeps{}, nil }
+	p := adapter.NewProvider("slo", "test", loadDeps, definitions.SloResource())
+	regs := p.TypedRegistrations()
+	require.Len(t, regs, 1)
+
+	reg := regs[0]
+	assert.NotNil(t, reg.Schema, "schema must be auto-derived from Slo, not hand-threaded")
+	require.NotNil(t, reg.Example, "example must be derived from SloResource.Example")
+	assert.Contains(t, string(reg.Example), "HTTP Availability")
+	var example unstructured.Unstructured
+	require.NoError(t, json.Unmarshal(reg.Example, &example))
+	assert.Equal(t, "my-slo", example.GetName())
+	spec, found, err := unstructured.NestedMap(example.Object, "spec")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.NotContains(t, spec, "uuid")
+	assert.NotContains(t, spec, "readOnly")
+
+	a, err := reg.Factory(t.Context())
+	require.NoError(t, err)
+	assert.NotNil(t, a.Schema(), "AsAdapter's Schema() must never be nil (FR-016)")
+	assert.Equal(t, reg.Example, a.Example())
+}
+
+// TestSloResource_SharedByBothFrontDoors covers AC-001/AC-019: the same
+// definitions.SloResource declaration (and therefore the same NewClient /
+// capability-seam construction) backs both provider.go's `gcx slo` command
+// tree (via NewTypedCRUD) and the `gcx resources` pipeline (via
+// adapter.NewProvider's TypedRegistrations()) — this test drives both call
+// sites against the same test server and asserts field-for-field equivalent
+// data.
+func TestSloResource_SharedByBothFrontDoors(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/api/plugins/grafana-slo-app/resources/v1/slo":
+			writeJSON(w, definitions.SLOListResponse{
+				SLOs: []definitions.Slo{{UUID: "shared-uuid", Name: "Shared SLO"}},
+			})
+		default:
+			w.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	}))
+	defer server.Close()
+
+	// Front door 1: gcx resources, via SloResource's adapter.NewProvider
+	// registration/capability-seam path.
+	a := newTestAdapter(t, server, "shared-ns")
+	viaResources, err := a.List(t.Context(), metav1.ListOptions{})
+	require.NoError(t, err)
+	require.Len(t, viaResources.Items, 1)
+
+	// Front door 2: gcx slo definitions, via commands.go's frozen
+	// NewTypedCRUD entry point — backed by the same Client capability
+	// methods as SloResource.NewClient.
+	loader := stubGrafanaConfigLoader{host: server.URL, namespace: "shared-ns"}
+	crud, _, err := definitions.NewTypedCRUD(t.Context(), loader)
+	require.NoError(t, err)
+	viaCommands, err := crud.List(t.Context(), 0)
+	require.NoError(t, err)
+	require.Len(t, viaCommands, 1)
+
+	assert.Equal(t, viaResources.Items[0].GetName(), viaCommands[0].Spec.UUID)
+	assert.Equal(t, "Shared SLO", viaCommands[0].Spec.Name)
+	spec, found, err := unstructured.NestedMap(viaResources.Items[0].Object, "spec")
+	require.NoError(t, err)
+	require.True(t, found)
+	assert.Equal(t, "Shared SLO", spec["name"])
+}
+
+// stubGrafanaConfigLoader implements definitions.GrafanaConfigLoader for
+// TestSloResource_SharedByBothFrontDoors.
+type stubGrafanaConfigLoader struct {
+	host      string
+	namespace string
+}
+
+func (l stubGrafanaConfigLoader) LoadGrafanaConfig(context.Context) (config.NamespacedRESTConfig, error) {
+	return config.NamespacedRESTConfig{
+		Config:    rest.Config{Host: l.host},
+		Namespace: l.namespace,
+	}, nil
 }

--- a/internal/providers/slo/provider.go
+++ b/internal/providers/slo/provider.go
@@ -1,33 +1,40 @@
 package slo
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/grafana/gcx/internal/providers"
 	"github.com/grafana/gcx/internal/providers/slo/definitions"
 	"github.com/grafana/gcx/internal/providers/slo/reports"
 	"github.com/grafana/gcx/internal/resources/adapter"
 	"github.com/spf13/cobra"
+	"k8s.io/client-go/rest"
 )
 
 func init() { //nolint:gochecknoinits // Self-registration pattern (like database/sql drivers).
-	providers.Register(&SLOProvider{})
+	providers.Register(NewSLOProvider())
 }
 
-// SLOProvider manages Grafana SLO resources.
-type SLOProvider struct{}
+// shortDesc is the SLO provider's one-line description, shared by the cobra
+// command tree and adapter.NewProvider.
+const shortDesc = "Manage Grafana SLO definitions and reports"
 
-// Name returns the unique identifier for this provider.
-func (p *SLOProvider) Name() string { return "slo" }
+// NewSLOProvider builds the declarative SLO provider: SLO definitions
+// registered via adapter.Resource[Slo] (definitions.SloResource), with the
+// existing hand-written `slo` command tree (definitions + reports) attached
+// via WithCommands (FR-018, NC-003, NC-004).
+func NewSLOProvider() *adapter.Provider {
+	return adapter.NewProvider("slo", shortDesc, loadSLODeps, definitions.SloResource()).
+		WithCommands(newSLOCommands)
+}
 
-// ShortDesc returns a one-line description of the provider.
-func (p *SLOProvider) ShortDesc() string { return "Manage Grafana SLO definitions and reports" }
-
-// Commands returns the Cobra commands contributed by this provider.
-func (p *SLOProvider) Commands() []*cobra.Command {
+func newSLOCommands() []*cobra.Command {
 	loader := &providers.ConfigLoader{}
 
 	sloCmd := &cobra.Command{
 		Use:   "slo",
-		Short: p.ShortDesc(),
+		Short: shortDesc,
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
 			if root := cmd.Root(); root.PersistentPreRun != nil {
 				root.PersistentPreRun(cmd, args)
@@ -44,31 +51,27 @@ func (p *SLOProvider) Commands() []*cobra.Command {
 	return []*cobra.Command{sloCmd}
 }
 
-// Validate checks that the given provider configuration is valid.
-// The SLO provider uses Grafana's built-in authentication, so no extra keys
-// are required.
-func (p *SLOProvider) Validate(cfg map[string]string) error {
-	return nil
-}
-
-// ConfigKeys returns the configuration keys used by this provider.
-// The SLO provider uses Grafana's built-in authentication and does not require
-// additional provider-specific keys.
-func (p *SLOProvider) ConfigKeys() []providers.ConfigKey {
-	return nil
-}
-
-// TypedRegistrations returns adapter registrations for SLO resource types.
-func (p *SLOProvider) TypedRegistrations() []adapter.Registration {
-	desc := definitions.StaticDescriptor()
-	return []adapter.Registration{
-		{
-			Factory:     definitions.NewLazyFactory(),
-			Descriptor:  desc,
-			GVK:         desc.GroupVersionKind(),
-			Schema:      definitions.SloSchema(),
-			Example:     definitions.SloExample(),
-			URLTemplate: "/a/grafana-slo-app/slo/{name}",
-		},
+// loadSLODeps resolves adapter.ClientDeps for the SLO definitions resource:
+// it loads REST config via providers.ConfigLoader and builds the HTTP
+// client via rest.HTTPClientFor, exactly like every hand-written provider
+// command already does. adapter cannot import internal/providers (see
+// adapter.DepsLoader's doc comment), so NewProvider takes this loader as a
+// caller-supplied closure.
+func loadSLODeps(ctx context.Context) (adapter.ClientDeps, error) {
+	var loader providers.ConfigLoader
+	cfg, err := loader.LoadGrafanaConfig(ctx)
+	if err != nil {
+		return adapter.ClientDeps{}, fmt.Errorf("failed to load REST config for SLO: %w", err)
 	}
+
+	httpClient, err := rest.HTTPClientFor(&cfg.Config)
+	if err != nil {
+		return adapter.ClientDeps{}, fmt.Errorf("failed to create HTTP client for SLO: %w", err)
+	}
+
+	return adapter.ClientDeps{
+		HTTP:      httpClient,
+		BaseURL:   cfg.Host,
+		Namespace: cfg.Namespace,
+	}, nil
 }

--- a/internal/providers/slo/provider_test.go
+++ b/internal/providers/slo/provider_test.go
@@ -1,6 +1,8 @@
 package slo_test
 
 import (
+	"bytes"
+	"fmt"
 	"testing"
 
 	"github.com/grafana/gcx/internal/providers/slo"
@@ -10,7 +12,7 @@ import (
 )
 
 func TestSLOProvider_Interface(t *testing.T) {
-	p := &slo.SLOProvider{}
+	p := slo.NewSLOProvider()
 
 	assert.Equal(t, "slo", p.Name())
 	assert.NotEmpty(t, p.ShortDesc())
@@ -20,7 +22,7 @@ func TestSLOProvider_Interface(t *testing.T) {
 }
 
 func TestSLOProvider_Commands(t *testing.T) {
-	p := &slo.SLOProvider{}
+	p := slo.NewSLOProvider()
 	cmds := p.Commands()
 	require.Len(t, cmds, 1)
 
@@ -80,4 +82,40 @@ func TestSLOProvider_Commands(t *testing.T) {
 	assert.Contains(t, reportSubNames, "push")
 	assert.Contains(t, reportSubNames, "pull")
 	assert.Contains(t, reportSubNames, "delete")
+}
+
+func TestSLOProvider_CommandsReturnFreshTrees(t *testing.T) {
+	p := slo.NewSLOProvider()
+	firstCommands := p.Commands()
+	secondCommands := p.Commands()
+	require.Len(t, firstCommands, 1)
+	require.Len(t, secondCommands, 1)
+	assert.NotSame(t, firstCommands[0], secondCommands[0], "each Commands call must return a fresh Cobra tree")
+
+	firstRoot := &cobra.Command{Use: "first"}
+	secondRoot := &cobra.Command{Use: "second"}
+	var firstOutput, secondOutput bytes.Buffer
+	firstRoot.SetOut(&firstOutput)
+	secondRoot.SetOut(&secondOutput)
+	firstRoot.AddCommand(firstCommands...)
+	secondRoot.AddCommand(secondCommands...)
+
+	definitions := firstCommands[0].Commands()[0]
+	var list *cobra.Command
+	for _, sub := range definitions.Commands() {
+		if sub.Name() == "list" {
+			list = sub
+			break
+		}
+	}
+	require.NotNil(t, list)
+	list.RunE = func(cmd *cobra.Command, _ []string) error {
+		_, err := fmt.Fprint(cmd.OutOrStdout(), "first tree")
+		return err
+	}
+
+	firstRoot.SetArgs([]string{"slo", "definitions", "list"})
+	require.NoError(t, firstRoot.Execute())
+	assert.Equal(t, "first tree", firstOutput.String())
+	assert.Empty(t, secondOutput.String())
 }

--- a/internal/providers/slo/reports/status.go
+++ b/internal/providers/slo/reports/status.go
@@ -11,6 +11,7 @@ import (
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers/slo/definitions"
 	"github.com/grafana/gcx/internal/query/prometheus"
+	"github.com/grafana/gcx/internal/resources/adapter"
 	"github.com/grafana/gcx/internal/style"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -114,7 +115,7 @@ metrics, and computes combined SLI and error budget per report.`,
 			})
 			initG.Go(func() error {
 				var err error
-				allSLOs, err = sloClient.List(initCtx)
+				allSLOs, err = sloClient.List(initCtx, adapter.ListOptions{})
 				return err
 			})
 			if err := initG.Wait(); err != nil {

--- a/internal/providers/slo/reports/timeline.go
+++ b/internal/providers/slo/reports/timeline.go
@@ -11,6 +11,7 @@ import (
 	cmdio "github.com/grafana/gcx/internal/output"
 	"github.com/grafana/gcx/internal/providers/slo/definitions"
 	"github.com/grafana/gcx/internal/query/prometheus"
+	"github.com/grafana/gcx/internal/resources/adapter"
 	"github.com/grafana/gcx/internal/style"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -147,7 +148,7 @@ grafana_slo_sli_window metrics.`,
 			}
 
 			// Fetch all SLO definitions and index by UUID.
-			allSLOs, err := sloClient.List(ctx)
+			allSLOs, err := sloClient.List(ctx, adapter.ListOptions{})
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
## What

Migrates SLO definitions to `adapter.Resource[T]` and replaces OnCall's private registration builder with the shared builder from #931. Moves SLO's create/update-and-refetch behavior into its client and constructs fresh command trees for each CLI root.

Keeps the existing command surface, fail-safe dry-run behavior, and resource output. Provider tests stay with the migration, including coverage for equivalent adapter output and isolated Cobra command state. Updates the provider-authoring guidance to use the migrated examples.

## Why

This is the adoption step after #931's reusable machinery. Its diff contains only provider migrations, their tests, and the associated guidance, so reviewers can assess the behavior change separately from the new API.

## How it was tested

- [x] `GOFLAGS=-mod=readonly GCX_AGENT_MODE=false mise run all` passed independently on this branch.
- [x] Race-enabled adapter, SLO, and OnCall tests passed.
- [x] Generated references remained unchanged.

## Related

- Depends on #931; merge the machinery PR first.

<hr/>

<!-- STACKIT-SECTION-START -->
#### Stack


* **PR #931**
  * **PR #1293** 👈

<sub>Auto-generated by [Stackit](https://github.com/getstackit/stackit)</sub>
<!-- STACKIT-SECTION-END -->

---
**Generated by Codex**
