### PR TITLE
feat(alert): add state-history command

### DIFF
--- a/cmd/gcx/root/testdata/output_classes.json
+++ b/cmd/gcx/root/testdata/output_classes.json
@@ -103,6 +103,7 @@
  "gcx alert ruler namespaces list": "finite",
  "gcx alert rules get": "finite",
  "gcx alert rules list": "finite",
+ "gcx alert state-history list": "finite",
  "gcx alert templates delete": "finite",
  "gcx alert templates get": "finite",
  "gcx alert templates list": "finite",

--- a/docs/reference/cli/gcx_alert.md
+++ b/docs/reference/cli/gcx_alert.md
@@ -31,5 +31,6 @@ Manage Grafana alert rules and alert groups
 * [gcx alert notification-policies](gcx_alert_notification-policies.md)	 - Manage the Grafana alerting notification policy tree.
 * [gcx alert ruler](gcx_alert_ruler.md)	 - Manage datasource-managed (Mimir/Loki ruler) rules.
 * [gcx alert rules](gcx_alert_rules.md)	 - Inspect alert rule state and health.
+* [gcx alert state-history](gcx_alert_state-history.md)	 - Inspect alert state history.
 * [gcx alert templates](gcx_alert_templates.md)	 - Manage Grafana alerting notification templates.
 

