### PR TITLE
ci(review): restore inline review publishing

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,6 +10,7 @@
       "Bash(git fetch:*)",
       "Bash(git log:*)",
       "Bash(git show:*)",
+      "Bash(gh api repos/grafana/gcx/pulls/*/reviews -X POST *)",
       "Bash(gh issue list:*)",
       "Bash(gh issue view:*)",
       "Bash(gh pr comment:*)",

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -162,6 +162,15 @@ Silence is a valid result. If there are no findings, say so in one line — and
 post that line. A review that ends without posting cannot be told apart from
 one that never ran. Never invent a finding.
 
+Publish one review with `event: COMMENT`, using the mechanics below. Use the
+workflow's **Review head** as `commit_id` and append its **Review marker** to
+the summary as an HTML comment, after the closing line. The workflow checks
+that this run published a review for that commit before adding its label.
+
+If publication is denied, stop and report the failed command. Do not retry it
+through scripts, post test comments, or move inline findings into a regular PR
+comment. A permission failure needs a workflow fix, not a different report.
+
 ## Offering to post the review
 
 After the report, offer to post it to the PR as inline comments. Do not post
@@ -183,11 +192,23 @@ judges the code. The event judges a colleague's work, and that choice is theirs.
 ### Mechanics
 
 One `POST` creates the whole review, both the summary body and every inline
-comment. The author then gets one notification instead of ten:
+comment. The author then gets one notification instead of ten. Pass the JSON
+directly on stdin; CI does not allow creating payload files. A quoted heredoc
+keeps backticks, dollar signs, and suggestions literal:
 
 ```bash
-gh api repos/{owner}/{repo}/pulls/{n}/reviews -X POST --input review.json
+gh api repos/{owner}/{repo}/pulls/{n}/reviews -X POST --input - <<'REVIEW_JSON'
+{
+  "event": "COMMENT",
+  "commit_id": "<reviewed head SHA>",
+  "body": "<summary and, in CI, the review marker>",
+  "comments": []
+}
+REVIEW_JSON
 ```
+
+Replace the placeholders, use the chosen event for a human-invoked review,
+and put the inline findings in `comments`. Leave it empty for a clean review.
 
 Each comment needs `path`, `line`, and `side`. Use `RIGHT` for the file after
 the change. A range also needs `start_line` and `start_side`.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -41,11 +41,15 @@ jobs:
     steps:
       # One number for both entry points: pull_request carries it on the PR,
       # issue_comment on the issue.
-      - name: Resolve pull request number
+      - name: Resolve pull request
         id: pr
         env:
+          GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
-        run: echo "number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+          gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --json headRefOid --jq '"head_sha=" + .headRefOid' >> "$GITHUB_OUTPUT"
 
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -85,14 +89,17 @@ jobs:
           # a rule added here instead of there applies to CI only, and silently
           # stops applying the moment someone reviews the same PR locally.
           prompt: |
-            Review ${{ github.repository }}/pull/${{ steps.pr.outputs.number }}
-            with the /review-pr skill. Invoke it as a skill; reading the file
-            leaves its unattended-run rules unapplied.
-          # Pin the model to keep the behaviour consistent. Tool permissions
-          # live in .claude/settings.json, which this session loads as a
-          # project setting source, so a local /review-pr run and this workflow
-          # get the same allowlist instead of drifting apart.
-          claude_args: '--model claude-opus-4-6'
+            Invoke the /review-pr skill to review
+            ${{ github.repository }}/pull/${{ steps.pr.outputs.number }}.
+            This is an unattended workflow run.
+            Review head: ${{ steps.pr.outputs.head_sha }}
+            Review marker: <!-- gcx-claude-review:${{ github.run_id }}:${{ github.run_attempt }} -->
+          # Shared permissions live in .claude/settings.json. The action also
+          # reads --allowedTools to decide which MCP servers to register, so
+          # this tool must stay here even though settings already allow it.
+          claude_args: >-
+            --model claude-opus-4-6
+            --allowedTools mcp__github_inline_comment__create_inline_comment
 
       # The transcript records every tool call and every permission denial.
       # Without it a review that silently denied its way to no output looks
@@ -105,8 +112,29 @@ jobs:
           path: ${{ steps.claude-review.outputs.execution_file }}
           retention-days: 7
 
