### PR TITLE
chore(codeowners): add fleet-management-frontend to fleet areas

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,8 +16,8 @@
 /internal/providers/irm/ @grafana/grafana-gcx @grafana/grafana-irm-backend
 /internal/providers/k6/ @grafana/grafana-gcx @grafana/k6-backend
 /internal/providers/faro/ @grafana/grafana-gcx @grafana/frontend-o11y @grafana/mobile-o11y
-/internal/providers/fleet/ @grafana/grafana-gcx @grafana/fleet-management-backend
-/internal/fleet/ @grafana/grafana-gcx @grafana/fleet-management-backend
+/internal/providers/fleet/ @grafana/grafana-gcx @grafana/fleet-management-backend @grafana/fleet-management-frontend
+/internal/fleet/ @grafana/grafana-gcx @grafana/fleet-management-backend @grafana/fleet-management-frontend
 /internal/providers/instrumentation/ @grafana/grafana-gcx @grafana/o11y-ingest
 /internal/providers/kg/ @grafana/grafana-gcx @grafana/asserts-team
 /internal/providers/appo11y/ @grafana/grafana-gcx @grafana/app-o11y-visualizations
@@ -82,7 +82,7 @@
 /docs/reference/cli/gcx_irm* @grafana/grafana-gcx @grafana/grafana-irm-backend
 /docs/reference/cli/gcx_k6* @grafana/grafana-gcx @grafana/k6-backend
 /docs/reference/cli/gcx_frontend* @grafana/grafana-gcx @grafana/frontend-o11y @grafana/mobile-o11y
-/docs/reference/cli/gcx_fleet* @grafana/grafana-gcx @grafana/fleet-management-backend
+/docs/reference/cli/gcx_fleet* @grafana/grafana-gcx @grafana/fleet-management-backend @grafana/fleet-management-frontend
 /docs/reference/cli/gcx_kg* @grafana/grafana-gcx @grafana/asserts-team
 /docs/reference/cli/gcx_appo11y* @grafana/grafana-gcx @grafana/app-o11y-visualizations
 /docs/reference/cli/gcx_dbo11y* @grafana/grafana-gcx @grafana/db-o11y-squad


### PR DESCRIPTION
Adds `@grafana/fleet-management-frontend` alongside `@grafana/fleet-management-backend` on the three fleet-owned paths, so a frontender on the Fleet Management squad can approve and merge gcx fleet changes without waiting on a backender or the gcx team.

Raised per the ownership model in [CONTRIBUTING.md](https://github.com/grafana/gcx/blob/main/CONTRIBUTING.md) ("please do reach out ... or raise a pull request with a CODEOWNERS change") and the #gcx announcement.

<h2>What changed</h2>

| Path | Owners now |
|---|---|
| `/internal/providers/fleet/` | `grafana-gcx` + `fleet-management-backend` + **`fleet-management-frontend`** |
| `/internal/fleet/` | `grafana-gcx` + `fleet-management-backend` + **`fleet-management-frontend`** |
| `/docs/reference/cli/gcx_fleet*` | `grafana-gcx` + `fleet-management-backend` + **`fleet-management-frontend`** |

Two partner teams on a single line follows existing precedent in the file — `/internal/providers/faro/` already lists `@grafana/frontend-o11y @grafana/mobile-o11y`. Because last-matching-pattern wins and one approval from any owner on the line satisfies the requirement, this widens who can unblock a fleet PR without removing anyone.

The generated-docs line is included deliberately: any flag or command change under the fleet provider regenerates `docs/reference/cli/gcx_fleet*`, so leaving it off would still route a provider-only PR back through the fallback rule.

<h2>Why the frontend team</h2>

Fleet Management is one squad with separate backend and frontend GitHub teams. The frontend half owns [grafana-collector-app](https://github.com/grafana/grafana-collector-app), the plugin whose proxy gcx's fleet provider actually calls — see this repo's own [`docs/adrs/fleet-plugin-proxy/001-fleet-via-collector-app-proxy.md`](https://github.com/grafana/gcx/blob/main/docs/adrs/fleet-plugin-proxy/001-fleet-via-collector-app-proxy.md). Changes to the collector/pipeline command surface land on our side of that boundary as often as on the backend's.

<h2>One thing for maintainers to check</h2>

GitHub silently ignores a CODEOWNERS entry for a team without write access to the repo (and flags the line under the repo's CODEOWNERS validation). I could not confirm from outside whether `@grafana/fleet-management-frontend` has gcx write access — if it does not, could you grant it, or let me know and I will request it?

<a id="out-of-scope"></a>
<details>
<summary><h2>Deliberately out of scope</h2></summary>

Two adjacent claims I did not make unilaterally — happy to raise either separately if the gcx team prefers:

<h3>(a) The instrumentation areas</h3>

`/cmd/gcx/instrumentation/` and `/internal/providers/instrumentation/` are owned by `@grafana/o11y-ingest`. Fleet Management frontend owns Instrumentation Hub in the collector app, so there may be a shared claim there — but that is a conversation with `@grafana/o11y-ingest`, not something to change in this PR.

<h3>(b) ADR directory ownership</h3>

`docs/adrs/fleet-plugin-proxy/` is squarely fleet territory, but CODEOWNERS currently assigns no `docs/adrs/` directory to any team. Adding the first one is a pattern change for the maintainers to weigh in on.

</details>

<h2>Testing</h2>

CODEOWNERS-only change: no Go, no generated docs, nothing for the gate to exercise, so I ran no build or test commands. Verified instead that:

- `@grafana/fleet-management-frontend` resolves to a real team ("Frontenders on the Fleet Management squad", 4 members).
- The three edited lines are the complete set of fleet-owned paths in the file (`git ls-files | grep -iE "fleet|collector"` surfaces nothing else outside the fleet provider dirs, the generated CLI docs, and the ADR noted above).
- The diff touches only those three lines — 3 insertions, 3 deletions.