--- a/docs/reference/cli/gcx_alert_state-history.md
+++ b/docs/reference/cli/gcx_alert_state-history.md
@@ -1,0 +1,38 @@
+## gcx alert state-history
+
+Inspect alert state history.
+
+### Synopsis
+
+Query the recorded history of alert rule state transitions.
+
+State history is served by Grafana's alerting history backend. The default Loki
+backend answers both rule-scoped and global queries; the annotations backend
+requires --rule. Records are returned newest-first.
+
+  gcx alert state-history list --rule <uid> --from now-24h
+  gcx alert state-history list --label severity=critical --limit 200
+
+### Options
+
+```
+  -h, --help   help for state-history
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, OPENCODE, PI_CODING_AGENT, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx alert](gcx_alert.md)	 - Manage Grafana alert rules and alert groups
+* [gcx alert state-history list](gcx_alert_state-history_list.md)	 - List recorded alert state transitions.
+

--- a/docs/reference/cli/gcx_alert_state-history_list.md
+++ b/docs/reference/cli/gcx_alert_state-history_list.md
@@ -1,0 +1,38 @@
+## gcx alert state-history list
+
+List recorded alert state transitions.
+
+```
+gcx alert state-history list [flags]
+```
+
+### Options
+
+```
+      --from string         Start of the time range (RFC3339, Unix seconds, or relative e.g. now-6h) (default "now-6h")
+  -h, --help                help for list
+      --jq string           jq expression to apply to JSON output. Mutually exclusive with --json.
+      --json string         Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields
+      --label stringArray   Filter by instance label equality (key=value); repeatable
+      --limit int           Maximum number of records to return (0 for the backend default) (default 100)
+  -o, --output string       Output format. One of: agents, json, table, wide, yaml (default "table")
+      --rule string         Filter by rule UID (required by the annotations history backend)
+      --to string           End of the time range (RFC3339, Unix seconds, or relative e.g. now) (default "now")
+```
+
+### Options inherited from parent commands
+
+```
+      --agent                       Enable agent mode (JSON output, no color). Auto-detected from CLAUDECODE, CLAUDE_CODE, CURSOR_AGENT, GITHUB_COPILOT, AMAZON_Q, OPENCODE, PI_CODING_AGENT, or GCX_AGENT_MODE env vars.
+      --config string               Path to the configuration file to use
+      --context string              Name of the context to use (overrides current-context in config)
+      --insecure-log-http-payload   Log full HTTP request/response bodies including raw credentials, authorization tokens, cookies, and OAuth refresh tokens. Do not ship these logs.
+      --no-color                    Disable color output
+      --no-truncate                 Disable table column truncation (auto-enabled when stdout is piped)
+  -v, --verbose count               Verbose mode. Multiple -v options increase the verbosity (maximum: 3).
+```
+
+### SEE ALSO
+
+* [gcx alert state-history](gcx_alert_state-history.md)	 - Inspect alert state history.
+

--- a/internal/agent/command_annotations.go
+++ b/internal/agent/command_annotations.go
@@ -180,6 +180,7 @@ var commandAnnotations = map[string]annotation{
 	"gcx alert instances list":                   {Cost: "large", Hint: "--state firing --group <name> -o json"},
 	"gcx alert rules get":                        {Cost: "small"},
 	"gcx alert rules list":                       {Cost: "medium", Hint: "--folder <uid> --group <name> -o json"},
+	"gcx alert state-history list":               {Cost: "medium", Hint: "Recorded state transitions from Grafana's alerting history backend (needs Loki or annotations configured). Scope with --rule <uid> --from now-24h --to now --label key=value --limit N -o json. The annotations backend requires --rule."},
 	"gcx alert ruler namespaces list":            {Cost: "small", Hint: "--datasource <uid>"},
 	"gcx alert ruler namespaces delete":          {Cost: "small", Hint: "<namespace> --datasource <uid> --force"},
 	"gcx alert ruler groups list":                {Cost: "medium", Hint: "--datasource <uid> [--namespace <ns>] -o json"},

--- a/internal/providers/alert/export_test.go
+++ b/internal/providers/alert/export_test.go
@@ -16,6 +16,11 @@ func NewInstancesListCommandForTest(loader GrafanaConfigLoader) *cobra.Command {
 	return newInstancesListCommand(loader)
 }
 
+// NewStateHistoryListCommandForTest wraps newStateHistoryListCommand.
+func NewStateHistoryListCommandForTest(loader GrafanaConfigLoader) *cobra.Command {
+	return newStateHistoryListCommand(loader)
+}
+
 // NewContactPointsDeleteCommandForTest wraps newContactPointsDeleteCommand.
 func NewContactPointsDeleteCommandForTest(loader GrafanaConfigLoader) *cobra.Command {
 	return newContactPointsDeleteCommand(loader)

--- a/internal/providers/alert/provider.go
+++ b/internal/providers/alert/provider.go
@@ -43,6 +43,7 @@ func (p *AlertProvider) Commands() []*cobra.Command {
 	alertCmd.AddCommand(groupsCommands(loader))
 	alertCmd.AddCommand(rulerCommands(loader))
 	alertCmd.AddCommand(instancesCommands(loader))
+	alertCmd.AddCommand(stateHistoryCommands(loader))
 	alertCmd.AddCommand(contactPointsCommands(loader))
 	alertCmd.AddCommand(muteTimingsCommands(loader))
 	alertCmd.AddCommand(notificationPoliciesCommands(loader))

--- a/internal/providers/alert/state_history_client.go
+++ b/internal/providers/alert/state_history_client.go
@@ -1,0 +1,244 @@
+package alert
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/grafana/gcx/internal/providers"
+	"github.com/grafana/gcx/internal/query/dataframe"
+)
+
+// stateHistoryPath is the Grafana alerting state-history endpoint. It returns a
+// single Grafana data frame (schema + column-oriented data) describing the
+// state transitions recorded by the configured history backend (Loki or
+// annotations).
+const stateHistoryPath = "/api/v1/rules/history"
+
+// State-history frame column names, as emitted by Grafana's history builder
+// (grafana/pkg/services/ngalert/state/historian): a merged history of one
+// timestamp, one JSON "line", and one JSON "labels" object per transition.
+const (
+	dfColTime   = "time"
+	dfColLine   = "line"
+	dfColLabels = "labels"
+)
+
+// StateHistoryOptions configures a state-history query.
+type StateHistoryOptions struct {
+	// RuleUID filters to a single rule. The annotations history backend
+	// requires it; the Loki backend treats it as optional.
+	RuleUID string
+	// From and To bound the query time range. A zero value omits that bound.
+	From time.Time
+	To   time.Time
+	// Limit caps the number of returned records. A value <= 0 omits the bound
+	// and lets the backend apply its own default.
+	Limit int
+	// Labels are instance-label equality filters, sent to the API as
+	// labels_<key>=<value> query parameters.
+	Labels map[string]string
+}
+
+// StateTransition is one recorded alert state change, flattened from the
+// state-history data frame for display and machine consumption.
+type StateTransition struct {
+	Time         time.Time         `json:"time"`
+	RuleUID      string            `json:"ruleUid,omitempty"`
+	RuleTitle    string            `json:"ruleTitle,omitempty"`
+	Previous     string            `json:"previous"`
+	Current      string            `json:"current"`
+	Error        string            `json:"error,omitempty"`
+	Values       map[string]any    `json:"values,omitempty"`
+	Labels       map[string]string `json:"labels,omitempty"`
+	Fingerprint  string            `json:"fingerprint,omitempty"`
+	DashboardUID string            `json:"dashboardUid,omitempty"`
+	PanelID      int64             `json:"panelId,omitempty"`
+}
+
+// lokiLine mirrors the JSON object stored in the frame's "line" column
+// (grafana/pkg/services/ngalert/state/historian.LokiEntry). Only the fields
+// gcx surfaces are decoded.
+type lokiLine struct {
+	Previous     string            `json:"previous"`
+	Current      string            `json:"current"`
+	Error        string            `json:"error"`
+	Values       map[string]any    `json:"values"`
+	DashboardUID string            `json:"dashboardUID"`
+	PanelID      int64             `json:"panelID"`
+	Fingerprint  string            `json:"fingerprint"`
+	RuleTitle    string            `json:"ruleTitle"`
+	RuleUID      string            `json:"ruleUID"`
+	Labels       map[string]string `json:"labels"`
+}
+
+// QueryStateHistory queries alert state history and returns the recorded
+// transitions ordered newest-first.
+func (c *Client) QueryStateHistory(ctx context.Context, opts StateHistoryOptions) ([]StateTransition, error) {
+	params := url.Values{}
+	if opts.RuleUID != "" {
+		params.Set("ruleUID", opts.RuleUID)
+	}
+	if !opts.From.IsZero() {
+		params.Set("from", strconv.FormatInt(opts.From.Unix(), 10))
+	}
+	if !opts.To.IsZero() {
+		params.Set("to", strconv.FormatInt(opts.To.Unix(), 10))
+	}
+	if opts.Limit > 0 {
+		params.Set("limit", strconv.Itoa(opts.Limit))
+	}
+	for k, v := range opts.Labels {
+		params.Set("labels_"+k, v)
+	}
+
+	path := stateHistoryPath
+	if len(params) > 0 {
+		path += "?" + params.Encode()
+	}
+
+	frame, err := c.getStateHistoryFrame(ctx, path)
+	if err != nil {
+		return nil, err
+	}
+	return transitionsFromFrame(frame)
+}
+
+func (c *Client) getStateHistoryFrame(ctx context.Context, path string) (*dataframe.Frame, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.host+path, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to execute request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, providers.HandleErrorResponse(resp)
+	}
+
+	// The endpoint returns a bare Grafana data frame ({schema, data}), not the
+	// {results: {...}} envelope of the datasource query API.
+	var frame dataframe.Frame
+	if err := json.NewDecoder(resp.Body).Decode(&frame); err != nil {
+		return nil, fmt.Errorf("failed to decode state history response: %w", err)
+	}
+	return &frame, nil
+}
+
+// transitionsFromFrame flattens the "states" data frame into StateTransition
+// records ordered newest-first. It resolves columns by schema field name and
+// falls back to the documented positional order (time, line, labels).
+func transitionsFromFrame(frame *dataframe.Frame) ([]StateTransition, error) {
+	cols := make(map[string]int, len(frame.Schema.Fields))
+	for i, f := range frame.Schema.Fields {
+		cols[f.Name] = i
+	}
+
+	timeCol := columnValues(frame, cols, dfColTime, 0)
+	lineCol := columnValues(frame, cols, dfColLine, 1)
+	labelCol := columnValues(frame, cols, dfColLabels, 2)
+
+	transitions := make([]StateTransition, 0, len(timeCol))
+	for i := range timeCol {
+		st := StateTransition{Time: frameTime(timeCol[i])}
+
+		if i < len(lineCol) {
+			line, err := decodeLine(lineCol[i])
+			if err != nil {
+				return nil, err
+			}
+			st.RuleUID = line.RuleUID
+			st.RuleTitle = line.RuleTitle
+			st.Previous = line.Previous
+			st.Current = line.Current
+			st.Error = line.Error
+			st.Values = line.Values
+			st.Fingerprint = line.Fingerprint
+			st.DashboardUID = line.DashboardUID
+			st.PanelID = line.PanelID
+			st.Labels = line.Labels
+		}
+
+		// Fall back to the stream-labels column when the line carried none.
+		if len(st.Labels) == 0 && i < len(labelCol) {
+			if lbls, err := decodeLabels(labelCol[i]); err == nil {
+				st.Labels = lbls
+			}
+		}
+
+		transitions = append(transitions, st)
+	}
+
+	sort.SliceStable(transitions, func(i, j int) bool {
+		return transitions[i].Time.After(transitions[j].Time)
+	})
+	return transitions, nil
+}
+
+// columnValues returns the values for the named schema field, falling back to
+// the given positional index when the schema does not name it.
+func columnValues(frame *dataframe.Frame, cols map[string]int, name string, fallback int) []any {
+	idx, ok := cols[name]
+	if !ok {
+		idx = fallback
+	}
+	if idx < 0 || idx >= len(frame.Data.Values) {
+		return nil
+	}
+	return frame.Data.Values[idx]
+}
+
+// decodeLine re-encodes the decoded "line" value and unmarshals it into the
+// typed LokiEntry subset gcx surfaces.
+func decodeLine(v any) (lokiLine, error) {
+	var line lokiLine
+	// The frame value may arrive already decoded (map[string]any) or as raw
+	// JSON; a round-trip normalizes both into the typed struct.
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return line, fmt.Errorf("failed to re-encode state history line: %w", err)
+	}
+	if err := json.Unmarshal(raw, &line); err != nil {
+		return line, fmt.Errorf("failed to decode state history line: %w", err)
+	}
+	return line, nil
+}
+
+func decodeLabels(v any) (map[string]string, error) {
+	raw, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	var labels map[string]string
+	if err := json.Unmarshal(raw, &labels); err != nil {
+		return nil, err
+	}
+	return labels, nil
+}
+
+// frameTime converts a data-frame time value (epoch milliseconds) to a UTC
+// time. It returns the zero time for unrecognized encodings.
+func frameTime(v any) time.Time {
+	switch t := v.(type) {
+	case float64:
+		return time.UnixMilli(int64(t)).UTC()
+	case json.Number:
+		if ms, err := t.Int64(); err == nil {
+			return time.UnixMilli(ms).UTC()
+		}
+	case string:
+		if parsed, err := time.Parse(time.RFC3339, t); err == nil {
+			return parsed.UTC()
+		}
+	}
+	return time.Time{}
+}

--- a/internal/providers/alert/state_history_client_test.go
+++ b/internal/providers/alert/state_history_client_test.go
@@ -1,0 +1,119 @@
+package alert_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/grafana/gcx/internal/providers/alert"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// stateHistoryFrameJSON is a minimal but faithful reproduction of the bare
+// Grafana data frame returned by GET /api/v1/rules/history: three columns
+// (time in epoch ms, the JSON "line", and the JSON stream "labels"). Row 0 is
+// older than row 1 so ordering (newest-first) is observable.
+const stateHistoryFrameJSON = `{
+  "schema": {
+    "name": "states",
+    "fields": [
+      {"name": "time", "type": "time"},
+      {"name": "line", "type": "other"},
+      {"name": "labels", "type": "other"}
+    ]
+  },
+  "data": {
+    "values": [
+      [1727189670000, 1727189680000],
+      [
+        {"schemaVersion":1,"previous":"Alerting","current":"Normal","ruleUID":"uid-1","ruleTitle":"CPU Usage","fingerprint":"abc123","dashboardUID":"dash-1","panelID":3,"labels":{"alertname":"CPU Usage","severity":"critical"}},
+        {"schemaVersion":1,"previous":"Normal","current":"Alerting","ruleUID":"uid-1","ruleTitle":"CPU Usage","values":{"B":42},"labels":{"alertname":"CPU Usage","severity":"critical"}}
+      ],
+      [
+        {"alertname":"CPU Usage"},
+        {"alertname":"CPU Usage"}
+      ]
+    ]
+  }
+}`
+
+func TestClient_QueryStateHistory(t *testing.T) {
+	var gotQuery url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		assert.Equal(t, "/api/v1/rules/history", r.URL.Path)
+		gotQuery = r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(stateHistoryFrameJSON))
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	transitions, err := client.QueryStateHistory(context.Background(), alert.StateHistoryOptions{
+		RuleUID: "uid-1",
+		From:    time.Unix(1727189000, 0),
+		To:      time.Unix(1727190000, 0),
+		Limit:   50,
+		Labels:  map[string]string{"severity": "critical"},
+	})
+	require.NoError(t, err)
+
+	// Query parameters are translated to the alerting API vocabulary.
+	assert.Equal(t, "uid-1", gotQuery.Get("ruleUID"))
+	assert.Equal(t, "1727189000", gotQuery.Get("from"))
+	assert.Equal(t, "1727190000", gotQuery.Get("to"))
+	assert.Equal(t, "50", gotQuery.Get("limit"))
+	assert.Equal(t, "critical", gotQuery.Get("labels_severity"))
+
+	// Records are flattened and ordered newest-first.
+	require.Len(t, transitions, 2)
+	assert.True(t, transitions[0].Time.After(transitions[1].Time), "transitions must be newest-first")
+
+	newest := transitions[0] // row 1 (1727189680000)
+	assert.Equal(t, "uid-1", newest.RuleUID)
+	assert.Equal(t, "CPU Usage", newest.RuleTitle)
+	assert.Equal(t, "Normal", newest.Previous)
+	assert.Equal(t, "Alerting", newest.Current)
+	assert.Equal(t, map[string]string{"alertname": "CPU Usage", "severity": "critical"}, newest.Labels)
+	assert.Equal(t, int64(1727189680000), newest.Time.UnixMilli())
+
+	oldest := transitions[1] // row 0 (1727189670000)
+	assert.Equal(t, "Normal", oldest.Current)
+	assert.Equal(t, "dash-1", oldest.DashboardUID)
+	assert.Equal(t, int64(3), oldest.PanelID)
+	assert.Equal(t, "abc123", oldest.Fingerprint)
+}
+
+func TestClient_QueryStateHistory_OmitsUnsetParams(t *testing.T) {
+	var gotQuery url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query()
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"schema":{"fields":[]},"data":{"values":[]}}`))
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	transitions, err := client.QueryStateHistory(context.Background(), alert.StateHistoryOptions{})
+	require.NoError(t, err)
+	assert.Empty(t, transitions)
+
+	// A fully-zero query sends no parameters at all.
+	assert.Empty(t, gotQuery)
+}
+
+func TestClient_QueryStateHistory_Error(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"ruleUID is required to query annotations"}`))
+	}))
+	defer srv.Close()
+
+	client := newTestClient(t, srv)
+	_, err := client.QueryStateHistory(context.Background(), alert.StateHistoryOptions{})
+	require.Error(t, err)
+}

--- a/internal/providers/alert/state_history_commands.go
+++ b/internal/providers/alert/state_history_commands.go
@@ -1,0 +1,186 @@
+package alert
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"time"
+
+	"github.com/grafana/gcx/internal/format"
+	cmdio "github.com/grafana/gcx/internal/output"
+	"github.com/grafana/gcx/internal/shared"
+	"github.com/grafana/gcx/internal/style"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func stateHistoryCommands(loader GrafanaConfigLoader) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "state-history",
+		Short: "Inspect alert state history.",
+		Long: `Query the recorded history of alert rule state transitions.
+
+State history is served by Grafana's alerting history backend. The default Loki
+backend answers both rule-scoped and global queries; the annotations backend
+requires --rule. Records are returned newest-first.
+
+  gcx alert state-history list --rule <uid> --from now-24h
+  gcx alert state-history list --label severity=critical --limit 200`,
+	}
+	cmd.AddCommand(newStateHistoryListCommand(loader))
+	return cmd
+}
+
+type stateHistoryListOpts struct {
+	IO      cmdio.Options
+	RuleUID string
+	From    string
+	To      string
+	Limit   int
+	Labels  []string
+}
+
+func (o *stateHistoryListOpts) setup(flags *pflag.FlagSet) {
+	o.IO.RegisterCustomCodec("table", &StateHistoryTableCodec{})
+	o.IO.RegisterCustomCodec("wide", &StateHistoryTableCodec{Wide: true})
+	o.IO.DefaultFormat("table")
+	o.IO.BindFlags(flags)
+	flags.StringVar(&o.RuleUID, "rule", "", "Filter by rule UID (required by the annotations history backend)")
+	flags.StringVar(&o.From, "from", "now-6h", "Start of the time range (RFC3339, Unix seconds, or relative e.g. now-6h)")
+	flags.StringVar(&o.To, "to", "now", "End of the time range (RFC3339, Unix seconds, or relative e.g. now)")
+	flags.IntVar(&o.Limit, "limit", 100, "Maximum number of records to return (0 for the backend default)")
+	flags.StringArrayVar(&o.Labels, "label", nil, "Filter by instance label equality (key=value); repeatable")
+}
+
+// resolve validates the options and builds the client query relative to now.
+func (o *stateHistoryListOpts) resolve(now time.Time) (StateHistoryOptions, error) {
+	if err := o.IO.Validate(); err != nil {
+		return StateHistoryOptions{}, err
+	}
+
+	from, err := shared.ParseTime(o.From, now)
+	if err != nil {
+		return StateHistoryOptions{}, fmt.Errorf("invalid --from: %w", err)
+	}
+	to, err := shared.ParseTime(o.To, now)
+	if err != nil {
+		return StateHistoryOptions{}, fmt.Errorf("invalid --to: %w", err)
+	}
+	if !from.IsZero() && !to.IsZero() && to.Before(from) {
+		return StateHistoryOptions{}, errors.New("--to must not be before --from")
+	}
+	if o.Limit < 0 {
+		return StateHistoryOptions{}, errors.New("--limit must not be negative")
+	}
+
+	labels, err := parseLabelFilters(o.Labels)
+	if err != nil {
+		return StateHistoryOptions{}, err
+	}
+
+	return StateHistoryOptions{
+		RuleUID: o.RuleUID,
+		From:    from,
+		To:      to,
+		Limit:   o.Limit,
+		Labels:  labels,
+	}, nil
+}
+
+func newStateHistoryListCommand(loader GrafanaConfigLoader) *cobra.Command {
+	opts := &stateHistoryListOpts{}
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List recorded alert state transitions.",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			query, err := opts.resolve(time.Now())
+			if err != nil {
+				return err
+			}
+
+			ctx := cmd.Context()
+			restCfg, err := loader.LoadGrafanaConfig(ctx)
+			if err != nil {
+				return err
+			}
+
+			client, err := NewClient(restCfg)
+			if err != nil {
+				return err
+			}
+
+			transitions, err := client.QueryStateHistory(ctx, query)
+			if err != nil {
+				return err
+			}
+
+			return opts.IO.Encode(cmd.OutOrStdout(), transitions)
+		},
+	}
+	opts.setup(cmd.Flags())
+	return cmd
+}
+
+// parseLabelFilters turns repeated key=value flags into an equality-filter map.
+// The returned map is non-nil (possibly empty) so callers never see nil,nil.
+func parseLabelFilters(pairs []string) (map[string]string, error) {
+	labels := make(map[string]string, len(pairs))
+	for _, p := range pairs {
+		k, v, ok := strings.Cut(p, "=")
+		if !ok || k == "" {
+			return nil, fmt.Errorf("invalid --label %q: expected key=value", p)
+		}
+		labels[k] = v
+	}
+	return labels, nil
+}
+
+// StateHistoryTableCodec renders state transitions as tabular output.
+type StateHistoryTableCodec struct {
+	Wide bool
+}
+
+func (c *StateHistoryTableCodec) Format() format.Format {
+	if c.Wide {
+		return "wide"
+	}
+	return "table"
+}
+
+func (c *StateHistoryTableCodec) Encode(w io.Writer, v any) error {
+	transitions, ok := v.([]StateTransition)
+	if !ok {
+		return errors.New("invalid data type for table codec: expected []StateTransition")
+	}
+
+	var t *style.TableBuilder
+	if c.Wide {
+		t = style.NewTable("TIME", "RULE_UID", "RULE", "PREVIOUS", "CURRENT", "ERROR", "LABELS")
+	} else {
+		t = style.NewTable("TIME", "RULE", "PREVIOUS", "CURRENT", "LABELS")
+	}
+
+	for _, tr := range transitions {
+		ts := orDash(formatHistoryTime(tr.Time))
+		labels := formatLabels(tr.Labels)
+
+		if c.Wide {
+			t.Row(ts, orDash(tr.RuleUID), orDash(tr.RuleTitle), orDash(tr.Previous), orDash(tr.Current), orDash(tr.Error), labels)
+			continue
+		}
+		t.Row(ts, orDash(tr.RuleTitle), orDash(tr.Previous), orDash(tr.Current), labels)
+	}
+	return t.Render(w)
+}
+
+func (c *StateHistoryTableCodec) Decode(_ io.Reader, _ any) error {
+	return errors.New("table format does not support decoding")
+}
+
+func formatHistoryTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339)
+}

--- a/internal/providers/alert/state_history_commands_test.go
+++ b/internal/providers/alert/state_history_commands_test.go
@@ -1,0 +1,118 @@
+package alert_test
+
+import (
+	"bytes"
+	"net/http"
+	"testing"
+
+	"github.com/grafana/gcx/internal/providers/alert"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// serveStateHistory answers GET /api/v1/rules/history with the shared frame
+// fixture, recording the query it received.
+func serveStateHistory(gotQuery *string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		*gotQuery = r.URL.RawQuery
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(stateHistoryFrameJSON))
+	}
+}
+
+func TestStateHistoryListOutputContract(t *testing.T) {
+	t.Run("agent mode emits one JSON value", func(t *testing.T) {
+		setAgentMode(t, true)
+
+		var query string
+		loader := newAlertFixture(t, serveStateHistory(&query))
+		stdout, _, err := runCmdSplit(t, alert.NewStateHistoryListCommandForTest(loader),
+			[]string{"list", "--rule", "uid-1"}, "")
+		require.NoError(t, err)
+
+		doc := decodeSingleJSONDocument(t, stdout)
+		items, ok := doc.([]any)
+		require.True(t, ok, "state-history result should be a JSON array, got %T: %q", doc, stdout)
+		require.Len(t, items, 2)
+		record, ok := items[0].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "uid-1", record["ruleUid"])
+		assert.Equal(t, "Alerting", record["current"], "newest transition should sort first")
+	})
+
+	t.Run("human default renders the table", func(t *testing.T) {
+		setAgentMode(t, false)
+
+		var query string
+		loader := newAlertFixture(t, serveStateHistory(&query))
+		stdout, _, err := runCmdSplit(t, alert.NewStateHistoryListCommandForTest(loader),
+			[]string{"list"}, "")
+		require.NoError(t, err)
+
+		// The table header is stable regardless of row content.
+		assert.Contains(t, stdout, "PREVIOUS")
+		assert.Contains(t, stdout, "CURRENT")
+		assert.Contains(t, stdout, "CPU Usage")
+	})
+
+	t.Run("flags translate to alerting query params", func(t *testing.T) {
+		setAgentMode(t, false)
+
+		var query string
+		loader := newAlertFixture(t, serveStateHistory(&query))
+		_, _, err := runCmdSplit(t, alert.NewStateHistoryListCommandForTest(loader),
+			[]string{"list", "--rule", "uid-1", "--limit", "25", "--label", "severity=critical"}, "")
+		require.NoError(t, err)
+
+		assert.Contains(t, query, "ruleUID=uid-1")
+		assert.Contains(t, query, "limit=25")
+		assert.Contains(t, query, "labels_severity=critical")
+	})
+}
+
+func TestStateHistoryListValidation(t *testing.T) {
+	setAgentMode(t, false)
+
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"malformed label", []string{"list", "--label", "novalue"}},
+		{"negative limit", []string{"list", "--limit", "-1"}},
+		{"unparsable from", []string{"list", "--from", "notatime"}},
+		{"to before from", []string{"list", "--from", "now", "--to", "now-1h"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			loader := newAlertFixture(t, func(w http.ResponseWriter, r *http.Request) {
+				t.Errorf("unexpected API call on invalid input: %s %s", r.Method, r.URL.Path)
+				w.WriteHeader(http.StatusInternalServerError)
+			})
+			stdout, _, err := runCmdSplit(t, alert.NewStateHistoryListCommandForTest(loader), tc.args, "")
+			require.Error(t, err)
+			assert.Empty(t, stdout, "validation failures must not write to stdout")
+		})
+	}
+}
+
+// TestStateHistoryTableCodec pins the wide/narrow column shape independent of
+// the command wiring.
+func TestStateHistoryTableCodec(t *testing.T) {
+	rows := []alert.StateTransition{{
+		RuleUID:   "uid-1",
+		RuleTitle: "CPU Usage",
+		Previous:  "Normal",
+		Current:   "Alerting",
+		Labels:    map[string]string{"severity": "critical"},
+	}}
+
+	var narrow bytes.Buffer
+	require.NoError(t, (&alert.StateHistoryTableCodec{}).Encode(&narrow, rows))
+	assert.Contains(t, narrow.String(), "CURRENT")
+	assert.NotContains(t, narrow.String(), "RULE_UID")
+
+	var wide bytes.Buffer
+	require.NoError(t, (&alert.StateHistoryTableCodec{Wide: true}).Encode(&wide, rows))
+	assert.Contains(t, wide.String(), "RULE_UID")
+	assert.Contains(t, wide.String(), "uid-1")
+}


### PR DESCRIPTION
## What

Adds native support for **alert state history** in gcx:

```shell
gcx alert state-history list [--rule <uid>] [--from now-6h] [--to now] [--label key=value] [--limit N]
```

It queries Grafana's alert state-history API (`GET /api/v1/rules/history`) and returns recorded state transitions (e.g. `Normal → Alerting`), newest-first. This complements the existing read-only `gcx alert rules`/`groups`/`instances` commands — those show *current* state; this shows *historical* transitions.

## Why

State history was previously only reachable via `gcx api`. Alert triage frequently needs "how did this rule behave over the last N hours" — this exposes it as a first-class, agent-friendly command.

## How

- **Client**: new `Client.QueryStateHistory` decodes the bare Grafana data frame response (`time`/`line`/`labels` columns), reusing `internal/query/dataframe` wire types, and flattens it into typed `StateTransition` records ordered newest-first.
- **Command**: new `state-history` group + `list` subcommand following the standard opts/setup/validate pattern. Flags map to the API vocabulary — `--rule`→`ruleUID`, `--from`/`--to`→Unix-second bounds (accept relative like `now-6h`, RFC3339, or Unix seconds via `shared.ParseTime`), and repeatable `--label key=value`→`labels_<key>` **server-side** filters. Output: `table`/`wide`/`json`/`yaml`/`agents`.
- **Contracts**: registered the `finite` output class and a `medium` token-cost + LLM hint annotation.

## Testing

- Client tests: frame parsing, query-param translation, newest-first ordering, empty/error responses.
- Command tests: agent-mode single-JSON-value contract, human table rendering, flag→param translation, validation failures, and the table codec's narrow/wide shape.
- Verified live against an internal stack: rule scoping, relative time ranges, server-side label filtering, and the agent-mode contract all behave correctly. Grafana's state-reason suffixes (e.g. `Normal (NoData)`) pass through faithfully.

## Notes

- State history requires Grafana's history backend to be configured (Loki, or annotations — the annotations backend requires `--rule`). The command surfaces the backend error rather than trying to detect misconfiguration; this is called out in `--help` and the LLM hint.
- Gate run locally: `mise run lint` (0 issues), full `mise run tests`, `mise run build`, `mise run reference` (deterministic, no drift), and `mise run docs` (builds).

Made with [Cursor](https://cursor.com)