### PR TITLE
Stop OAuth when sandbox blocks keychain writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ gcx login my-stack --server https://my-stack.grafana.net
 
 Opens a browser for OAuth, then saves the access token, refresh token, and proxy endpoint to the `my-stack` context's named stack entry and makes the context current. Best for day-to-day use on Cloud stacks. If OAuth doesn't suit your setup, pick "Service account token" at the prompt.
 
+gcx stops before the browser flow when the current process cannot write to the
+OS credential store. Agent users must approve the same command outside the
+sandbox. See [Keychain credential storage](docs/sources/keychain.md).
+
 **Service account token (Cloud or on-premises, recommended for CI/automation):**
 
 ```bash

--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -64,7 +64,6 @@ func ErrorToDetailedError(err error) *gcxerrors.DetailedError {
 		convertCobraUnknownCommandErrors,
 		convertContextCanceled,                      // Context cancellation (must be first — cancellation can wrap other errors)
 		convertRequiredFlagErrors,                   // Cobra required-flag errors — must appear before generic checks
-		convertOAuthPersistenceErrors,               // OAuth preflight failures — must precede credential-store errors that they wrap
 		convertCredentialsErrors,                    // OS credential-store failures — must precede config errors that wrap them
 		convertConfigErrors,                         // Config-related
 		convertAuthErrors,                           // Auth-related (expired tokens)
@@ -94,34 +93,6 @@ func ErrorToDetailedError(err error) *gcxerrors.DetailedError {
 	}
 
 	return fallbackDetailedError(err)
-}
-
-func convertOAuthPersistenceErrors(err error) (*gcxerrors.DetailedError, bool) {
-	suggestions := []string{
-		"Retry the same command outside the sandbox, or grant this process access to the OS credential store",
-		"If an agent ran the command, use its approval flow to run gcx outside the sandbox",
-	}
-	if errors.Is(err, auth.ErrCredentialPersistencePreflight) {
-		return &gcxerrors.DetailedError{
-			Summary: "OAuth refresh cannot persist credentials",
-			Details: "gcx stopped before it sent the refresh token. The stored session is unchanged.",
-			Parent:  err,
-			Suggestions: append([]string{
-				"Do not run gcx login",
-			}, suggestions...),
-			DocsLink: docs.Keychain,
-		}, true
-	}
-	if errors.Is(err, login.ErrCredentialPersistencePreflight) {
-		return &gcxerrors.DetailedError{
-			Summary:     "OAuth login cannot persist credentials",
-			Details:     "gcx stopped before it started the OAuth browser flow.",
-			Parent:      err,
-			Suggestions: suggestions,
-			DocsLink:    docs.Keychain,
-		}, true
-	}
-	return nil, false
 }
 
 // convertAlreadyReported suppresses a secondary error envelope when a command

--- a/cmd/gcx/fail/convert.go
+++ b/cmd/gcx/fail/convert.go
@@ -64,7 +64,8 @@ func ErrorToDetailedError(err error) *gcxerrors.DetailedError {
 		convertCobraUnknownCommandErrors,
 		convertContextCanceled,                      // Context cancellation (must be first — cancellation can wrap other errors)
 		convertRequiredFlagErrors,                   // Cobra required-flag errors — must appear before generic checks
-		convertCredentialsErrors,                    // Locked OS keychain — must precede credential-rejection/config errors that wrap it
+		convertOAuthPersistenceErrors,               // OAuth preflight failures — must precede credential-store errors that they wrap
+		convertCredentialsErrors,                    // OS credential-store failures — must precede config errors that wrap them
 		convertConfigErrors,                         // Config-related
 		convertAuthErrors,                           // Auth-related (expired tokens)
 		convertUnavailableEndpoint,                  // Experimental/Cloud-only endpoint route absent
@@ -93,6 +94,34 @@ func ErrorToDetailedError(err error) *gcxerrors.DetailedError {
 	}
 
 	return fallbackDetailedError(err)
+}
+
+func convertOAuthPersistenceErrors(err error) (*gcxerrors.DetailedError, bool) {
+	suggestions := []string{
+		"Retry the same command outside the sandbox, or grant this process access to the OS credential store",
+		"If an agent ran the command, use its approval flow to run gcx outside the sandbox",
+	}
+	if errors.Is(err, auth.ErrCredentialPersistencePreflight) {
+		return &gcxerrors.DetailedError{
+			Summary: "OAuth refresh cannot persist credentials",
+			Details: "gcx stopped before it sent the refresh token. The stored session is unchanged.",
+			Parent:  err,
+			Suggestions: append([]string{
+				"Do not run gcx login",
+			}, suggestions...),
+			DocsLink: docs.Keychain,
+		}, true
+	}
+	if errors.Is(err, login.ErrCredentialPersistencePreflight) {
+		return &gcxerrors.DetailedError{
+			Summary:     "OAuth login cannot persist credentials",
+			Details:     "gcx stopped before it started the OAuth browser flow.",
+			Parent:      err,
+			Suggestions: suggestions,
+			DocsLink:    docs.Keychain,
+		}, true
+	}
+	return nil, false
 }
 
 // convertAlreadyReported suppresses a secondary error envelope when a command
@@ -212,17 +241,20 @@ func convertAuthErrors(err error) (*gcxerrors.DetailedError, bool) {
 	return nil, false
 }
 
-// convertCredentialsErrors converts unavailable and locked keychain errors
-// into actionable messages. Both conditions remain fatal so gcx never falls
-// back to a plaintext write unless the user explicitly selects that policy.
+// convertCredentialsErrors converts restricted, unavailable, and locked
+// credential-store errors into actionable messages. These conditions remain
+// fatal unless the user explicitly selects plaintext storage.
 func convertCredentialsErrors(err error) (*gcxerrors.DetailedError, bool) {
-	if errors.Is(err, credentials.ErrLocked) {
+	if errors.Is(err, credentials.ErrRestrictedSession) {
 		return &gcxerrors.DetailedError{
-			Summary:     "Keychain locked",
-			Details:     "The OS keychain is reachable, but it is locked or cannot be unlocked in this session. gcx does not fall back to a plaintext credential.",
-			Parent:      err,
-			Suggestions: keychainLockedSuggestions(runtime.GOOS),
-			DocsLink:    docs.Keychain,
+			Summary: "OS credential store access is restricted",
+			Details: "The credential store is available, but this execution session cannot write to it. gcx does not fall back to a plaintext credential.",
+			Parent:  err,
+			Suggestions: []string{
+				"Retry the same command outside the sandbox, or grant this process access to the OS credential store",
+				"If an agent ran the command, use its approval flow to run gcx outside the sandbox",
+			},
+			DocsLink: docs.Keychain,
 		}, true
 	}
 
@@ -240,6 +272,15 @@ func convertCredentialsErrors(err error) (*gcxerrors.DetailedError, bool) {
 		}, true
 	}
 
+	if errors.Is(err, credentials.ErrLocked) {
+		return &gcxerrors.DetailedError{
+			Summary:     "Keychain locked",
+			Details:     "The OS keychain is reachable, but it is locked or cannot be unlocked in this session. gcx does not fall back to a plaintext credential.",
+			Parent:      err,
+			Suggestions: keychainLockedSuggestions(runtime.GOOS),
+			DocsLink:    docs.Keychain,
+		}, true
+	}
 	return nil, false
 }
 

--- a/cmd/gcx/fail/convert_test.go
+++ b/cmd/gcx/fail/convert_test.go
@@ -1422,26 +1422,22 @@ func TestErrorToDetailedError_KeychainLocked(t *testing.T) {
 	}
 }
 
-func TestErrorToDetailedError_OAuthPersistencePreflight(t *testing.T) {
+func TestErrorToDetailedError_RestrictedCredentialSession(t *testing.T) {
 	tests := []struct {
-		name        string
-		err         error
-		wantSummary string
-		wantDetails string
-		wantNoLogin bool
+		name string
+		err  error
 	}{
 		{
-			name:        "refresh",
-			err:         fmt.Errorf("request failed: %w: %w", auth.ErrCredentialPersistencePreflight, credentials.ErrRestrictedSession),
-			wantSummary: "OAuth refresh cannot persist credentials",
-			wantDetails: "gcx stopped before it sent the refresh token. The stored session is unchanged.",
-			wantNoLogin: true,
+			name: "direct credential-store failure",
+			err:  fmt.Errorf("write config: %w", credentials.ErrRestrictedSession),
 		},
 		{
-			name:        "login",
-			err:         fmt.Errorf("login failed: %w: %w", login.ErrCredentialPersistencePreflight, credentials.ErrRestrictedSession),
-			wantSummary: "OAuth login cannot persist credentials",
-			wantDetails: "gcx stopped before it started the OAuth browser flow.",
+			name: "OAuth refresh preflight failure",
+			err:  fmt.Errorf("request failed: %w: %w", auth.ErrCredentialPersistencePreflight, credentials.ErrRestrictedSession),
+		},
+		{
+			name: "OAuth login preflight failure",
+			err:  fmt.Errorf("login failed: %w: %w", login.ErrCredentialPersistencePreflight, credentials.ErrRestrictedSession),
 		},
 	}
 
@@ -1449,24 +1445,9 @@ func TestErrorToDetailedError_OAuthPersistencePreflight(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			got := fail.ErrorToDetailedError(tt.err)
 			require.NotNil(t, got)
-			assert.Equal(t, tt.wantSummary, got.Summary)
-			assert.Equal(t, tt.wantDetails, got.Details)
+			assert.Equal(t, "OS credential store access is restricted", got.Summary)
+			assert.NotEqual(t, "Keychain locked", got.Summary)
 			assert.Equal(t, docs.Keychain, got.DocsLink)
-			assert.Contains(t, got.Suggestions, "Retry the same command outside the sandbox, or grant this process access to the OS credential store")
-			assert.Contains(t, got.Suggestions, "If an agent ran the command, use its approval flow to run gcx outside the sandbox")
-			if tt.wantNoLogin {
-				assert.Contains(t, got.Suggestions, "Do not run gcx login")
-			} else {
-				assert.NotContains(t, got.Suggestions, "Do not run gcx login")
-			}
 		})
 	}
-}
-
-func TestErrorToDetailedError_RestrictedCredentialSession(t *testing.T) {
-	got := fail.ErrorToDetailedError(fmt.Errorf("write config: %w", credentials.ErrRestrictedSession))
-	require.NotNil(t, got)
-	assert.Equal(t, "OS credential store access is restricted", got.Summary)
-	assert.NotEqual(t, "Keychain locked", got.Summary)
-	assert.Equal(t, docs.Keychain, got.DocsLink)
 }

--- a/cmd/gcx/fail/convert_test.go
+++ b/cmd/gcx/fail/convert_test.go
@@ -1421,3 +1421,52 @@ func TestErrorToDetailedError_KeychainLocked(t *testing.T) {
 		})
 	}
 }
+
+func TestErrorToDetailedError_OAuthPersistencePreflight(t *testing.T) {
+	tests := []struct {
+		name        string
+		err         error
+		wantSummary string
+		wantDetails string
+		wantNoLogin bool
+	}{
+		{
+			name:        "refresh",
+			err:         fmt.Errorf("request failed: %w: %w", auth.ErrCredentialPersistencePreflight, credentials.ErrRestrictedSession),
+			wantSummary: "OAuth refresh cannot persist credentials",
+			wantDetails: "gcx stopped before it sent the refresh token. The stored session is unchanged.",
+			wantNoLogin: true,
+		},
+		{
+			name:        "login",
+			err:         fmt.Errorf("login failed: %w: %w", login.ErrCredentialPersistencePreflight, credentials.ErrRestrictedSession),
+			wantSummary: "OAuth login cannot persist credentials",
+			wantDetails: "gcx stopped before it started the OAuth browser flow.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := fail.ErrorToDetailedError(tt.err)
+			require.NotNil(t, got)
+			assert.Equal(t, tt.wantSummary, got.Summary)
+			assert.Equal(t, tt.wantDetails, got.Details)
+			assert.Equal(t, docs.Keychain, got.DocsLink)
+			assert.Contains(t, got.Suggestions, "Retry the same command outside the sandbox, or grant this process access to the OS credential store")
+			assert.Contains(t, got.Suggestions, "If an agent ran the command, use its approval flow to run gcx outside the sandbox")
+			if tt.wantNoLogin {
+				assert.Contains(t, got.Suggestions, "Do not run gcx login")
+			} else {
+				assert.NotContains(t, got.Suggestions, "Do not run gcx login")
+			}
+		})
+	}
+}
+
+func TestErrorToDetailedError_RestrictedCredentialSession(t *testing.T) {
+	got := fail.ErrorToDetailedError(fmt.Errorf("write config: %w", credentials.ErrRestrictedSession))
+	require.NotNil(t, got)
+	assert.Equal(t, "OS credential store access is restricted", got.Summary)
+	assert.NotEqual(t, "Keychain locked", got.Summary)
+	assert.Equal(t, docs.Keychain, got.DocsLink)
+}

--- a/cmd/gcx/login/command.go
+++ b/cmd/gcx/login/command.go
@@ -394,9 +394,10 @@ func runLogin(cmd *cobra.Command, flags *loginOpts, args []string) error {
 			StoredProxyEndpoint:         storedProxyEndpoint,
 		},
 		Hooks: login.Hooks{
-			ConfigSource:        mutationSource,
-			CloudMutationSafety: cloudMutationSafety,
-			LoginMutationGuard:  loginMutationGuard,
+			ConfigSource:               mutationSource,
+			CloudMutationSafety:        cloudMutationSafety,
+			LoginMutationGuard:         loginMutationGuard,
+			CheckCredentialPersistence: cfg.CheckOAuthCredentialPersistence,
 			NewAuthFlow: func(server string, ao internalauth.Options) login.AuthFlow {
 				return internalauth.NewFlow(server, ao)
 			},

--- a/docs/architecture/auth-system.md
+++ b/docs/architecture/auth-system.md
@@ -195,8 +195,8 @@ backend (which issues and refreshes tokens), and a short-lived callback
 server that gcx starts on a loopback port.
 
 Before gcx starts the browser flow, it confirms that the credential store can
-write, read, and remove a random non-secret value. It stops before browser or
-network use when a sandbox or another process policy blocks the write.
+write, read, and remove a random non-secret value. If the check fails, gcx stops
+the OAuth flow.
 
 ```mermaid
 sequenceDiagram