-      - name: Add claude-reviewed label
+      - name: Verify review and add claude-reviewed label
         if: success()
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh pr edit "${{ steps.pr.outputs.number }}" --add-label claude-reviewed
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          REVIEW_HEAD: ${{ steps.pr.outputs.head_sha }}
+          REVIEW_MARKER: '<!-- gcx-claude-review:${{ github.run_id }}:${{ github.run_attempt }} -->'
+        run: |
+          current_head=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" \
+            --json headRefOid --jq .headRefOid)
+          if [[ "$current_head" != "$REVIEW_HEAD" ]]; then
+            echo "::error::The PR changed during the review. Run @claude review again."
+            exit 1
+          fi
+          if ! gh api --paginate --slurp "repos/$GITHUB_REPOSITORY/pulls/$PR_NUMBER/reviews" |
+            jq -e --arg head "$REVIEW_HEAD" --arg marker "$REVIEW_MARKER" '
+              any(.[][];
+                .user.login == "claude[bot]" and
+                .state == "COMMENTED" and
+                .commit_id == $head and
+                ((.body // "") | contains($marker)))' > /dev/null; then
+            echo "::error::Claude did not publish a COMMENT review for this run and commit. Check the session transcript."
+            exit 1
+          fi
+          gh pr edit "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label claude-reviewed

--- a/scripts/review_workflow_test.go
+++ b/scripts/review_workflow_test.go
@@ -1,0 +1,160 @@
+package scripts_test
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Execute the workflow's actual shell with a fake GitHub API. In particular,
+// an old review or a failed API call must never be enough to add the label.
+func TestReviewWorkflowPublicationGate(t *testing.T) {
+	if _, err := exec.LookPath("jq"); err != nil {
+		t.Skip("jq is required to execute the review workflow")
+	}
+	data, err := os.ReadFile("../.github/workflows/claude-code-review.yml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var workflow struct {
+		Jobs map[string]struct {
+			Steps []struct {
+				Name  string `yaml:"name"`
+				Run   string `yaml:"run"`
+				Shell string `yaml:"shell"`
+			} `yaml:"steps"`
+		} `yaml:"jobs"`
+	}
+	if err := yaml.Unmarshal(data, &workflow); err != nil {
+		t.Fatal(err)
+	}
+	var script string
+	for _, step := range workflow.Jobs["claude-review"].Steps {
+		if step.Name == "Verify review and add claude-reviewed label" {
+			if step.Shell != "bash" {
+				t.Fatal("the publication gate needs explicit bash for pipefail")
+			}
+			script = step.Run
+		}
+	}
+	if script == "" {
+		t.Fatal("review publication gate is missing")
+	}
+
+	const review = `{"user":{"login":"claude[bot]"},"state":"COMMENTED","commit_id":"head","body":"No issues. <!-- gcx-claude-review:123:1 -->"}`
+	const mockGH = `#!/usr/bin/env bash
+set -euo pipefail
+case "$1 $2" in
+  "pr view") printf '%s\n' "$TEST_CURRENT_HEAD" ;;
+  "api --paginate") cat "$TEST_REVIEWS_FILE"; exit "$TEST_API_EXIT" ;;
+  "pr edit") printf '%s\n' "$*" > "$TEST_LABEL_FILE" ;;
+  *) echo "Unexpected gh invocation: $*" >&2; exit 2 ;;
+esac
+`
+	tests := []struct {
+		name, pages, currentHead, apiExit string
+		wantLabel                         bool
+	}{
+		{"clean review", "[[" + review + "]]", "head", "0", true},
+		{"review on later page", "[[],[" + review + "]]", "head", "0", true},
+		{"nothing published", "[[]]", "head", "0", false},
+		{"previous run", "[[" + strings.ReplaceAll(review, "123:1", "122:1") + "]]", "head", "0", false},
+		{"previous attempt", "[[" + strings.ReplaceAll(review, "123:1", "123:0") + "]]", "head", "0", false},
+		{"wrong commit", "[[" + strings.ReplaceAll(review, `"head"`, `"old"`) + "]]", "head", "0", false},
+		{"other author", "[[" + strings.ReplaceAll(review, "claude[bot]", "other[bot]") + "]]", "head", "0", false},
+		{"approval", "[[" + strings.ReplaceAll(review, "COMMENTED", "APPROVED") + "]]", "head", "0", false},
+		{"pending review", "[[" + strings.ReplaceAll(review, "COMMENTED", "PENDING") + "]]", "head", "0", false},
+		{"head changed", "[[" + review + "]]", "new-head", "0", false},
+		{"API failed after a page", "[[" + review + "]]", "head", "1", false},
+		{"invalid API response", "not json", "head", "0", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, "gh"), []byte(mockGH), 0o700); err != nil { // #nosec G306 -- Executable test stub in t.TempDir.
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, "reviews.json"), []byte(tt.pages), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			labelFile := filepath.Join(dir, "label")
+			cmd := exec.CommandContext(t.Context(), "bash", "--noprofile", "--norc", "-eo", "pipefail", "-c", script)
+			cmd.Env = append(os.Environ(),
+				"PATH="+dir+string(os.PathListSeparator)+os.Getenv("PATH"),
+				"GITHUB_REPOSITORY=grafana/gcx", "PR_NUMBER=1292", "REVIEW_HEAD=head",
+				"REVIEW_MARKER=<!-- gcx-claude-review:123:1 -->",
+				"TEST_CURRENT_HEAD="+tt.currentHead, "TEST_API_EXIT="+tt.apiExit,
+				"TEST_REVIEWS_FILE="+filepath.Join(dir, "reviews.json"), "TEST_LABEL_FILE="+labelFile)
+			out, err := cmd.CombinedOutput()
+			if (err == nil) != tt.wantLabel {
+				t.Fatalf("workflow error = %v, want label %v; output: %s", err, tt.wantLabel, out)
+			}
+			label, readErr := os.ReadFile(labelFile)
+			if tt.wantLabel {
+				if readErr != nil || string(label) != "pr edit 1292 --repo grafana/gcx --add-label claude-reviewed\n" {
+					t.Fatalf("label invocation = %q, read error = %v", label, readErr)
+				}
+			} else if !os.IsNotExist(readErr) {
+				t.Fatalf("label command ran despite failed verification: %q (%v)", label, readErr)
+			}
+		})
+	}
+}
+
+// Run the skill's posting example against a fake gh, including shell syntax in
+// the review text. It must reach stdin unchanged without creating payload files.
+func TestReviewSkillPostsJSONOnStdin(t *testing.T) {
+	data, err := os.ReadFile("../.claude/skills/review-pr/SKILL.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, block, ok := strings.Cut(string(data), "```bash\ngh api ")
+	if !ok {
+		t.Fatal("review API example is missing")
+	}
+	block, _, ok = strings.Cut(block, "\n```")
+	if !ok {
+		t.Fatal("review API example is not closed")
+	}
+	dir := t.TempDir()
+	body := "Use `agents` and $(touch " + filepath.Join(dir, "expanded") + ")."
+	encodedBody, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	script := "gh api " + strings.NewReplacer(
+		"{owner}", "grafana", "{repo}", "gcx", "{n}", "1292",
+		`"<summary and, in CI, the review marker>"`, string(encodedBody),
+	).Replace(block)
+	mock := "#!/bin/sh\n[ \"$*\" = 'api repos/grafana/gcx/pulls/1292/reviews -X POST --input -' ] || exit 2\ncat\n"
+	if err := os.WriteFile(filepath.Join(dir, "gh"), []byte(mock), 0o700); err != nil { // #nosec G306 -- Executable test stub in t.TempDir.
+		t.Fatal(err)
+	}
+	cmd := exec.CommandContext(t.Context(), "bash", "-e", "-c", script)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "PATH="+dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("posting example failed: %v: %s", err, out)
+	}
+	var payload struct {
+		Event    string            `json:"event"`
+		Body     string            `json:"body"`
+		Comments []json.RawMessage `json:"comments"`
+	}
+	if err := json.Unmarshal(out, &payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload.Event != "COMMENT" || payload.Body != body || payload.Comments == nil {
+		t.Fatalf("unexpected review payload: %s", out)
+	}
+	files, err := os.ReadDir(dir)
+	if err != nil || len(files) != 1 || files[0].Name() != "gh" {
+		t.Fatalf("posting example created files: %v (error: %v)", files, err)
+	}
+}


### PR DESCRIPTION
#1295 got Claude posting again. In the [rerun on #1292](https://github.com/grafana/gcx/actions/runs/34278669367), it completed the review but hit 65 permission denials and eventually put everything in a [regular PR comment](https://github.com/grafana/gcx/pull/1292#issuecomment-5592022070). The finding never appeared inline, and the run still added `claude-reviewed`.

#1290 moved permissions into settings, but the [pinned action also reads `--allowedTools` to register MCP servers](https://github.com/anthropics/claude-code-action/blob/dde2242db6af13460b916652159b6ba19a598f30/src/mcp/install-mcp-server.ts#L137-L159). The inline tool was still allowed in settings, but its server was no longer registered. The transcript also shows that the skill's review API call and attempts to write a JSON payload were denied. These explain the fallback we saw; they don't establish the cause of every earlier silent run.

This restores inline server registration and allows the documented review POST, with the payload sent on stdin. The workflow now checks that this run published a COMMENT review for the current commit before adding `claude-reviewed`. A denied post should fail clearly instead of sending Claude through alternative posting attempts.

The publishing changes still need a live run after merge: rerun `@claude review` on #1292 to check the summary and inline finding, then try a PR with no findings to check the clean-review path.

Validated with `GCX_AGENT_MODE=false mise run all` and `actionlint`. The added tests execute the workflow's publication check against a fake GitHub API and check that the documented stdin payload preserves review text without creating files.
