### PR TITLE
chore: improve oncall and irm discoverability

### DIFF
--- a/claude-plugin/skills/gcx/SKILL.md
+++ b/claude-plugin/skills/gcx/SKILL.md
@@ -79,14 +79,16 @@ Similarly, prefer `gcx metrics query` over `gcx datasources query <prometheus-ui
 for PromQL queries — the signal-specific command handles datasource resolution
 automatically.
 
-## Verify Context First
+## Target Context
 
-Before any operation, confirm which environment is targeted:
-- `gcx config check` — validates the active context and tests connectivity
-- `gcx config view` — shows full config (secrets redacted; use `--raw` to reveal)
-- `gcx config current-context` — shows just the active context name
-- `gcx config use-context <name>` — switch contexts
-- `--context <name>` flag on any command — target a specific context without switching
+When the target context is known, pass `--context <name>` directly;
+no separate configuration or connectivity check is needed.
+Inspect configuration only when the target is ambiguous or a request fails
+with a configuration, authentication, or connectivity error:
+- `gcx config list-contexts` — list configured contexts and their servers
+- `gcx config current-context` — show the active context name
+- `gcx config check` — validate the active context and test connectivity
+- `gcx config view` — inspect configuration with secrets redacted
 
 ## Output Control
 

--- a/docs/reference/cli/gcx_irm_oncall_schedules_list.md
+++ b/docs/reference/cli/gcx_irm_oncall_schedules_list.md
@@ -2,8 +2,31 @@
 
 List OnCall schedules.
 
+### Synopsis
+
+List OnCall schedules and their current assignees.
+
+JSON output includes current assignees in spec.on_call_now, with usernames
+available directly without a separate users lookup.
+Use --jq to filter the returned schedules by name and select only the fields you need.
+For coverage over a date range or handover times, use schedules list-final-shifts
+with the schedule ID from metadata.name; on_call_now describes only the current moment.
+
 ```
 gcx irm oncall schedules list [flags]
+```
+
+### Examples
+
+```
+  # List schedules and current assignees
+  gcx irm oncall schedules list
+
+  # Show only schedule names and current usernames
+  gcx irm oncall schedules list --jq '[.[] | {name: .spec.name, on_call_now: [.spec.on_call_now[]? | .username]}]'
+
+  # Find Payments schedules in a known context (name match, case-insensitive)
+  gcx --context prod irm oncall schedules list --jq '[.[] | select(.spec.name | test("payments"; "i")) | {id: .metadata.name, name: .spec.name, on_call_now: [.spec.on_call_now[]? | .username]}]'
 ```
 
 ### Options

--- a/internal/providers/irm/oncall_commands.go
+++ b/internal/providers/irm/oncall_commands.go
@@ -456,12 +456,28 @@ func newSchedulesCmd(loader OnCallConfigLoader) *cobra.Command {
 		Short:   "Manage OnCall schedules.",
 		Aliases: []string{"schedule"},
 	}
+	listCmd := newListSubcommand(loader, "schedules", "Schedule", "List OnCall schedules.", "id",
+		func(ctx context.Context, c OnCallAPI) ([]Schedule, error) { return c.ListSchedules(ctx) },
+		func(ctx context.Context, c OnCallAPI, name string) (*Schedule, error) {
+			return c.GetSchedule(ctx, name)
+		})
+	listCmd.Long = `List OnCall schedules and their current assignees.
+
+JSON output includes current assignees in spec.on_call_now, with usernames
+available directly without a separate users lookup.
+Use --jq to filter the returned schedules by name and select only the fields you need.
+For coverage over a date range or handover times, use schedules list-final-shifts
+with the schedule ID from metadata.name; on_call_now describes only the current moment.`
+	listCmd.Example = `  # List schedules and current assignees
+  gcx irm oncall schedules list
+
+  # Show only schedule names and current usernames
+  gcx irm oncall schedules list --jq '[.[] | {name: .spec.name, on_call_now: [.spec.on_call_now[]? | .username]}]'
+
+  # Find Payments schedules in a known context (name match, case-insensitive)
+  gcx --context prod irm oncall schedules list --jq '[.[] | select(.spec.name | test("payments"; "i")) | {id: .metadata.name, name: .spec.name, on_call_now: [.spec.on_call_now[]? | .username]}]'`
 	cmd.AddCommand(
-		newListSubcommand(loader, "schedules", "Schedule", "List OnCall schedules.", "id",
-			func(ctx context.Context, c OnCallAPI) ([]Schedule, error) { return c.ListSchedules(ctx) },
-			func(ctx context.Context, c OnCallAPI, name string) (*Schedule, error) {
-				return c.GetSchedule(ctx, name)
-			}),
+		listCmd,
 		newGetSubcommand(loader, "Get a schedule by ID.",
 			func(ctx context.Context, c OnCallAPI, name string) (*Schedule, error) {
 				return c.GetSchedule(ctx, name)


### PR DESCRIPTION
An agent being prompted to check who is on call currently spend 5 or 6 turns until it makes the correct command execution. It always check the context and it uses wrong timezone.

To improve this I'm adding a more precise instructions in the help