@@ -370,10 +370,7 @@ the server-side refresh token. Cancellation is still honored before the lock
 and network request begin.
 
 After the lock and reload, the transport checks that the credential store is
-writable. This check occurs only when a network refresh is still required. A
-failure stops the operation before gcx sends the refresh token. A retry of an
-already rotated pending generation skips this check and retries only the
-persistence callback.
+writable. If the check fails, gcx stops the token refresh flow.
 
 A successful refresh response is not exposed to protected requests until
 persistence succeeds. Rotation-capable issuers may return a new refresh token;

--- a/docs/architecture/auth-system.md
+++ b/docs/architecture/auth-system.md
@@ -194,6 +194,10 @@ spans three remote actors: the Grafana instance (which hosts the
 backend (which issues and refreshes tokens), and a short-lived callback
 server that gcx starts on a loopback port.
 
+Before gcx starts the browser flow, it confirms that the credential store can
+write, read, and remove a random non-secret value. It stops before browser or
+network use when a sandbox or another process policy blocks the write.
+
 ```mermaid
 sequenceDiagram
     participant User
@@ -364,6 +368,12 @@ uses a context detached from the caller's request context so that a caller
 cancellation cannot abandon a refresh that has already consumed and rotated
 the server-side refresh token. Cancellation is still honored before the lock
 and network request begin.
+
+After the lock and reload, the transport checks that the credential store is
+writable. This check occurs only when a network refresh is still required. A
+failure stops the operation before gcx sends the refresh token. A retry of an
+already rotated pending generation skips this check and retries only the
+persistence callback.
 
 A successful refresh response is not exposed to protected requests until
 persistence succeeds. Rotation-capable issuers may return a new refresh token;

--- a/docs/architecture/config-system.md
+++ b/docs/architecture/config-system.md
@@ -352,12 +352,10 @@ backend, replacing or deleting an existing generation, replacing a missing or
 rejected sentinel, and
 value-size, policy, cancellation, or unknown backend failures all fail closed.
 
-Some sandboxes allow credential reads and block credential writes. OAuth login
-and refresh use a random non-secret write, read, and delete probe to detect this
-condition before they send OAuth credentials. Known macOS authorization exit
-codes use `credentials.ErrRestrictedSession`. Other probe failures stay fatal.
-The check uses credential-store behavior instead of an agent-specific
-environment variable.
+Some sandboxes allow credential reads and block credential writes. The OAuth
+login and refresh flows check for this condition before they start. They stop
+if the condition is true. gcx returns `credentials.ErrRestrictedSession` for
+known macOS authorization exit codes. Other probe failures stay fatal.
 
 Silently continuing in those cases could orphan the only resolvable credential,
 leave an old credential active, downgrade a credential for an unrelated backend

--- a/docs/architecture/config-system.md
+++ b/docs/architecture/config-system.md
@@ -351,6 +351,14 @@ same cause while keeping the rotated generation pending for retry. A locked
 backend, replacing or deleting an existing generation, replacing a missing or
 rejected sentinel, and
 value-size, policy, cancellation, or unknown backend failures all fail closed.
+
+Some sandboxes allow credential reads and block credential writes. OAuth login
+and refresh use a random non-secret write, read, and delete probe to detect this
+condition before they send OAuth credentials. Known macOS authorization exit
+codes use `credentials.ErrRestrictedSession`. Other probe failures stay fatal.
+The check uses credential-store behavior instead of an agent-specific
+environment variable.
+
 Silently continuing in those cases could orphan the only resolvable credential,
 leave an old credential active, downgrade a credential for an unrelated backend
 error, or write a secret in plaintext while a real secret backend exists.

--- a/docs/design/errors.md
+++ b/docs/design/errors.md
@@ -165,6 +165,9 @@ Adding a new summary requires a PR amending this list.
 | `Authentication failed` | Token expired or missing |
 | `Keychain locked` | The OS keychain answers, but it is locked or the current session cannot unlock it, so gcx cannot store or use the credential |
 | `Keychain unavailable` | The OS keychain cannot be reached, so gcx cannot store or use the credential without an explicit plaintext-storage opt-out |
+| `OS credential store access is restricted` | The credential store is available, but the current execution session cannot write to it |
+| `OAuth login cannot persist credentials` | gcx cannot confirm that it can persist a new OAuth credential before the browser flow starts |
+| `OAuth refresh cannot persist credentials` | gcx cannot confirm that it can persist a rotated OAuth credential before it sends the refresh token |
 | `Authorization failed` | Permission denied (403) |
 | `Resource not found` | 404 or client-side not-found detection |
 | `Resource conflict` | Optimistic lock / RMW conflict, or an API-reported conflict whose exact cause is not machine-discriminable (e.g. GCOM stack 409s) |

--- a/docs/design/errors.md
+++ b/docs/design/errors.md
@@ -166,8 +166,6 @@ Adding a new summary requires a PR amending this list.
 | `Keychain locked` | The OS keychain answers, but it is locked or the current session cannot unlock it, so gcx cannot store or use the credential |
 | `Keychain unavailable` | The OS keychain cannot be reached, so gcx cannot store or use the credential without an explicit plaintext-storage opt-out |
 | `OS credential store access is restricted` | The credential store is available, but the current execution session cannot write to it |
-| `OAuth login cannot persist credentials` | gcx cannot confirm that it can persist a new OAuth credential before the browser flow starts |
-| `OAuth refresh cannot persist credentials` | gcx cannot confirm that it can persist a rotated OAuth credential before it sends the refresh token |
 | `Authorization failed` | Permission denied (403) |
 | `Resource not found` | 404 or client-side not-found detection |
 | `Resource conflict` | Optimistic lock / RMW conflict, or an API-reported conflict whose exact cause is not machine-discriminable (e.g. GCOM stack 409s) |

--- a/docs/reference/configuration/keychain.md
+++ b/docs/reference/configuration/keychain.md
@@ -113,13 +113,12 @@ Some agent tools run commands in a sandbox. The sandbox can allow credential
 reads and block credential writes. A read-only check cannot detect this state.
 
 Before an OAuth login or token refresh, gcx writes, reads, and removes a random
-non-secret test value. If this test fails, gcx stops before it starts the browser
-flow or sends the refresh token. The stored OAuth session stays unchanged.
+non-secret test value. If the check fails, gcx stops the OAuth flow. The stored
+OAuth session stays unchanged.
 
-Run the same gcx command outside the sandbox. If an agent ran the command, use
-the agent approval flow to run gcx with access to the operating system
-credential store. Do not run `gcx login` when a refresh command reports this
-error. Retry the original command.
+The remedy is to run the same command outside the sandbox. If an agent ran the
+command, use the agent approval flow to run gcx with access to the operating
+system credential store.
 
 gcx detects this condition from credential-store behavior. It does not depend
 on an environment variable from one agent tool.

--- a/docs/reference/configuration/keychain.md
+++ b/docs/reference/configuration/keychain.md
@@ -107,6 +107,23 @@ This applies only to credentials that are in the credential store. A credential
 that is already plaintext in the configuration file has nothing to remove from
 the store, so `gcx config unset` and entry deletion both work as usual.
 
+## Restricted execution sessions
+
+Some agent tools run commands in a sandbox. The sandbox can allow credential
+reads and block credential writes. A read-only check cannot detect this state.
+
+Before an OAuth login or token refresh, gcx writes, reads, and removes a random
+non-secret test value. If this test fails, gcx stops before it starts the browser
+flow or sends the refresh token. The stored OAuth session stays unchanged.
+
+Run the same gcx command outside the sandbox. If an agent ran the command, use
+the agent approval flow to run gcx with access to the operating system
+credential store. Do not run `gcx login` when a refresh command reports this
+error. Retry the original command.
+
+gcx detects this condition from credential-store behavior. It does not depend
+on an environment variable from one agent tool.
+
 ## `Keychain locked`
 
 This error means that macOS Keychain or a Linux or BSD Secret Service is

--- a/docs/sources/keychain.md
+++ b/docs/sources/keychain.md
@@ -125,13 +125,12 @@ Some agent tools run commands in a sandbox. The sandbox can allow credential
 reads and block credential writes. A read-only check cannot detect this state.
 
 Before an OAuth login or token refresh, gcx writes, reads, and removes a random
-non-secret test value. If this test fails, gcx stops before it starts the browser
-flow or sends the refresh token. The stored OAuth session stays unchanged.
+non-secret test value. If the check fails, gcx stops the OAuth flow. The stored
+OAuth session stays unchanged.
 
-Run the same gcx command outside the sandbox. If an agent ran the command, use
-the agent approval flow to run gcx with access to the operating system
-credential store. Do not run `gcx login` when a refresh command reports this
-error. Retry the original command.
+The remedy is to run the same command outside the sandbox. If an agent ran the
+command, use the agent approval flow to run gcx with access to the operating
+system credential store.
 
 gcx detects this condition from credential-store behavior. It does not depend
 on an environment variable from one agent tool.

--- a/docs/sources/keychain.md
+++ b/docs/sources/keychain.md
@@ -119,6 +119,23 @@ This applies only to credentials that are in the credential store. A credential
 that is already plaintext in the configuration file has nothing to remove from
 the store, so `gcx config unset` and entry deletion both work as usual.
 
+## Restricted execution sessions
+
+Some agent tools run commands in a sandbox. The sandbox can allow credential
+reads and block credential writes. A read-only check cannot detect this state.
+
+Before an OAuth login or token refresh, gcx writes, reads, and removes a random
+non-secret test value. If this test fails, gcx stops before it starts the browser
+flow or sends the refresh token. The stored OAuth session stays unchanged.
+
+Run the same gcx command outside the sandbox. If an agent ran the command, use
+the agent approval flow to run gcx with access to the operating system
+credential store. Do not run `gcx login` when a refresh command reports this
+error. Retry the original command.
+
+gcx detects this condition from credential-store behavior. It does not depend
+on an environment variable from one agent tool.
+
 ## `Keychain locked`
 
 This error means that macOS Keychain or a Linux or BSD Secret Service is

--- a/internal/auth/transport.go
+++ b/internal/auth/transport.go
@@ -26,6 +26,9 @@ var (
 	// ErrInvalidRefreshResponse means a successful HTTP refresh response omitted
 	// or malformed fields required to safely use the rotated token generation.
 	ErrInvalidRefreshResponse = errors.New("OAuth refresh response is invalid")
+	// ErrCredentialPersistencePreflight means gcx could not confirm that it can
+	// persist a rotated token before it sent the current refresh token.
+	ErrCredentialPersistencePreflight = errors.New("OAuth credential persistence preflight failed")
 )
 
 // refreshThreshold is how far before token expiry we trigger a proactive refresh.
@@ -53,6 +56,10 @@ type StoredTokens struct {
 // persisted tokens are available.
 type TokenReloader func() (StoredTokens, bool, error)
 
+// TokenPersistenceChecker verifies that a rotated token can be persisted.
+// It runs inside the cross-process lock and before any refresh request.
+type TokenPersistenceChecker func() error
+
 // RefreshTransport wraps an http.RoundTripper and transparently refreshes
 // the gat_ access token when it is close to expiry.
 type RefreshTransport struct {
@@ -63,6 +70,7 @@ type RefreshTransport struct {
 	ExpiresAt        time.Time
 	RefreshExpiresAt time.Time
 	OnRefresh        TokenRefresher
+	CheckPersistence TokenPersistenceChecker
 
 	// Lock, if set, is called before a refresh to serialize concurrent gcx
 	// invocations that share a config file. Without it, two processes race to
@@ -273,6 +281,11 @@ func (t *RefreshTransport) refreshAndPersist(req *http.Request) error {
 	}
 	if adopted {
 		return nil
+	}
+	if t.CheckPersistence != nil {
+		if err := t.CheckPersistence(); err != nil {
+			return fmt.Errorf("%w: %w", ErrCredentialPersistencePreflight, err)
+		}
 	}
 
 	t.mu.Lock()

--- a/internal/auth/transport_test.go
+++ b/internal/auth/transport_test.go
@@ -139,6 +139,74 @@ func TestRefreshTransport_LockAndReloadFailuresMakeNoHTTPCalls(t *testing.T) {
 	}
 }
 
+func TestRefreshTransport_PersistencePreflightMakesNoHTTPCalls(t *testing.T) {
+	want := errors.New("credential store write denied")
+	var baseCalls atomic.Int32
+	var checkCalls atomic.Int32
+	transport := &auth.RefreshTransport{
+		Base: testRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			baseCalls.Add(1)
+			return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: http.NoBody, Request: req}, nil
+		}),
+		ProxyEndpoint: "https://proxy.invalid",
+		Token:         "gat_expired",
+		RefreshToken:  "refresh-token",
+		ExpiresAt:     time.Now().Add(-time.Minute),
+		CheckPersistence: func() error {
+			checkCalls.Add(1)
+			return want
+		},
+	}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://proxy.invalid/protected", nil)
+	require.NoError(t, err)
+
+	resp, err := transport.RoundTrip(req)
+	if resp != nil {
+		require.NoError(t, resp.Body.Close())
+	}
+	assert.Nil(t, resp)
+	require.ErrorIs(t, err, auth.ErrCredentialPersistencePreflight)
+	require.ErrorIs(t, err, want)
+	assert.Equal(t, int32(1), checkCalls.Load())
+	assert.Zero(t, baseCalls.Load())
+	assert.Equal(t, "refresh-token", transport.RefreshToken)
+}
+
+func TestRefreshTransport_AdoptedTokenSkipsPersistencePreflight(t *testing.T) {
+	var checkCalls atomic.Int32
+	var protectedCalls atomic.Int32
+	transport := &auth.RefreshTransport{
+		Base: testRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			protectedCalls.Add(1)
+			return &http.Response{StatusCode: http.StatusOK, Header: make(http.Header), Body: http.NoBody, Request: req}, nil
+		}),
+		ProxyEndpoint: "https://proxy.invalid",
+		Token:         "gat_expired",
+		RefreshToken:  "old-refresh-token",
+		ExpiresAt:     time.Now().Add(-time.Minute),
+		Reload: func() (auth.StoredTokens, bool, error) {
+			return auth.StoredTokens{
+				Token:        "gat_fresh",
+				RefreshToken: "new-refresh-token",
+				ExpiresAt:    time.Now().Add(time.Hour),
+			}, true, nil
+		},
+		CheckPersistence: func() error {
+			checkCalls.Add(1)
+			return errors.New("must not run")
+		},
+	}
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "https://proxy.invalid/protected", nil)
+	require.NoError(t, err)
+
+	resp, err := transport.RoundTrip(req)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	require.NoError(t, resp.Body.Close())
+	assert.Zero(t, checkCalls.Load())
+	assert.Equal(t, int32(1), protectedCalls.Load())
+}
+
 func TestRefreshTransport_CancellationBeforeRotationMakesNoCalls(t *testing.T) {
 	var lockCalls, reloadCalls, refreshCalls, protectedCalls atomic.Int32
 	transport := &auth.RefreshTransport{
@@ -374,6 +442,7 @@ func TestRefreshTransport_ConcurrentWaitersReceiveLeaderFailure(t *testing.T) {
 
 func TestRefreshTransport_RetriesPendingPersistenceWithoutSecondRefresh(t *testing.T) {
 	var refreshCalls atomic.Int32
+	var checkCalls atomic.Int32
 	base := testRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 		require.Equal(t, "/api/cli/v1/auth/refresh", req.URL.Path)
 		refreshCalls.Add(1)
@@ -395,6 +464,12 @@ func TestRefreshTransport_RetriesPendingPersistenceWithoutSecondRefresh(t *testi
 		Lock: func(context.Context) (func(), error) {
 			return func() {}, nil
 		},
+		CheckPersistence: func() error {
+			if checkCalls.Add(1) > 1 {
+				return errors.New("preflight must not run for a pending generation")
+			}
+			return nil
+		},
 		OnRefresh: func(previousRefreshToken, token, refreshToken, _, _ string) error {
 			require.Equal(t, "gar_old", previousRefreshToken)
 			require.Equal(t, "gat_new", token)
@@ -415,6 +490,7 @@ func TestRefreshTransport_RetriesPendingPersistenceWithoutSecondRefresh(t *testi
 	assert.Equal(t, "gat_new", token)
 	assert.Equal(t, int32(1), refreshCalls.Load())
 	assert.Equal(t, int32(2), persistCalls.Load())
+	assert.Equal(t, int32(1), checkCalls.Load())
 }
 
 func TestRefreshTransport_ConcurrentPersistenceFailureBlocksProtectedAPI(t *testing.T) {

--- a/internal/config/export_test.go
+++ b/internal/config/export_test.go
@@ -72,6 +72,15 @@ func (n *NamespacedRESTConfig) OnRefreshForTest() auth.TokenRefresher {
 	return n.oauthTransport.OnRefresh
 }
 
+// CheckPersistenceForTest returns the persistence preflight callback wired by
+// WireTokenPersistence. Exposed solely for tests in config_test.
+func (n *NamespacedRESTConfig) CheckPersistenceForTest() auth.TokenPersistenceChecker {
+	if n.oauthTransport == nil {
+		return nil
+	}
+	return n.oauthTransport.CheckPersistence
+}
+
 // SeedStackIDCacheForTest primes the process-lifetime stack-ID discovery cache
 // for a server, then returns a function that clears the whole cache. Exposed
 // solely for tests in config_test that exercise the cache-peek mismatch path.

--- a/internal/config/oauth_persistence_test.go
+++ b/internal/config/oauth_persistence_test.go
@@ -1,0 +1,88 @@
+package config_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/grafana/gcx/internal/config"
+	"github.com/grafana/gcx/internal/credentials"
+	"github.com/stretchr/testify/require"
+)
+
+type persistenceProbeStore struct {
+	err    error
+	values map[string]string
+}
+
+func (s *persistenceProbeStore) Get(key string) (string, error) {
+	if s.err != nil {
+		return "", s.err
+	}
+	value, ok := s.values[key]
+	if !ok {
+		return "", credentials.ErrNotFound
+	}
+	return value, nil
+}
+
+func (s *persistenceProbeStore) Set(key, value string) error {
+	if s.err != nil {
+		return s.err
+	}
+	s.values[key] = value
+	return nil
+}
+
+func (s *persistenceProbeStore) Delete(key string) error {
+	if s.err != nil {
+		return s.err
+	}
+	delete(s.values, key)
+	return nil
+}
+
+func TestCheckOAuthCredentialPersistence(t *testing.T) {
+	tests := []struct {
+		name    string
+		store   credentials.Store
+		wantErr error
+	}{
+		{
+			name:  "writable store",
+			store: &persistenceProbeStore{values: map[string]string{}},
+		},
+		{
+			name:  "unavailable store keeps plaintext fallback",
+			store: &persistenceProbeStore{err: credentials.ErrUnavailable},
+		},
+		{
+			name:    "restricted session fails closed",
+			store:   &persistenceProbeStore{err: credentials.ErrRestrictedSession},
+			wantErr: credentials.ErrRestrictedSession,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			restore := config.SetKeychainStoreFnForTest(func() credentials.Store { return tt.store })
+			t.Cleanup(restore)
+
+			err := config.CheckOAuthCredentialPersistence()
+			if tt.wantErr == nil {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorIs(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestCheckOAuthCredentialPersistenceKeepsUnknownFailuresFatal(t *testing.T) {
+	want := errors.New("unknown store failure")
+	restore := config.SetKeychainStoreFnForTest(func() credentials.Store {
+		return &persistenceProbeStore{err: want}
+	})
+	t.Cleanup(restore)
+
+	require.ErrorIs(t, config.CheckOAuthCredentialPersistence(), want)
+}

--- a/internal/config/oauth_persistence_test.go
+++ b/internal/config/oauth_persistence_test.go
@@ -2,6 +2,8 @@ package config_test
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/grafana/gcx/internal/config"
@@ -85,4 +87,38 @@ func TestCheckOAuthCredentialPersistenceKeepsUnknownFailuresFatal(t *testing.T) 
 	t.Cleanup(restore)
 
 	require.ErrorIs(t, config.CheckOAuthCredentialPersistence(), want)
+}
+
+func TestConfigCheckOAuthCredentialPersistenceHonorsResolvedPolicy(t *testing.T) {
+	tests := []struct {
+		name    string
+		mode    string
+		wantErr error
+	}{
+		{name: "configured off keeps plaintext fallback", mode: "off"},
+		{name: "configured on checks the OS store", mode: "on", wantErr: credentials.ErrRestrictedSession},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "config.yaml")
+			contents := []byte("version: 1\ncredentials:\n  keychain: " + tt.mode + "\n")
+			require.NoError(t, os.WriteFile(path, contents, 0o600))
+
+			restore := config.SetKeychainStoreFnForTest(func() credentials.Store {
+				return &persistenceProbeStore{err: credentials.ErrRestrictedSession}
+			})
+			t.Cleanup(restore)
+
+			cfg, err := config.Load(t.Context(), config.ExplicitConfigFile(path))
+			require.NoError(t, err)
+
+			err = cfg.CheckOAuthCredentialPersistence()
+			if tt.wantErr == nil {
+				require.NoError(t, err)
+				return
+			}
+			require.ErrorIs(t, err, tt.wantErr)
+		})
+	}
 }

--- a/internal/config/oauth_persistence_test.go
+++ b/internal/config/oauth_persistence_test.go
@@ -54,8 +54,13 @@ func TestCheckOAuthCredentialPersistence(t *testing.T) {
 			store: &persistenceProbeStore{values: map[string]string{}},
 		},
 		{
-			name:  "unavailable store keeps plaintext fallback",
-			store: &persistenceProbeStore{err: credentials.ErrUnavailable},
+			name:  "disabled store keeps plaintext fallback",
+			store: &persistenceProbeStore{err: credentials.ErrDisabled},
+		},
+		{
+			name:    "unavailable store fails closed",
+			store:   &persistenceProbeStore{err: credentials.ErrUnavailable},
+			wantErr: credentials.ErrUnavailable,
 		},
 		{
 			name:    "restricted session fails closed",

--- a/internal/config/rest.go
+++ b/internal/config/rest.go
@@ -198,9 +198,8 @@ func (n *NamespacedRESTConfig) WireTokenPersistence(ctx context.Context, source 
 			return err
 		}
 		err = credentials.CheckWritable(fresh.keychainStore)
-		if errors.Is(err, credentials.ErrUnavailable) || errors.Is(err, credentials.ErrDisabled) {
-			// A new plaintext credential can stay in the mode-0600 config file
-			// when no credential store is available or the user disabled it.
+		if errors.Is(err, credentials.ErrDisabled) {
+			// The user selected plaintext credential storage.
 			return nil
 		}
 		return err
@@ -299,8 +298,8 @@ func tokenPersistenceIdentity(sources []ConfigSource, path string) (string, erro
 }
 
 // CheckOAuthCredentialPersistence verifies that a new OAuth credential can be
-// persisted before gcx starts a browser flow. A truly unavailable or disabled
-// store keeps the documented plaintext fallback.
+// persisted before gcx starts a browser flow. A disabled store keeps the
+// documented plaintext fallback.
 func CheckOAuthCredentialPersistence() error {
 	return checkOAuthCredentialPersistence(keychainStoreFn())
 }
@@ -316,7 +315,7 @@ func (cfg *Config) CheckOAuthCredentialPersistence() error {
 
 func checkOAuthCredentialPersistence(store credentials.Store) error {
 	err := credentials.CheckWritable(store)
-	if errors.Is(err, credentials.ErrUnavailable) || errors.Is(err, credentials.ErrDisabled) {
+	if errors.Is(err, credentials.ErrDisabled) {
 		return nil
 	}
 	return err

--- a/internal/config/rest.go
+++ b/internal/config/rest.go
@@ -302,7 +302,20 @@ func tokenPersistenceIdentity(sources []ConfigSource, path string) (string, erro
 // persisted before gcx starts a browser flow. A truly unavailable or disabled
 // store keeps the documented plaintext fallback.
 func CheckOAuthCredentialPersistence() error {
-	err := credentials.CheckWritable(keychainStoreFn())
+	return checkOAuthCredentialPersistence(keychainStoreFn())
+}
+
+// CheckOAuthCredentialPersistence verifies OAuth persistence with the
+// credential-store policy that was resolved when cfg was loaded.
+func (cfg *Config) CheckOAuthCredentialPersistence() error {
+	if cfg == nil || cfg.keychainStore == nil {
+		return CheckOAuthCredentialPersistence()
+	}
+	return checkOAuthCredentialPersistence(cfg.keychainStore)
+}
+
+func checkOAuthCredentialPersistence(store credentials.Store) error {
+	err := credentials.CheckWritable(store)
 	if errors.Is(err, credentials.ErrUnavailable) || errors.Is(err, credentials.ErrDisabled) {
 		return nil
 	}

--- a/internal/config/rest.go
+++ b/internal/config/rest.go
@@ -85,7 +85,7 @@ func (n *NamespacedRESTConfig) SetOnRefresh(fn auth.TokenRefresher) {
 // when empty it defaults to contextName (the stack-named-after-context
 // convention used by login).
 //
-//nolint:gocyclo // Refresh locking, reload, binding CAS, and persistence form one security-critical transaction.
+//nolint:gocyclo,maintidx // Refresh locking, reload, binding CAS, and persistence form one security-critical transaction.
 func (n *NamespacedRESTConfig) WireTokenPersistence(ctx context.Context, source Source, contextName, stackName string, sources []ConfigSource) {
 	if n.oauthTransport == nil {
 		return
@@ -192,6 +192,20 @@ func (n *NamespacedRESTConfig) WireTokenPersistence(ctx context.Context, source 
 		}, true, nil
 	}
 
+	n.oauthTransport.CheckPersistence = func() error {
+		fresh, err := persistLoad()
+		if err != nil {
+			return err
+		}
+		err = credentials.CheckWritable(fresh.keychainStore)
+		if errors.Is(err, credentials.ErrUnavailable) || errors.Is(err, credentials.ErrDisabled) {
+			// A new plaintext credential can stay in the mode-0600 config file
+			// when no credential store is available or the user disabled it.
+			return nil
+		}
+		return err
+	}
+
 	n.SetOnRefresh(func(previousRefreshToken, token, refreshToken, expiresAt, refreshExpiresAt string) error {
 		fresh, err := persistLoad()
 		if err != nil {
@@ -282,6 +296,17 @@ func tokenPersistenceIdentity(sources []ConfigSource, path string) (string, erro
 		layer = selected.Type
 	}
 	return canonicalConfigSourceForLayer(path, layer)
+}
+
+// CheckOAuthCredentialPersistence verifies that a new OAuth credential can be
+// persisted before gcx starts a browser flow. A truly unavailable or disabled
+// store keeps the documented plaintext fallback.
+func CheckOAuthCredentialPersistence() error {
+	err := credentials.CheckWritable(keychainStoreFn())
+	if errors.Is(err, credentials.ErrUnavailable) || errors.Is(err, credentials.ErrDisabled) {
+		return nil
+	}
+	return err
 }
 
 func configSourceForPath(sources []ConfigSource, path string) (ConfigSource, bool) {

--- a/internal/config/rest_persistence_test.go
+++ b/internal/config/rest_persistence_test.go
@@ -189,6 +189,44 @@ current-context: default
 	require.ErrorContains(t, err, "credential owner \"default\" disappeared")
 }
 
+func TestWireTokenPersistence_UnavailableWritesFailPreflight(t *testing.T) {
+	store := withFakeStore(t)
+	dir := t.TempDir()
+	file := filepath.Join(dir, "config.yaml")
+	writeTestConfigFile(t, file, `
+version: 1
+stacks:
+  default:
+    grafana:
+      server: https://grafana.invalid
+      proxy-endpoint: https://proxy.invalid
+      oauth-token: gat_old
+      oauth-refresh-token: gar_old
+      oauth-token-expires-at: "2020-01-01T00:00:00Z"
+      oauth-refresh-expires-at: "2099-01-01T00:00:00Z"
+contexts:
+  default:
+    stack: default
+current-context: default
+`)
+	cfg, err := config.Load(t.Context(), config.ExplicitConfigFile(file))
+	require.NoError(t, err)
+	restCfg, err := config.NewNamespacedRESTConfig(t.Context(), *cfg.Contexts["default"])
+	require.NoError(t, err)
+	restCfg.WireTokenPersistence(
+		t.Context(),
+		config.ExplicitConfigFile(file),
+		"default",
+		"default",
+		[]config.ConfigSource{{Path: file, Type: "explicit"}},
+	)
+
+	store.setErr = credentials.ErrUnavailable
+	checkPersistence := restCfg.CheckPersistenceForTest()
+	require.NotNil(t, checkPersistence)
+	require.ErrorIs(t, checkPersistence(), credentials.ErrUnavailable)
+}
+
 func TestWireTokenPersistence_ExplicitModeWritesToExplicitSource(t *testing.T) {
 	store := withFakeStore(t)
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -396,6 +434,8 @@ current-context: default
 }
 
 func TestWireTokenPersistence_PendingGenerationCannotOverwriteRelogin(t *testing.T) {
+	t.Setenv("GCX_KEYCHAIN", "off")
+
 	var refreshCalls, protectedCalls atomic.Int32
 	var protectedAuthorization atomic.Value
 	protectedAuthorization.Store("")
@@ -787,6 +827,8 @@ current-context: default
 }
 
 func TestWireTokenPersistence_TLSFileSwapRejectsRotatedGeneration(t *testing.T) {
+	t.Setenv("GCX_KEYCHAIN", "off")
+
 	var refreshCalls, protectedCalls atomic.Int32
 	caFile := filepath.Join(t.TempDir(), "ca.pem")
 	require.NoError(t, os.WriteFile(caFile, []byte("initial-ca-material"), 0o600))

--- a/internal/credentials/credentials.go
+++ b/internal/credentials/credentials.go
@@ -84,6 +84,11 @@ var ErrUnavailable = errors.New("credentials: keychain unavailable")
 // must fail and ask the user to unlock the keychain.
 var ErrLocked = errors.New("credentials: keychain locked")
 
+// ErrRestrictedSession is returned when the credential store exists, but the
+// current execution session cannot write to it. A sandbox or another process
+// policy can cause this condition. Callers must not fall back to plaintext.
+var ErrRestrictedSession = errors.New("credentials: access restricted in this execution session")
+
 // ErrDisabled is reported by a store that stands in for a keychain the user has
 // deliberately turned off. Unlike ErrLocked it wraps ErrUnavailable, because no
 // keychain is in play at all, but callers must not rely on that wrapping: since
@@ -97,6 +102,46 @@ type Store interface {
 	Get(key string) (string, error)
 	Set(key, value string) error
 	Delete(key string) error
+}
+
+// CheckWritable verifies that store can persist and retrieve a new value. The
+// probe uses a random account and a non-secret value. It removes the account
+// before it returns.
+func CheckWritable(store Store) error {
+	if store == nil {
+		return errors.New("credentials: credential store is nil")
+	}
+
+	random := make([]byte, 18)
+	if _, err := rand.Read(random); err != nil {
+		return fmt.Errorf("credentials: generate write probe: %w", err)
+	}
+	account := "__gcx_write_probe__:" + base64.RawURLEncoding.EncodeToString(random)
+	const value = "gcx-write-probe"
+
+	if err := store.Set(account, value); err != nil {
+		return fmt.Errorf("credentials: write probe: %w", err)
+	}
+
+	stored, getErr := store.Get(account)
+	deleteErr := store.Delete(account)
+	if getErr != nil {
+		return errors.Join(fmt.Errorf("credentials: read write probe: %w", getErr), wrapProbeDeleteError(deleteErr))
+	}
+	if stored != value {
+		return errors.Join(errors.New("credentials: write probe returned a different value"), wrapProbeDeleteError(deleteErr))
+	}
+	if deleteErr != nil {
+		return wrapProbeDeleteError(deleteErr)
+	}
+	return nil
+}
+
+func wrapProbeDeleteError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("credentials: remove write probe: %w", err)
 }
 
 // Binding is the complete authority boundary for one keychain credential.

--- a/internal/credentials/keychain.go
+++ b/internal/credentials/keychain.go
@@ -81,8 +81,12 @@ func normalizeKeyringError(err error) error {
 
 func normalizeKeyringErrorForOS(err error, goos string) error {
 	if err == nil || errors.Is(err, ErrUnavailable) || errors.Is(err, ErrLocked) ||
+		errors.Is(err, ErrRestrictedSession) ||
 		errors.Is(err, keyring.ErrSetDataTooBig) {
 		return err
+	}
+	if nativeKeyringBackendRestricted(err, goos) {
+		return fmt.Errorf("%w: %w", ErrRestrictedSession, err)
 	}
 	// A locked backend is a reachable backend. Classify it before the
 	// unavailability check so it never downgrades to a plaintext fallback.
@@ -93,6 +97,16 @@ func normalizeKeyringErrorForOS(err error, goos string) error {
 		return fmt.Errorf("%w: %w", ErrUnavailable, err)
 	}
 	return err
+}
+
+// nativeKeyringBackendRestricted reports whether a process policy denied
+// credential-store access in the current execution session.
+func nativeKeyringBackendRestricted(err error, goos string) bool {
+	if goos != "darwin" {
+		return false
+	}
+	var exitErr *exec.ExitError
+	return errors.As(err, &exitErr) && darwinKeychainRestrictedExitCode(exitErr.ExitCode())
 }
 
 // nativeKeyringBackendLocked reports whether the error proves that a native
@@ -193,6 +207,18 @@ func darwinKeychainLockedExitCode(code int) bool {
 	// but cannot be unlocked interactively in the current session.
 	switch code {
 	case 24, 36, 154:
+		return true
+	default:
+		return false
+	}
+}
+
+func darwinKeychainRestrictedExitCode(code int) bool {
+	// These are low-byte process statuses returned by security(1) when the
+	// execution session cannot obtain authorization. Exit 152 is the low byte
+	// of errAuthorizationInternal (-60008). Some sandbox profiles return 161.
+	switch code {
+	case 152, 161:
 		return true
 	default:
 		return false

--- a/internal/credentials/keychain_internal_test.go
+++ b/internal/credentials/keychain_internal_test.go
@@ -37,11 +37,32 @@ func TestNormalizeKeyringErrorClassifiesDarwinLock(t *testing.T) {
 	}
 }
 
+func TestNormalizeKeyringErrorClassifiesDarwinRestrictedSession(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the synthetic exit-status fixture requires a POSIX shell")
+	}
+	for name, command := range map[string]string{
+		"exit 152": "exit 152",
+		"exit 161": "exit 161",
+	} {
+		t.Run(name, func(t *testing.T) {
+			cmd := exec.CommandContext(t.Context(), "/bin/sh", "-c", command)
+			err := cmd.Run()
+			require.Error(t, err)
+
+			got := normalizeKeyringErrorForOS(fmt.Errorf("native set: %w", err), "darwin")
+			require.ErrorIs(t, got, ErrRestrictedSession)
+			require.NotErrorIs(t, got, ErrLocked)
+			require.NotErrorIs(t, got, ErrUnavailable)
+		})
+	}
+}
+
 func TestDarwinKeychainUnavailableExitCodes(t *testing.T) {
 	for _, code := range []int{37, 50, 53} {
 		assert.True(t, darwinKeychainUnavailableExitCode(code), "exit code %d", code)
 	}
-	for _, code := range []int{1, 24, 36, 44, 51, 128, 154, 255} {
+	for _, code := range []int{1, 24, 36, 44, 51, 128, 152, 154, 161, 255} {
 		assert.False(t, darwinKeychainUnavailableExitCode(code), "exit code %d", code)
 	}
 }
@@ -50,8 +71,17 @@ func TestDarwinKeychainLockedExitCodes(t *testing.T) {
 	for _, code := range []int{24, 36, 154} {
 		assert.True(t, darwinKeychainLockedExitCode(code), "exit code %d", code)
 	}
-	for _, code := range []int{1, 37, 44, 50, 51, 53, 128, 255} {
+	for _, code := range []int{1, 37, 44, 50, 51, 53, 128, 152, 161, 255} {
 		assert.False(t, darwinKeychainLockedExitCode(code), "exit code %d", code)
+	}
+}
+
+func TestDarwinKeychainRestrictedExitCodes(t *testing.T) {
+	for _, code := range []int{152, 161} {
+		assert.True(t, darwinKeychainRestrictedExitCode(code), "exit code %d", code)
+	}
+	for _, code := range []int{1, 24, 36, 37, 44, 50, 51, 53, 128, 154, 255} {
+		assert.False(t, darwinKeychainRestrictedExitCode(code), "exit code %d", code)
 	}
 }
 

--- a/internal/credentials/writable_test.go
+++ b/internal/credentials/writable_test.go
@@ -1,0 +1,89 @@
+package credentials_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/grafana/gcx/internal/credentials"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type probeStore struct {
+	values      map[string]string
+	setErr      error
+	getErr      error
+	deleteErr   error
+	setCalls    int
+	getCalls    int
+	deleteCalls int
+}
+
+func (s *probeStore) Get(key string) (string, error) {
+	s.getCalls++
+	if s.getErr != nil {
+		return "", s.getErr
+	}
+	value, ok := s.values[key]
+	if !ok {
+		return "", credentials.ErrNotFound
+	}
+	return value, nil
+}
+
+func (s *probeStore) Set(key, value string) error {
+	s.setCalls++
+	if s.setErr != nil {
+		return s.setErr
+	}
+	s.values[key] = value
+	return nil
+}
+
+func (s *probeStore) Delete(key string) error {
+	s.deleteCalls++
+	if s.deleteErr != nil {
+		return s.deleteErr
+	}
+	delete(s.values, key)
+	return nil
+}
+
+func TestCheckWritableWritesReadsAndRemovesProbe(t *testing.T) {
+	store := &probeStore{values: map[string]string{}}
+
+	require.NoError(t, credentials.CheckWritable(store))
+	assert.Equal(t, 1, store.setCalls)
+	assert.Equal(t, 1, store.getCalls)
+	assert.Equal(t, 1, store.deleteCalls)
+	assert.Empty(t, store.values)
+}
+
+func TestCheckWritableStopsAfterWriteFailure(t *testing.T) {
+	want := errors.New("write denied")
+	store := &probeStore{values: map[string]string{}, setErr: want}
+
+	err := credentials.CheckWritable(store)
+	require.ErrorIs(t, err, want)
+	assert.Equal(t, 1, store.setCalls)
+	assert.Zero(t, store.getCalls)
+	assert.Zero(t, store.deleteCalls)
+}
+
+func TestCheckWritableRemovesProbeAfterReadFailure(t *testing.T) {
+	want := errors.New("read failed")
+	store := &probeStore{values: map[string]string{}, getErr: want}
+
+	err := credentials.CheckWritable(store)
+	require.ErrorIs(t, err, want)
+	assert.Equal(t, 1, store.deleteCalls)
+	assert.Empty(t, store.values)
+}
+
+func TestCheckWritableReturnsCleanupFailure(t *testing.T) {
+	want := errors.New("delete failed")
+	store := &probeStore{values: map[string]string{}, deleteErr: want}
+
+	err := credentials.CheckWritable(store)
+	require.ErrorIs(t, err, want)
+}

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -664,6 +664,12 @@ func resolveGrafanaAuth(ctx context.Context, opts Options, target Target) (strin
 		if opts.NewAuthFlow == nil {
 			return "", nil, errors.New("OAuth requested but no auth flow factory provided")
 		}
+		// Manual OAuth reads the pasted redirect URL. internal/login must not
+		// reach for os.Stdin itself, so a missing reader is a programmer error
+		// rather than a silent fallback. Reject it before the persistence probe.
+		if opts.OAuthManual && opts.Reader == nil {
+			return "", nil, errors.New("manual OAuth requires an input reader")
+		}
 		checkPersistence := opts.CheckCredentialPersistence
 		if checkPersistence == nil {
 			checkPersistence = config.CheckOAuthCredentialPersistence
@@ -679,12 +685,6 @@ func resolveGrafanaAuth(ctx context.Context, opts Options, target Target) (strin
 		w := opts.Writer
 		if w == nil {
 			w = io.Discard
-		}
-		// Manual OAuth reads the pasted redirect URL. internal/login must not
-		// reach for os.Stdin itself, so a missing reader is a programmer error
-		// rather than a silent fallback.
-		if opts.OAuthManual && opts.Reader == nil {
-			return "", nil, errors.New("manual OAuth requires an input reader")
 		}
 		flow := opts.NewAuthFlow(opts.Server, auth.Options{
 			Writer: w,

--- a/internal/login/login.go
+++ b/internal/login/login.go
@@ -152,6 +152,10 @@ type Hooks struct {
 	// pass a factory that wraps auth.NewFlow.
 	NewAuthFlow func(server string, opts auth.Options) AuthFlow
 
+	// CheckCredentialPersistence verifies that OAuth results can be stored
+	// before the browser flow starts. Nil uses the configured OS store.
+	CheckCredentialPersistence func() error
+
 	// NewCloudAuthFlow constructs the direct GCOM OAuth PKCE flow used by the
 	// optional Cloud follow-up. Nil selects auth.NewGCOMFlow. The seam keeps the
 	// command path deterministic in tests without putting browser logic in cmd/.
@@ -215,6 +219,10 @@ type Options struct {
 	Hooks
 	RetryState
 }
+
+// ErrCredentialPersistencePreflight means gcx stopped before it started the
+// OAuth browser flow because it could not persist the result.
+var ErrCredentialPersistencePreflight = errors.New("OAuth login credential persistence preflight failed")
 
 // Result is returned by Run on success and carries enough data for callers to
 // render a post-login summary and persist auth-method metadata.
@@ -655,6 +663,13 @@ func resolveGrafanaAuth(ctx context.Context, opts Options, target Target) (strin
 	case opts.UseOAuth:
 		if opts.NewAuthFlow == nil {
 			return "", nil, errors.New("OAuth requested but no auth flow factory provided")
+		}
+		checkPersistence := opts.CheckCredentialPersistence
+		if checkPersistence == nil {
+			checkPersistence = config.CheckOAuthCredentialPersistence
+		}
+		if err := checkPersistence(); err != nil {
+			return "", nil, fmt.Errorf("%w: %w", ErrCredentialPersistencePreflight, err)
 		}
 		// The internal/login package is UI-free (NC-001) — it never touches
 		// process streams directly. Callers that want OAuth output surfaced

--- a/internal/login/login_internal_test.go
+++ b/internal/login/login_internal_test.go
@@ -2,6 +2,7 @@ package login
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/grafana/gcx/internal/auth"
@@ -9,6 +10,29 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestResolveGrafanaOAuthChecksPersistenceBeforeFlow(t *testing.T) {
+	want := errors.New("credential store write denied")
+	var flowCalls int
+
+	_, _, err := resolveGrafanaAuth(t.Context(), Options{
+		Inputs: Inputs{
+			Server:   "https://grafana.example.invalid",
+			UseOAuth: true,
+		},
+		Hooks: Hooks{
+			CheckCredentialPersistence: func() error { return want },
+			NewAuthFlow: func(string, auth.Options) AuthFlow {
+				flowCalls++
+				return nil
+			},
+		},
+	}, TargetOnPrem)
+
+	require.ErrorIs(t, err, ErrCredentialPersistencePreflight)
+	require.ErrorIs(t, err, want)
+	assert.Zero(t, flowCalls)
+}
 
 func TestResolveGrafanaTokenAuthCarriesRuntimeProxyDestination(t *testing.T) {
 	const proxy = "https://proxy.example.invalid"

--- a/internal/login/login_internal_test.go
+++ b/internal/login/login_internal_test.go
@@ -82,6 +82,7 @@ func TestRuntimeOnlyOAuthDestinationChecksBeforeAndAfterFlow(t *testing.T) {
 				RuntimeProxyEndpoint:        "https://runtime-proxy.example.invalid",
 			},
 			Hooks: Hooks{
+				CheckCredentialPersistence: func() error { return nil },
 				NewAuthFlow: func(string, auth.Options) AuthFlow {
 					return &stubInternalAuthFlow{result: &auth.Result{
 						Token:        "oauth-token",

--- a/internal/login/login_test.go
+++ b/internal/login/login_test.go
@@ -1723,6 +1723,7 @@ func TestRun_MTLSOnlyAuth(t *testing.T) {
 // token, the ErrNeedInput hint guides the user to where a token is created and
 // which scopes are recommended (issue #820).
 func TestRun_CloudTokenHintGuidance(t *testing.T) {
+	usePlaintextCredentialStorage(t)
 	t.Setenv("GCX_AGENT_MODE", "0")
 	agent.ResetForTesting()
 	t.Cleanup(func() { agent.ResetForTesting() })
@@ -1815,6 +1816,7 @@ func TestRun_PersistsDiscoveredStackID(t *testing.T) {
 // progress Writer (wrapping up the OAuth step) and frames the upcoming optional
 // Cloud API token prompt — rather than jumping straight into the prompt.
 func TestRun_OAuthSuccess_AnnouncesSignInBeforeCloudTokenPrompt(t *testing.T) {
+	usePlaintextCredentialStorage(t)
 	t.Setenv("GCX_AGENT_MODE", "0")
 	agent.ResetForTesting()
 


### PR DESCRIPTION
## Summary

- Add a non-secret write, read, and delete probe for the OS credential store.
- Run the probe before OAuth login starts the browser flow.
- Run the probe before OAuth refresh sends the refresh token.
- Keep pending rotated tokens on the persistence-only retry path.
- Classify macOS authorization failures as restricted execution sessions.
- Tell agent users to retry the same command outside the sandbox.
- Keep plaintext storage only when the user explicitly disables the credential store.

## Rationale

Some sandboxes allow keychain reads and block keychain writes. A read-only check reports a false success in this state. The capability probe detects the real failure without an agent-specific environment variable.

The refresh path stops before network use. The stored OAuth session stays unchanged.

## Validation

- `GCX_AGENT_MODE=false mise run all`
- Focused credential, auth, config, login, and error tests
- Signed commit verification

Fixes #1312
