### PR TITLE
ci(review): move the review rules into the skill

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,6 +7,7 @@
       "Skill",
       "Task",
       "Bash(git diff:*)",
+      "Bash(git fetch:*)",
       "Bash(git log:*)",
       "Bash(git show:*)",
       "Bash(gh issue list:*)",

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -28,7 +28,9 @@ Run both passes, then combine them:
 
 1. **`/code-review`**, for correctness bugs. Do not pass `--comment`. The
    findings must return to you instead of going straight to the PR, or you have
-   nothing left to combine.
+   nothing left to combine. It signs off with "no `--comment` argument was
+   provided, so stopping here without posting" — that is it handing findings
+   back, not the end of your review. Do not repeat the line or stop on it.
 2. **The triggers above** that fire for this diff, plus the compliance
    hierarchy.
 
@@ -136,7 +138,7 @@ which. Otherwise five blocking findings look heavier than the change deserves.
 
 ## When a workflow invoked this
 
-Five things change when no human is present. The rest of the review is the same.
+Six things change when no human is present. The rest of the review is the same.
 
 - **Post without asking.** The offer below applies when a human can answer. In
   CI nobody can, and the trigger is the consent.
@@ -152,7 +154,13 @@ Five things change when no human is present. The rest of the review is the same.
 
   > Comment `@claude review` for a fresh review.
 
-Silence is a valid result. If there are no findings, say so in one line. Never invent a finding.
+- **Upgrade `recommended` findings to blocking.** A human reviewer can weigh a
+  should-fix in conversation. Nobody is here to do that, so a finding is either
+  worth the author's attention or it is a nit.
+
+Silence is a valid result. If there are no findings, say so in one line — and
+post that line. A review that ends without posting cannot be told apart from
+one that never ran. Never invent a finding.
 
 ## Offering to post the review
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -77,54 +77,17 @@ jobs:
           classify_inline_comments: true
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          # The review process lives in the repo-local review-pr skill, so a PR
-          # gets the same treatment whether a developer runs it locally or this
-          # workflow runs it. The skill carries the severity split, the skip
-          # rules, the report shape, and the unattended-run overrides.
-          #
-          # /code-review runs without --comment on purpose: its findings must
-          # come back into the session so they can be merged with the skill's
-          # checks before anything is posted. That skill signs off with "not
-          # posting because --comment was not passed" — a session once took
-          # that as its own conclusion and ended having posted nothing, so the
-          # prompt now names it and makes posting the last required step.
+          # The review process lives entirely in the repo-local review-pr
+          # skill, so a PR gets the same treatment whether a developer runs it
+          # locally or this workflow does. Everything that used to be repeated
+          # here — the two passes, the report shape, the unattended-run
+          # overrides, the closing line — is in that file. Keep it that way:
+          # a rule added here instead of there applies to CI only, and silently
+          # stops applying the moment someone reviews the same PR locally.
           prompt: |
-            Review ${{ github.repository }}/pull/${{ steps.pr.outputs.number }}.
-
-            Run two passes.
-
-            1. The /review-pr skill, for PR
-               ${{ steps.pr.outputs.number }}. Run it as a skill rather than
-               reading the file, so its "When a workflow invoked this"
-               section governs the run.
-            2. The /code-review:code-review skill, for correctness bugs.
-               Do not pass --comment: its findings must come back to you so
-               they can be merged with the first pass.
-
-            Base the report on both sets combined: drop duplicates, and where
-            the two disagree, resolve it against the code and report one
-            conclusion rather than both. The report should always follow the
-            structure in .claude/skills/review-pr/SKILL.md#Report-shape, but
-            prefer to put blocking and nits feedback in inline comments. do
-            not duplicate inline comments in the main report body. Do not
-            mention the process you used to generate the report.
-
-            We should categorise findings as blocking or nits. Recommended
-            findings should be upgraded to blocking.
-
-            Finally, post the combined report to the PR yourself.
-
-            /code-review:code-review ends by saying it is not posting because
-            --comment was not passed. That is expected and it is not the end
-            of your task: it hands its findings back so you can post them
-            together with the first pass. Do not repeat that line and do not
-            stop there.
-
-            Post even when you found nothing — one line saying so, plus the
-            closing line the review-pr skill specifies. Nobody is watching
-            this run, so a review that ends without posting is
-            indistinguishable from one that never ran. Do not end your turn
-            until the report is on the PR.
+            Review ${{ github.repository }}/pull/${{ steps.pr.outputs.number }}
+            with the /review-pr skill. Invoke it as a skill; reading the file
+            leaves its unattended-run rules unapplied.
           # Pin the model to keep the behaviour consistent. Tool permissions
           # live in .claude/settings.json, which this session loads as a
           # project setting source, so a local /review-pr run and this workflow

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -84,26 +84,47 @@ jobs:
           #
           # /code-review runs without --comment on purpose: its findings must
           # come back into the session so they can be merged with the skill's
