### PR TITLE
fix(kg): notifications list zero-result shape, NoArgs, category help

### DIFF
--- a/docs/reference/cli/gcx_kg_notifications_list.md
+++ b/docs/reference/cli/gcx_kg_notifications_list.md
@@ -9,7 +9,7 @@ gcx kg notifications list [flags]
 ### Options
 
 ```
-      --category string   Filter by category: request, resource, health, or slo.
+      --category string   Filter by category: request, resource, health, or slo (server-side, exact match). Empty or omitted lists all categories.
   -h, --help              help for list
       --jq string         jq expression to apply to JSON output. Mutually exclusive with --json.
       --json string       Comma-separated list of fields to include in JSON output, or 'list' (or '?') to discover available fields

--- a/internal/providers/kg/commands.go
+++ b/internal/providers/kg/commands.go
@@ -1017,6 +1017,7 @@ flag. Distinct from "gcx kg suppressions", which manages disabled-alert configs.
 	listCmd := &cobra.Command{
 		Use:   "list",
 		Short: "List alert notification configs, optionally filtered by category.",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := listOpts.IO.Validate(); err != nil {
 				return err
@@ -1037,7 +1038,12 @@ flag. Distinct from "gcx kg suppressions", which manages disabled-alert configs.
 			if err != nil {
 				return err
 			}
-			return listOpts.IO.Encode(cmd.OutOrStdout(), configs.AlertConfigs)
+			items := configs.AlertConfigs
+			if items == nil {
+				// Zero results must serialize as [] in machine formats, not null.
+				items = []AlertConfig{}
+			}
+			return listOpts.IO.Encode(cmd.OutOrStdout(), items)
 		},
 	}
 	listOpts.setup(listCmd.Flags())
@@ -1071,6 +1077,7 @@ flag. Distinct from "gcx kg suppressions", which manages disabled-alert configs.
 	createOpts := &notificationsCreateOpts{}
 	createCmd := &cobra.Command{
 		Use:   "upsert",
+		Args:  cobra.NoArgs,
 		Short: "Upsert (create or update) one or more alert notification configs from a YAML file or stdin.",
 		Long: `Upsert (create or update) one or more alert notification configs from a YAML file or stdin.
 
@@ -1174,7 +1181,7 @@ type notificationsListOpts struct {
 }
 
 func (o *notificationsListOpts) setup(flags *pflag.FlagSet) {
-	flags.StringVar(&o.Category, "category", "", "Filter by category: request, resource, health, or slo.")
+	flags.StringVar(&o.Category, "category", "", "Filter by category: request, resource, health, or slo (server-side, exact match). Empty or omitted lists all categories.")
 	o.IO.RegisterCustomCodec("table", &NotificationTableCodec{})
 	o.IO.DefaultFormat("table")
 	o.IO.BindFlags(flags)

--- a/internal/providers/kg/notifications_test.go
+++ b/internal/providers/kg/notifications_test.go
@@ -181,6 +181,23 @@ func TestNotifications_List_InvalidCategory(t *testing.T) {
 	assert.Contains(t, err.Error(), "invalid --category")
 }
 
+func TestNotifications_List_ZeroResults(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		// No alertConfigs key: the decoded slice is nil, which must still
+		// serialize as [] in machine formats, never null.
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+
+	var stdout bytes.Buffer
+	cmd := kg.NewNotificationsCommand(writeLoaderFor(server))
+	cmd.SetArgs([]string{"list", "-o", "json"})
+	cmd.SetOut(&stdout)
+	require.NoError(t, cmd.Execute())
+	assert.JSONEq(t, `[]`, stdout.String())
+}
+
 func TestNotifications_Get_HitAndMiss(t *testing.T) {
 	newServer := func() *httptest.Server {
 		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {


### PR DESCRIPTION
## What

Small follow-up to #1077 (merged 2026-08-20), catching three gaps found in a review pass against the newly-landed `integrate-with-gcx` contributor skill:

1. `Args: cobra.NoArgs` on the flags-only `list` and `upsert` leaves — without it they silently swallow stray positionals instead of rejecting them.
2. `gcx kg notifications list -o json|yaml` on zero results now serializes `[]` instead of `null`, with a regression test (`TestNotifications_List_ZeroResults`).
3. `--category` flag help now states its empty/omitted behavior and that matching is server-side and exact.

## Notes

- Unrelated to the two items still open in #1098 (accepting `get`/`list` output shapes on `upsert`, strict YAML parse) — no overlap.
- `gcx kg suppressions list` has the same null-vs-`[]` zero-result issue; out of scope here, flagged separately as family-wide debt.
- Full gate green: `GCX_AGENT_MODE=false mise run all` (lint 0 issues, all tests, reference docs regenerated with no drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)