-          # checks before anything is posted.
+          # checks before anything is posted. That skill signs off with "not
+          # posting because --comment was not passed" — a session once took
+          # that as its own conclusion and ended having posted nothing, so the
+          # prompt now names it and makes posting the last required step.
           prompt: |
-            Review ${{ github.repository }}/pull/${{ steps.pr.outputs.number }}
-            by following .claude/skills/review-pr/SKILL.md, including its
-            "When a workflow invoked this" section.
+            Review ${{ github.repository }}/pull/${{ steps.pr.outputs.number }}.
 
-            Run two passes. Use the /code-review:code-review skill for
-            correctness bugs, without --comment so its findings return to you.
-            Separately run the checks the review-pr skill routes you to.
+            Run two passes.
+
+            1. The /review-pr skill, for PR
+               ${{ steps.pr.outputs.number }}. Run it as a skill rather than
+               reading the file, so its "When a workflow invoked this"
+               section governs the run.
+            2. The /code-review:code-review skill, for correctness bugs.
+               Do not pass --comment: its findings must come back to you so
+               they can be merged with the first pass.
 
             Base the report on both sets combined: drop duplicates, and where
             the two disagree, resolve it against the code and report one
-            conclusion rather than both. The report should always follow the 
+            conclusion rather than both. The report should always follow the
             structure in .claude/skills/review-pr/SKILL.md#Report-shape, but
             prefer to put blocking and nits feedback in inline comments. do
             not duplicate inline comments in the main report body. Do not
-            mention the process you used to generate the report. 
+            mention the process you used to generate the report.
 
             We should categorise findings as blocking or nits. Recommended
             findings should be upgraded to blocking.
+
+            Finally, post the combined report to the PR yourself.
+
+            /code-review:code-review ends by saying it is not posting because
+            --comment was not passed. That is expected and it is not the end
+            of your task: it hands its findings back so you can post them
+            together with the first pass. Do not repeat that line and do not
+            stop there.
+
+            Post even when you found nothing — one line saying so, plus the
+            closing line the review-pr skill specifies. Nobody is watching
+            this run, so a review that ends without posting is
+            indistinguishable from one that never ran. Do not end your turn
+            until the report is on the PR.
           # Pin the model to keep the behaviour consistent. Tool permissions
           # live in .claude/settings.json, which this session loads as a
           # project setting source, so a local /review-pr run and this workflow


### PR DESCRIPTION
Follows #1290. claude review CI jobs were still running silently, but for #1292 we have a trranscript, so I try and use that to fix things. #1292 had a "clean" review, which is my theory for it passing silently. I want it to comment "no issues" in this scenario.

- We were repeating instructions in the prompt and in the review-pr skill. move the majority of prompting into the skill. the prompt in the CI is now much shorter. Hopefully this will make the instructions on how to present results more clear to the agent
- Also, allow `git fetch` since the skill needs that.

other denials from the transcript were `gh pr checkout`, `go build` and `bin/gcx --help`. I left those disallowed as we dont want it to build the program.

**Verifying**

Like #1290, this cannot be checked from the PR, because the workflow only takes effect once merged. 
